### PR TITLE
[caclmgrd][dualtor] add iptables rule for dualtor gRPC to allow packets getting forwarded from loopback IP

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -41,6 +41,22 @@ def _ip_prefix_in_key(key):
     """
     return (isinstance(key, tuple))
 
+def get_ip_from_interface_table(table, intf_name):
+
+    if table:
+        for key, _ in table.items():
+            if not _ip_prefix_in_key(key):
+                continue
+
+            iface_name, iface_cidr = key
+            if iface_name.startswith(intf_name):
+                ip_ntwrk = ipaddress.ip_network(iface_cidr, strict=False)
+                if isinstance(ip_ntwrk, ipaddress.IPv4Network):
+                    ip_addr = ip_ntwrk.network_address
+                    return ip_addr
+
+    return None
+
 # ============================== Classes ==============================
 
 
@@ -57,6 +73,8 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
     ACL_RULE = "ACL_RULE"
     DEVICE_METADATA_TABLE = "DEVICE_METADATA"
     MUX_CABLE_TABLE = "MUX_CABLE_TABLE"
+    CONFIG_MUX_CABLE = "MUX_CABLE"
+    LOOPBACK_TABLE = "LOOPBACK_INTERFACE"
 
     ACL_TABLE_TYPE_CTRLPLANE = "CTRLPLANE"
 
@@ -283,6 +301,28 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                                                      (docker_mgmt_ipv6, self.namespace_mgmt_ipv6))
 
         return allow_internal_docker_ip_cmds
+
+
+    def generate_fwd_traffic_from_host_to_soc(self, namespace):
+
+        fwd_dualtor_grpc_traffic_from_host_to_soc_cmds = []
+        if self.DualToR:
+            loopback_table = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.LOOPBACK_TABLE)
+            loopback_name = 'Loopback3'
+            loopback_address = get_ip_from_interface_table(loopback_table, loopback_name)
+            fwd_dualtor_grpc_traffic_from_host_to_soc_cmds.append(self.iptables_cmd_ns_prefix[namespace] + 
+                    "iptables -t nat --flush POSTROUTING")
+            
+            if loopback_address is not None:
+                mux_table = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.CONFIG_MUX_CABLE)
+                mux_table_keys = mux_table.keys()
+                for key in mux_table_keys:
+                    kvp = mux_table.get(key)
+                    if 'cable_type' in kvp and kvp['cable_type'] == 'active-active':
+                        fwd_dualtor_grpc_traffic_from_host_to_soc_cmds.append(self.iptables_cmd_ns_prefix[namespace] + 
+                                "iptables -t nat -A POSTROUTING --destination {} -j SNAT --to-source {}".format(kvp['soc_ipv4'], loopback_address))
+
+        return fwd_dualtor_grpc_traffic_from_host_to_soc_cmds
 
     def generate_fwd_traffic_from_namespace_to_host_commands(self, namespace, acl_source_ip_map):
         """
@@ -684,6 +724,13 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
             self.log_info("  " + cmd)
 
         self.run_commands(iptables_cmds)
+
+        if self.DualToR:
+            dualtor_iptables_cmds = self.generate_fwd_traffic_from_host_to_soc(namespace)
+            for cmd in dualtor_iptables_cmds:
+                self.log_info("  " + cmd)
+            self.run_commands(dualtor_iptables_cmds)
+
 
     def check_and_update_control_plane_acls(self, namespace, num_changes):
         """

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -178,6 +178,60 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
             self.namespace_docker_mgmt_ipv6[namespace] = self.get_namespace_mgmt_ipv6(self.iptables_cmd_ns_prefix[namespace],
                                                                                              namespace)
 
+    def pick_src_intf_ipaddrs(self, keys, src_intf):
+        new_ipv4_addr = ""
+        new_ipv6_addr = ""
+
+        for it in keys:
+            if not it[0].startswith(src_intf) or (isinstance(it, tuple) == False):
+                continue
+            if new_ipv4_addr != "" and new_ipv6_addr != "":
+                break
+            ip_str = it[1].split("/")[0]
+            ip_addr = ipaddress.ip_address(ip_str)
+            # Pick the first IP address from the table that matches the source interface
+            if isinstance(ip_addr, ipaddress.IPv6Address):
+                if new_ipv6_addr != "":
+                    continue
+                new_ipv6_addr = ip_addr
+            elif isinstance(ip_addr, ipaddress.IPv4Address):
+                if new_ipv4_addr != "":
+                    continue
+                new_ipv4_addr = ip_addr
+
+        return(new_ipv4_addr, new_ipv6_addr)
+
+    def get_interface_ip(self, source, config_db, addr=None):
+        keys = None
+        try:
+            if source.startswith("Eth"):
+                if is_vlan_sub_interface(source):
+                    keys = config_db.get_keys('VLAN_SUB_INTERFACE')
+                else:
+                    keys = config_db.get_keys('INTERFACE')
+            elif source.startswith("Vlan"):
+                keys = config_db.get_keys('VLAN_INTERFACE')
+                self.log_warning("got keys ")
+
+            elif source.startswith("Loopback"):
+                keys = config_db.get_keys('LOOPBACK_INTERFACE')
+            elif source == "eth0":
+                keys = config_db.get_keys('MGMT_INTERFACE')
+        except Exception as e:
+            pass
+
+        interface_ip = ""
+        if keys != None:
+            ipv4_addr, ipv6_addr = self.pick_src_intf_ipaddrs(keys, source)
+            # Based on the type of addr, return v4 or v6
+            if addr and isinstance(addr, ipaddress.IPv6Address):
+                interface_ip = ipv6_addr
+            else:
+                # This could be tuned, but that involves a DNS query, so
+                # offline configuration might trip (or cause delays).
+                interface_ip = ipv4_addr
+        return interface_ip
+
     def get_namespace_mgmt_ip(self, iptable_ns_cmd_prefix, namespace):
         ip_address_get_command = iptable_ns_cmd_prefix + "ip -4 -o addr show " + ("eth0" if namespace else "docker0") +\
                                  " | awk '{print $4}' | cut -d'/' -f1 | head -1"
@@ -317,6 +371,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
             loopback_table = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.LOOPBACK_TABLE)
             loopback_name = 'Loopback3'
             loopback_address = get_ip_from_interface_table(loopback_table, loopback_name)
+            vlan_address = self.get_interface_ip("Vlan", self.config_db_map[DEFAULT_NAMESPACE])
             fwd_dualtor_grpc_traffic_from_host_to_soc_cmds.append(self.iptables_cmd_ns_prefix[namespace] + 
                     "iptables -t nat --flush POSTROUTING")
             
@@ -327,7 +382,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                     kvp = mux_table.get(key)
                     if 'cable_type' in kvp and kvp['cable_type'] == 'active-active':
                         fwd_dualtor_grpc_traffic_from_host_to_soc_cmds.append(self.iptables_cmd_ns_prefix[namespace] + 
-                                "iptables -t nat -A POSTROUTING --destination {} -j SNAT --to-source {}".format(kvp['soc_ipv4'], loopback_address))
+                                "iptables -t nat -A POSTROUTING --destination {} --source {} -j SNAT --to-source {}".format(kvp['soc_ipv4'], vlan_address, loopback_address))
 
         return fwd_dualtor_grpc_traffic_from_host_to_soc_cmds
 

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -48,11 +48,12 @@ def get_ip_from_interface_table(table, intf_name):
             if not _ip_prefix_in_key(key):
                 continue
 
+
             iface_name, iface_cidr = key
             if iface_name.startswith(intf_name):
-                ip_ntwrk = ipaddress.ip_network(iface_cidr, strict=False)
-                if isinstance(ip_ntwrk, ipaddress.IPv4Network):
-                    ip_addr = ip_ntwrk.network_address
+                ip_str = iface_cidr.split("/")[0]
+                ip_addr = ipaddress.ip_address(ip_str)
+                if isinstance(ip_addr, ipaddress.IPv4Address):
                     return ip_addr
 
     return None
@@ -75,6 +76,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
     MUX_CABLE_TABLE = "MUX_CABLE_TABLE"
     CONFIG_MUX_CABLE = "MUX_CABLE"
     LOOPBACK_TABLE = "LOOPBACK_INTERFACE"
+    VLAN_INTF_TABLE = "VLAN_INTERFACE"
 
     ACL_TABLE_TYPE_CTRLPLANE = "CTRLPLANE"
 
@@ -177,60 +179,6 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                                                                                              namespace)
             self.namespace_docker_mgmt_ipv6[namespace] = self.get_namespace_mgmt_ipv6(self.iptables_cmd_ns_prefix[namespace],
                                                                                              namespace)
-
-    def pick_src_intf_ipaddrs(self, keys, src_intf):
-        new_ipv4_addr = ""
-        new_ipv6_addr = ""
-
-        for it in keys:
-            if not it[0].startswith(src_intf) or (isinstance(it, tuple) == False):
-                continue
-            if new_ipv4_addr != "" and new_ipv6_addr != "":
-                break
-            ip_str = it[1].split("/")[0]
-            ip_addr = ipaddress.ip_address(ip_str)
-            # Pick the first IP address from the table that matches the source interface
-            if isinstance(ip_addr, ipaddress.IPv6Address):
-                if new_ipv6_addr != "":
-                    continue
-                new_ipv6_addr = ip_addr
-            elif isinstance(ip_addr, ipaddress.IPv4Address):
-                if new_ipv4_addr != "":
-                    continue
-                new_ipv4_addr = ip_addr
-
-        return(new_ipv4_addr, new_ipv6_addr)
-
-    def get_interface_ip(self, source, config_db, addr=None):
-        keys = None
-        try:
-            if source.startswith("Eth"):
-                if is_vlan_sub_interface(source):
-                    keys = config_db.get_keys('VLAN_SUB_INTERFACE')
-                else:
-                    keys = config_db.get_keys('INTERFACE')
-            elif source.startswith("Vlan"):
-                keys = config_db.get_keys('VLAN_INTERFACE')
-                self.log_warning("got keys ")
-
-            elif source.startswith("Loopback"):
-                keys = config_db.get_keys('LOOPBACK_INTERFACE')
-            elif source == "eth0":
-                keys = config_db.get_keys('MGMT_INTERFACE')
-        except Exception as e:
-            pass
-
-        interface_ip = ""
-        if keys != None:
-            ipv4_addr, ipv6_addr = self.pick_src_intf_ipaddrs(keys, source)
-            # Based on the type of addr, return v4 or v6
-            if addr and isinstance(addr, ipaddress.IPv6Address):
-                interface_ip = ipv6_addr
-            else:
-                # This could be tuned, but that involves a DNS query, so
-                # offline configuration might trip (or cause delays).
-                interface_ip = ipv4_addr
-        return interface_ip
 
     def get_namespace_mgmt_ip(self, iptable_ns_cmd_prefix, namespace):
         ip_address_get_command = iptable_ns_cmd_prefix + "ip -4 -o addr show " + ("eth0" if namespace else "docker0") +\
@@ -371,7 +319,9 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
             loopback_table = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.LOOPBACK_TABLE)
             loopback_name = 'Loopback3'
             loopback_address = get_ip_from_interface_table(loopback_table, loopback_name)
-            vlan_address = self.get_interface_ip("Vlan", self.config_db_map[DEFAULT_NAMESPACE])
+            vlan_name = 'Vlan'
+            vlan_table = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.VLAN_INTF_TABLE)
+            vlan_address = get_ip_from_interface_table(vlan_table, vlan_name)
             fwd_dualtor_grpc_traffic_from_host_to_soc_cmds.append(self.iptables_cmd_ns_prefix[namespace] + 
                     "iptables -t nat --flush POSTROUTING")
             

--- a/tests/caclmgrd/caclmgrd_soc_rules_test.py
+++ b/tests/caclmgrd/caclmgrd_soc_rules_test.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import swsscommon
+
+from parameterized import parameterized
+from sonic_py_common.general import load_module_from_source
+from unittest import TestCase, mock
+from pyfakefs.fake_filesystem_unittest import patchfs
+
+from .test_soc_rules_vectors import CACLMGRD_SOC_TEST_VECTOR
+from tests.common.mock_configdb import MockConfigDb
+from unittest.mock import MagicMock, patch
+
+DBCONFIG_PATH = '/var/run/redis/sonic-db/database_config.json'
+
+class TestCaclmgrdSoc(TestCase):
+    """
+        Test caclmgrd soc
+    """
+    def setUp(self):
+        swsscommon.swsscommon.ConfigDBConnector = MockConfigDb
+        test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        modules_path = os.path.dirname(test_path)
+        scripts_path = os.path.join(modules_path, "scripts")
+        sys.path.insert(0, modules_path)
+        caclmgrd_path = os.path.join(scripts_path, 'caclmgrd')
+        self.caclmgrd = load_module_from_source('caclmgrd', caclmgrd_path)
+        
+    @parameterized.expand(CACLMGRD_SOC_TEST_VECTOR)
+    @patchfs
+    @patch('caclmgrd.get_ip_from_interface_table', MagicMock(return_value="10.10.10.10"))
+    def test_caclmgrd_soc(self, test_name, test_data, fs):
+        if not os.path.exists(DBCONFIG_PATH):
+            fs.create_file(DBCONFIG_PATH) # fake database_config.json
+
+        MockConfigDb.set_config_db(test_data["config_db"])
+
+        with mock.patch("caclmgrd.subprocess") as mocked_subprocess:
+            popen_mock = mock.Mock()
+            popen_attrs = test_data["popen_attributes"]
+            popen_mock.configure_mock(**popen_attrs)
+            mocked_subprocess.Popen.return_value = popen_mock
+            mocked_subprocess.PIPE = -1
+
+            call_rc = test_data["call_rc"]
+            mocked_subprocess.call.return_value = call_rc
+
+            caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
+            caclmgrd_daemon.update_control_plane_nat_acls('', {})
+            mocked_subprocess.Popen.assert_has_calls(test_data["expected_subprocess_calls"], any_order=True)
+

--- a/tests/caclmgrd/caclmgrd_soc_rules_test.py
+++ b/tests/caclmgrd/caclmgrd_soc_rules_test.py
@@ -4,6 +4,7 @@ import swsscommon
 
 from parameterized import parameterized
 from sonic_py_common.general import load_module_from_source
+from ipaddress import IPv4Address
 from unittest import TestCase, mock
 from pyfakefs.fake_filesystem_unittest import patchfs
 
@@ -49,3 +50,11 @@ class TestCaclmgrdSoc(TestCase):
             caclmgrd_daemon.update_control_plane_nat_acls('', {})
             mocked_subprocess.Popen.assert_has_calls(test_data["expected_subprocess_calls"], any_order=True)
 
+    def test_get_ip_from_interface_table(self):
+        if not os.path.exists(DBCONFIG_PATH):
+            fs.create_file(DBCONFIG_PATH) # fake database_config.json
+
+        table = {("Vlan1000","10.10.10.1/32"): "val"}
+        ip_addr = self.caclmgrd.get_ip_from_interface_table(table, "Vlan")
+
+        assert (ip_addr == IPv4Address('10.10.10.1'))

--- a/tests/caclmgrd/caclmgrd_soc_rules_test.py
+++ b/tests/caclmgrd/caclmgrd_soc_rules_test.py
@@ -29,7 +29,6 @@ class TestCaclmgrdSoc(TestCase):
     @parameterized.expand(CACLMGRD_SOC_TEST_VECTOR)
     @patchfs
     @patch('caclmgrd.get_ip_from_interface_table', MagicMock(return_value="10.10.10.10"))
-    @patch('caclmgrd.ControlPlaneAclManager.get_interface_ip', MagicMock(return_value="10.10.2.2"))
     def test_caclmgrd_soc(self, test_name, test_data, fs):
         if not os.path.exists(DBCONFIG_PATH):
             fs.create_file(DBCONFIG_PATH) # fake database_config.json

--- a/tests/caclmgrd/caclmgrd_soc_rules_test.py
+++ b/tests/caclmgrd/caclmgrd_soc_rules_test.py
@@ -29,6 +29,7 @@ class TestCaclmgrdSoc(TestCase):
     @parameterized.expand(CACLMGRD_SOC_TEST_VECTOR)
     @patchfs
     @patch('caclmgrd.get_ip_from_interface_table', MagicMock(return_value="10.10.10.10"))
+    @patch('caclmgrd.ControlPlaneAclManager.get_interface_ip', MagicMock(return_value="10.10.2.2"))
     def test_caclmgrd_soc(self, test_name, test_data, fs):
         if not os.path.exists(DBCONFIG_PATH):
             fs.create_file(DBCONFIG_PATH) # fake database_config.json

--- a/tests/caclmgrd/test_soc_rules_vectors.py
+++ b/tests/caclmgrd/test_soc_rules_vectors.py
@@ -1,0 +1,41 @@
+from unittest.mock import call
+import subprocess
+
+"""
+    caclmgrd soc test vector
+"""
+CACLMGRD_SOC_TEST_VECTOR = [
+    [
+        "SOC_SESSION_TEST",
+        {
+            "config_db": {
+                "DEVICE_METADATA": {
+                    "localhost": {
+                        "subtype": "DualToR",
+                        "type": "ToRRouter",
+                    }
+                },
+                "MUX_CABLE": {
+                    "Ethernet4": {
+                        "cable_type": "active-active",
+                        "soc_ipv4": "192.168.1.0/32",
+                    }
+                },
+                "LOOPBACK_INTERFACE": {
+                    "Loopback3|10.10.10.10/32": {
+                        "NULL": "NULL",
+                    }
+                },
+                "FEATURE": {
+                },
+            },
+            "expected_subprocess_calls": [
+                call("iptables -t nat -A POSTROUTING --destination 192.168.1.0/32 -j SNAT --to-source 10.10.10.10",shell=True, universal_newlines=True, stdout=-1)
+            ],
+            "popen_attributes": {
+                'communicate.return_value': ('output', 'error'),
+            },
+            "call_rc": 0,
+        }
+    ]
+]

--- a/tests/caclmgrd/test_soc_rules_vectors.py
+++ b/tests/caclmgrd/test_soc_rules_vectors.py
@@ -35,7 +35,7 @@ CACLMGRD_SOC_TEST_VECTOR = [
                 },
             },
             "expected_subprocess_calls": [
-                call("iptables -t nat -A POSTROUTING --destination 192.168.1.0/32 --source 10.10.2.2 -j SNAT --to-source 10.10.10.10",shell=True, universal_newlines=True, stdout=-1)
+                call("iptables -t nat -A POSTROUTING --destination 192.168.1.0/32 --source 10.10.10.10 -j SNAT --to-source 10.10.10.10",shell=True, universal_newlines=True, stdout=-1)
             ],
             "popen_attributes": {
                 'communicate.return_value': ('output', 'error'),

--- a/tests/caclmgrd/test_soc_rules_vectors.py
+++ b/tests/caclmgrd/test_soc_rules_vectors.py
@@ -21,6 +21,11 @@ CACLMGRD_SOC_TEST_VECTOR = [
                         "soc_ipv4": "192.168.1.0/32",
                     }
                 },
+                "VLAN_INTERFACE": {
+                    "Vlan1000|10.10.2.2/23": {
+                        "NULL": "NULL",
+                    }
+                },
                 "LOOPBACK_INTERFACE": {
                     "Loopback3|10.10.10.10/32": {
                         "NULL": "NULL",
@@ -30,7 +35,7 @@ CACLMGRD_SOC_TEST_VECTOR = [
                 },
             },
             "expected_subprocess_calls": [
-                call("iptables -t nat -A POSTROUTING --destination 192.168.1.0/32 -j SNAT --to-source 10.10.10.10",shell=True, universal_newlines=True, stdout=-1)
+                call("iptables -t nat -A POSTROUTING --destination 192.168.1.0/32 --source 10.10.2.2 -j SNAT --to-source 10.10.10.10",shell=True, universal_newlines=True, stdout=-1)
             ],
             "popen_attributes": {
                 'communicate.return_value': ('output', 'error'),


### PR DESCRIPTION
This PR is a required for changing the L3 IP forwarding Behavior to SoC in active-active toplogy. Basically, for getting a packet to be forwarded to the SoC IP in active-active topology, the requirement is to use the the LoopBack 3 IP inside SONiC device as the SRC IP. This is required because in active-active topology by default if the ToR wants to send packet to the SoC, it would pick the Vlan IP since that's the IP in the subnet, but since there are firewalls inside the SoC , the IP packets with Vlan IP as src IP in the IP header will be dropped. Hence to overcome this limitation, there is an iptable nat rule that is installed inside the kernel, with which all the packets which have SoC IP as destination IP, use Loopnack 3 IP as src in IP header

#### How I did it
check the config DB if the ToR is a DualToR and has an SoC IP assigned.
put an iptable rule
iptables -t nat -A POSTROUTING --destination -j SNAT --to-source "
Signed-off-by: vaibhav-dahiya [vdahiya@microsoft.com](mailto:vdahiya@microsoft.com)

#### how to verify
```
Rules are only added once

Chain PREROUTING (policy ACCEPT)
target     prot opt source               destination         

Chain INPUT (policy ACCEPT)
target     prot opt source               destination         

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination         

Chain POSTROUTING (policy ACCEPT)
target     prot opt source               destination         
SNAT       all  --  192.168.0.1          192.168.0.7          to:10.1.0.38
SNAT       all  --  192.168.0.1          192.168.0.9          to:10.1.0.38
SNAT       all  --  192.168.0.1          192.168.0.11         to:10.1.0.38
SNAT       all  --  192.168.0.1          192.168.0.13         to:10.1.0.38
SNAT       all  --  192.168.0.1          192.168.0.15         to:10.1.0.38
SNAT       all  --  192.168.0.1          192.168.0.17         to:10.1.0.38
SNAT       all  --  192.168.0.1          192.168.0.19         to:10.1.0.38
SNAT       all  --  192.168.0.1          192.168.0.3          to:10.1.0.38
SNAT       all  --  192.168.0.1          192.168.0.21         to:10.1.0.38
SNAT       all  --  192.168.0.1          192.168.0.23         to:10.1.0.38
SNAT       all  --  192.168.0.1          192.168.0.25         to:10.1.0.38
SNAT       all  --  192.168.0.1          192.168.0.5          to:10.1.0.38
```

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>