### PR TITLE
[caclmgrd]: New traceroute iptables rules

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -641,10 +641,10 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         # Add iptables commands to block ip2me traffic
         iptables_cmds += self.generate_block_ip2me_traffic_iptables_commands(namespace)
 
-        # Add iptables/ip6tables commands to allow all incoming packets with TTL of 0 or 1
-        # This allows the device to respond to tools like tcptraceroute
-        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -A INPUT -m ttl --ttl-lt 2 -j ACCEPT")
-        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -A INPUT -p tcp -m hl --hl-lt 2 -j ACCEPT")
+        # Add iptables/ip6tables commands to allow traceroute.
+        # traceroute doesn't need to be accepted, it just needs a reply.
+        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "iptables -A INPUT -p udp --dport 33434:33523 -j REJECT --reject-with icmp-port-unreachable")
+        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + "ip6tables -A INPUT -p udp --dport 33434:33523 -j REJECT --reject-with icmp6-port-unreachable")
 
         # Finally, if the device has control plane ACLs configured,
         # add iptables/ip6tables commands to drop all other incoming packets


### PR DESCRIPTION
The current ip(6)tables rules allow all packets which have a TTL of 2 or below, which means anyone can access any port as long as they set their initial TTL to a suitable value.

In practice this means:
1. TCP traceroute is no longer allowed here. IMO this should be handled by the service ACLs, so that you can only do a TCP traceroute to port 22 if you're allowed to SSH to the device.
2. Instead of `ACCEPT`ing traceroute packets, reply with ICMP port unreachable. Traceroute clients are fine with that as a reply.
3. ICMP traceroute (from Windows mainly) are not allowed here, but they are in the general ping ACLs.
4. The port range is 33434-33523, which is enough for 30 hops.