### PR TITLE
caclmgrd: Don't block traffic to mgmt by default

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -215,7 +215,6 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
     def generate_block_ip2me_traffic_iptables_commands(self, namespace):
         INTERFACE_TABLE_NAME_LIST = [
             "LOOPBACK_INTERFACE",
-            "MGMT_INTERFACE",
             "VLAN_INTERFACE",
             "PORTCHANNEL_INTERFACE",
             "INTERFACE"

--- a/tests/caclmgrd/test_ip2me_vectors.py
+++ b/tests/caclmgrd/test_ip2me_vectors.py
@@ -24,7 +24,6 @@ CACLMGRD_IP2ME_TEST_VECTOR = [
                 "FEATURE": {},
             },
             "return": [
-                "iptables -A INPUT -d 172.18.0.0/32 -j DROP"
             ],
         },
     ],
@@ -55,7 +54,6 @@ CACLMGRD_IP2ME_TEST_VECTOR = [
             },
             "return": [
                 "iptables -A INPUT -d 10.10.10.10/32 -j DROP",
-                "iptables -A INPUT -d 172.18.0.0/32 -j DROP",
                 "iptables -A INPUT -d 10.10.11.10/32 -j DROP",
                 "iptables -A INPUT -d 10.10.12.10/32 -j DROP",
             ],
@@ -83,7 +81,6 @@ CACLMGRD_IP2ME_TEST_VECTOR = [
                 "FEATURE": {},
             },
             "return": [
-                "iptables -A INPUT -d 172.18.0.0/32 -j DROP",
                 "iptables -A INPUT -d 10.10.11.1/32 -j DROP",
             ],
         },
@@ -117,7 +114,6 @@ CACLMGRD_IP2ME_TEST_VECTOR = [
             },
             "return": [
                 "ip6tables -A INPUT -d 2001:db8:10::/128 -j DROP",
-                "ip6tables -A INPUT -d 2001:db8:200::/128 -j DROP",
                 "ip6tables -A INPUT -d 2001:db8:11::1/128 -j DROP",
                 "ip6tables -A INPUT -d 2001:db8:12::/128 -j DROP",
                 "ip6tables -A INPUT -d 2001:db8:13::/128 -j DROP"


### PR DESCRIPTION
Currently the IP2ME rules block the management interface's identity address instead of the actual host address. This logic results in a DROP rule that hits the management interface address only in the case of `/32` netmask - all other netmasks will result in traffic being accepted by default. Thus, it is exceedingly likely that the current DROP rule has never worked for management interfaces given that `/32` are mainly loopback addresses, not for network links.

**Claim**: Management addresses should not be dropped by default. This matches the current SONiC behavior in all current releases. Dropping by default would result in that the device can only be managed by serial console (physical or possibly BMC SoL).

Dropping management traffic is still possible by adding any  explicit ACL rule which will install a default DROP that hits management as well, so this change is a no-op for every case **except** if anybody is using `/32` on management interface **as well as** expects that traffic to be dropped (extremely unlikely, and still achievable by adding explicit ACLs).

Also see older discussion summary in https://github.com/sonic-net/sonic-buildimage/pull/9826#issuecomment-1041923180