### PR TITLE
ci: Rename sonic-buildimage repository

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ resources:
   repositories:
   - repository: sonic-buildimage
     type: github
-    name: Azure/sonic-buildimage
+    name: sonic-net/sonic-buildimage
     endpoint: build
 
 stages:


### PR DESCRIPTION
This fixes the issues that Azure DevOps pipelines [are not running](https://dev.azure.com/mssonic/build/_build?definitionId=547) for this repository.