### PR TITLE
Add hardware reboot cause as actual reboot cause when soft reboot fails

### DIFF
--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -158,25 +158,7 @@ def get_reboot_cause_dict(previous_reboot_cause, comment, gen_time):
  
     return reboot_cause_dict
 
-
-def main():
-    # Configure logger to log all messages INFO level and higher
-    sonic_logger.set_min_log_priority_info()
-
-    sonic_logger.log_info("Starting up...")
-
-    if not os.geteuid() == 0:
-        sonic_logger.log_error("User {} does not have permission to execute".format(pwd.getpwuid(os.getuid()).pw_name))
-        sys.exit("This utility must be run as root")
-
-    # Create REBOOT_CAUSE_DIR if it doesn't exist
-    if not os.path.exists(REBOOT_CAUSE_DIR):
-        os.makedirs(REBOOT_CAUSE_DIR)
-
-    # Remove stale PREVIOUS_REBOOT_CAUSE_FILE if it exists
-    if os.path.exists(PREVIOUS_REBOOT_CAUSE_FILE):
-        os.remove(PREVIOUS_REBOOT_CAUSE_FILE)
-
+def determin_reboot_cause():
     # This variable is kept for future-use purpose. When proc_cmd_line/vendor/software provides
     # any additional_reboot_info it will be stored as a "comment" in REBOOT_CAUSE_HISTORY_FILE
     additional_reboot_info = "N/A"
@@ -216,6 +198,29 @@ def main():
     else:
         # Get the reboot cause from REBOOT_CAUSE_FILE
         previous_reboot_cause = software_reboot_cause
+
+    return previous_reboot_cause, additional_reboot_info
+
+
+def main():
+    # Configure logger to log all messages INFO level and higher
+    sonic_logger.set_min_log_priority_info()
+
+    sonic_logger.log_info("Starting up...")
+
+    if not os.geteuid() == 0:
+        sonic_logger.log_error("User {} does not have permission to execute".format(pwd.getpwuid(os.getuid()).pw_name))
+        sys.exit("This utility must be run as root")
+
+    # Create REBOOT_CAUSE_DIR if it doesn't exist
+    if not os.path.exists(REBOOT_CAUSE_DIR):
+        os.makedirs(REBOOT_CAUSE_DIR)
+
+    # Remove stale PREVIOUS_REBOOT_CAUSE_FILE if it exists
+    if os.path.exists(PREVIOUS_REBOOT_CAUSE_FILE):
+        os.remove(PREVIOUS_REBOOT_CAUSE_FILE)
+
+    previous_reboot_cause, additional_reboot_info = determin_reboot_cause()
 
     # Current time
     reboot_cause_gen_time = str(datetime.datetime.now().strftime('%Y_%m_%d_%H_%M_%S'))

--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -184,7 +184,7 @@ def determine_reboot_cause():
     #   the software_reboot_cause will be treated as the reboot cause if it's not unknown
     #   otherwise, the cmdline_reboot_cause will be treated as the reboot cause if it's not none
     # Else the software_reboot_cause will be treated as the reboot cause
-    if not hardware_reboot_cause.startswith(REBOOT_CAUSE_NON_HARDWARE):
+    if REBOOT_CAUSE_NON_HARDWARE not in hardware_reboot_cause:
         previous_reboot_cause = hardware_reboot_cause
         # Check if any software reboot was issued before this hardware reboot happened
         if software_reboot_cause is not REBOOT_CAUSE_UNKNOWN:

--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -122,7 +122,12 @@ def find_hardware_reboot_cause():
     else:
         sonic_logger.log_info("No reboot cause found from platform api")
 
-    hardware_reboot_cause = "{} ({})".format(hardware_reboot_cause_major, hardware_reboot_cause_minor)
+    hardware_reboot_cause_minor_str = ""
+    if hardware_reboot_cause_minor:
+        hardware_reboot_cause_minor_str = " ({})".format(hardware_reboot_cause_minor)
+
+    hardware_reboot_cause = hardware_reboot_cause_major + hardware_reboot_cause_minor_str
+
     return hardware_reboot_cause
 
 

--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -158,7 +158,7 @@ def get_reboot_cause_dict(previous_reboot_cause, comment, gen_time):
  
     return reboot_cause_dict
 
-def determin_reboot_cause():
+def determine_reboot_cause():
     # This variable is kept for future-use purpose. When proc_cmd_line/vendor/software provides
     # any additional_reboot_info it will be stored as a "comment" in REBOOT_CAUSE_HISTORY_FILE
     additional_reboot_info = "N/A"
@@ -220,7 +220,7 @@ def main():
     if os.path.exists(PREVIOUS_REBOOT_CAUSE_FILE):
         os.remove(PREVIOUS_REBOOT_CAUSE_FILE)
 
-    previous_reboot_cause, additional_reboot_info = determin_reboot_cause()
+    previous_reboot_cause, additional_reboot_info = determine_reboot_cause()
 
     # Current time
     reboot_cause_gen_time = str(datetime.datetime.now().strftime('%Y_%m_%d_%H_%M_%S'))

--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -175,28 +175,29 @@ def determine_reboot_cause():
     software_reboot_cause = find_software_reboot_cause()
 
     # The main decision logic of the reboot cause:
-    # If there is a reboot cause indicated by /proc/cmdline, it should be warmreboot/fastreboot
+    # If there is a valid hardware reboot cause indicated by platform API, 
+    #    check the software reboot cause to add additional rebot cause.
+    # If there is a reboot cause indicated by /proc/cmdline, and/or warmreboot/fastreboot/softreboot
     #   the software_reboot_cause which is the content of /hosts/reboot-cause/reboot-cause.txt
-    #   will be treated as the reboot cause
-    # Elif there is a reboot cause indicated by platform API,
-    #   the hardware_reboot_cause will be treated as the reboot cause
+    #   will be treated as the additional reboot cause
+    # Elif there is a cmdline reboot cause, 
+    #   the software_reboot_cause will be treated as the reboot cause if it's not unknown
+    #   otherwise, the cmdline_reboot_cause will be treated as the reboot cause if it's not none
     # Else the software_reboot_cause will be treated as the reboot cause
-    if proc_cmdline_reboot_cause is not None:
-        if not hardware_reboot_cause.startswith(REBOOT_CAUSE_NON_HARDWARE):
-            # Add the hardware_reboot_cause as actual reboot cause
-            previous_reboot_cause = hardware_reboot_cause
-            additional_reboot_info = software_reboot_cause
-        else:
-            previous_reboot_cause = software_reboot_cause
-    elif hardware_reboot_cause is not None:
+    if not hardware_reboot_cause.startswith(REBOOT_CAUSE_NON_HARDWARE):
+        previous_reboot_cause = hardware_reboot_cause
         # Check if any software reboot was issued before this hardware reboot happened
         if software_reboot_cause is not REBOOT_CAUSE_UNKNOWN:
-            previous_reboot_cause = hardware_reboot_cause
             additional_reboot_info = software_reboot_cause
+        elif proc_cmdline_reboot_cause is not None:
+            additional_reboot_info = proc_cmdline_reboot_cause
+    elif proc_cmdline_reboot_cause is not None:
+        if software_reboot_cause is not REBOOT_CAUSE_UNKNOWN:
+            # Get the reboot cause from REBOOT_CAUSE_FILE
+            previous_reboot_cause = software_reboot_cause
         else:
-            previous_reboot_cause = hardware_reboot_cause
+            previous_reboot_cause = proc_cmdline_reboot_cause
     else:
-        # Get the reboot cause from REBOOT_CAUSE_FILE
         previous_reboot_cause = software_reboot_cause
 
     return previous_reboot_cause, additional_reboot_info

--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -181,18 +181,41 @@ def main():
     # any additional_reboot_info it will be stored as a "comment" in REBOOT_CAUSE_HISTORY_FILE
     additional_reboot_info = "N/A"
 
-    # Check if the previous reboot was warm/fast reboot by testing whether there is "fast|fastfast|warm" in /proc/cmdline
+    # 1. Check if the previous reboot was warm/fast reboot by testing whether there is "fast|fastfast|warm" in /proc/cmdline
     proc_cmdline_reboot_cause = find_proc_cmdline_reboot_cause()
 
-    # If /proc/cmdline does not indicate reboot cause, check if the previous reboot was caused by hardware
-    if proc_cmdline_reboot_cause is None:
-        previous_reboot_cause = find_hardware_reboot_cause()
-        if previous_reboot_cause.startswith(REBOOT_CAUSE_NON_HARDWARE):
-            # If the reboot cause is non-hardware, get the reboot cause from REBOOT_CAUSE_FILE
-            previous_reboot_cause = find_software_reboot_cause()
+    # 2. Check if the previous reboot was caused by hardware
+    #    If yes, the hardware reboot cause will be treated as the reboot cause
+    hardware_reboot_cause = find_hardware_reboot_cause()
+
+    # 3. If there is a REBOOT_CAUSE_FILE, it will contain any software-related
+    #    reboot info. We will use it as the previous cause.
+    software_reboot_cause = find_software_reboot_cause()
+
+    # The main decision logic of the reboot cause:
+    # If there is a reboot cause indicated by /proc/cmdline, it should be warmreboot/fastreboot
+    #   the software_reboot_cause which is the content of /hosts/reboot-cause/reboot-cause.txt
+    #   will be treated as the reboot cause
+    # Elif there is a reboot cause indicated by platform API,
+    #   the hardware_reboot_cause will be treated as the reboot cause
+    # Else the software_reboot_cause will be treated as the reboot cause
+    if proc_cmdline_reboot_cause is not None:
+        if not hardware_reboot_cause.startswith(REBOOT_CAUSE_NON_HARDWARE):
+            # Add the hardware_reboot_cause as actual reboot cause
+            previous_reboot_cause = hardware_reboot_cause
+            additional_reboot_info = software_reboot_cause
+        else:
+            previous_reboot_cause = software_reboot_cause
+    elif hardware_reboot_cause is not None:
+        # Check if any software reboot was issued before this hardware reboot happened
+        if software_reboot_cause is not REBOOT_CAUSE_UNKNOWN:
+            previous_reboot_cause = hardware_reboot_cause
+            additional_reboot_info = software_reboot_cause
+        else:
+            previous_reboot_cause = hardware_reboot_cause
     else:
         # Get the reboot cause from REBOOT_CAUSE_FILE
-        previous_reboot_cause = find_software_reboot_cause()
+        previous_reboot_cause = software_reboot_cause
 
     # Current time
     reboot_cause_gen_time = str(datetime.datetime.now().strftime('%Y_%m_%d_%H_%M_%S'))

--- a/tests/determine-reboot-cause_test.py
+++ b/tests/determine-reboot-cause_test.py
@@ -168,6 +168,6 @@ class TestDetermineRebootCause(object):
             with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
                 with mock.patch("determine_reboot_cause.find_hardware_reboot_cause", return_value=EXPECTED_HARDWARE_REBOOT_CAUSE):
                     previous_reboot_cause, additional_info = determine_reboot_cause.determine_reboot_cause()
-                    assert previous_reboot_cause == REBOOT_CAUSE_WATCHDOG
+                    assert previous_reboot_cause == EXPECTED_HARDWARE_REBOOT_CAUSE
                     assert additional_info == EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER
 

--- a/tests/determine-reboot-cause_test.py
+++ b/tests/determine-reboot-cause_test.py
@@ -128,24 +128,24 @@ class TestDetermineRebootCause(object):
 
     def test_determine_reboot_cause_software(self):
         with mock.patch("determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value="Unknown"):
-            with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value="Unknown"):
-                with mock.patch("determine_reboot_cause.find_hardware_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
+            with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
+                with mock.patch("determine_reboot_cause.find_hardware_reboot_cause", return_value="Unknown"):
                     previous_reboot_cause, additional_info = determine_reboot_cause.determine_reboot_cause()
                     assert previous_reboot_cause == EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER
                     assert additional_info == "N/A"
 
     def test_determine_reboot_cause_cmdline(self):
         with mock.patch("determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value=EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE):
-            with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value="Unknown"):
-                with mock.patch("determine_reboot_cause.find_hardware_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
+            with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
+                with mock.patch("determine_reboot_cause.find_hardware_reboot_cause", return_value="Unknown"):
                     previous_reboot_cause, additional_info = determine_reboot_cause.determine_reboot_cause()
                     assert previous_reboot_cause == EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER
                     assert additional_info == "N/A"
 
     def test_determine_reboot_cause_cmdline_hardware(self):
         with mock.patch("determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value=EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE):
-            with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value=REBOOT_CAUSE_WATCHDOG):
-                with mock.patch("determine_reboot_cause.find_hardware_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
+            with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
+                with mock.patch("determine_reboot_cause.find_hardware_reboot_cause", return_value=REBOOT_CAUSE_WATCHDOG):
                     previous_reboot_cause, additional_info = determine_reboot_cause.determine_reboot_cause()
                     assert previous_reboot_cause == REBOOT_CAUSE_WATCHDOG
                     assert additional_info == EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER

--- a/tests/determine-reboot-cause_test.py
+++ b/tests/determine-reboot-cause_test.py
@@ -119,33 +119,33 @@ class TestDetermineRebootCause(object):
         assert reboot_cause_dict == EXPECTED_KERNEL_PANIC_REBOOT_CAUSE_DICT
 
     def test_determine_reboot_cause_hardware(self):
-        with mock.patch("determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value="Unknown"):
-            with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value="Power Cycle"):
-                with mock.patch("determine_reboot_cause.find_hardware_reboot_cause", return_value="Unknown"):
+        with mock.patch("determine_reboot_cause.determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value="Unknown"):
+            with mock.patch("determine_reboot_cause.determine_reboot_cause.find_software_reboot_cause", return_value="Power Cycle"):
+                with mock.patch("determine_reboot_cause.determine_reboot_cause.find_hardware_reboot_cause", return_value="Unknown"):
                     previous_reboot_cause, additional_info = determine_reboot_cause.determine_reboot_cause()
                     assert previous_reboot_cause == "Power Cycle"
                     assert additional_info == "N/A"
 
     def test_determine_reboot_cause_software(self):
-        with mock.patch("determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value="Unknown"):
-            with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
-                with mock.patch("determine_reboot_cause.find_hardware_reboot_cause", return_value="Unknown"):
+        with mock.patch("determine_reboot_cause.determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value="Unknown"):
+            with mock.patch("determine_reboot_cause.determine_reboot_cause.find_software_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
+                with mock.patch("determine_reboot_cause.determine_reboot_cause.find_hardware_reboot_cause", return_value="Unknown"):
                     previous_reboot_cause, additional_info = determine_reboot_cause.determine_reboot_cause()
                     assert previous_reboot_cause == EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER
                     assert additional_info == "N/A"
 
     def test_determine_reboot_cause_cmdline(self):
-        with mock.patch("determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value=EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE):
-            with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
-                with mock.patch("determine_reboot_cause.find_hardware_reboot_cause", return_value="Unknown"):
+        with mock.patch("determine_reboot_cause.determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value=EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE):
+            with mock.patch("determine_reboot_cause.determine_reboot_cause.find_software_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
+                with mock.patch("determine_reboot_cause.determine_reboot_cause.find_hardware_reboot_cause", return_value="Unknown"):
                     previous_reboot_cause, additional_info = determine_reboot_cause.determine_reboot_cause()
                     assert previous_reboot_cause == EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER
                     assert additional_info == "N/A"
 
     def test_determine_reboot_cause_cmdline_hardware(self):
-        with mock.patch("determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value=EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE):
-            with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
-                with mock.patch("determine_reboot_cause.find_hardware_reboot_cause", return_value=REBOOT_CAUSE_WATCHDOG):
+        with mock.patch("determine_reboot_cause.determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value=EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE):
+            with mock.patch("determine_reboot_cause.determine_reboot_cause.find_software_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
+                with mock.patch("determine_reboot_cause.determine_reboot_cause.find_hardware_reboot_cause", return_value=REBOOT_CAUSE_WATCHDOG):
                     previous_reboot_cause, additional_info = determine_reboot_cause.determine_reboot_cause()
                     assert previous_reboot_cause == REBOOT_CAUSE_WATCHDOG
                     assert additional_info == EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER

--- a/tests/determine-reboot-cause_test.py
+++ b/tests/determine-reboot-cause_test.py
@@ -109,7 +109,12 @@ class TestDetermineRebootCause(object):
     def test_find_hardware_reboot_cause(self):
         with mock.patch("determine_reboot_cause.get_reboot_cause_from_platform", return_value=("Powerloss", None)):
             result = determine_reboot_cause.find_hardware_reboot_cause()
-            assert result == "Powerloss (None)"
+            assert result == "Powerloss"
+
+    def test_find_hardware_reboot_cause_with_minor(self):
+        with mock.patch("determine_reboot_cause.get_reboot_cause_from_platform", return_value=("Powerloss", "under-voltage")):
+            result = determine_reboot_cause.find_hardware_reboot_cause()
+            assert result == "Powerloss (under-voltage)"
 
     def test_get_reboot_cause_dict_watchdog(self):
         reboot_cause_dict = determine_reboot_cause.get_reboot_cause_dict(REBOOT_CAUSE_WATCHDOG, "", GEN_TIME_WATCHDOG)

--- a/tests/determine-reboot-cause_test.py
+++ b/tests/determine-reboot-cause_test.py
@@ -132,33 +132,33 @@ class TestDetermineRebootCause(object):
                     assert additional_reboot_info == "N/A"
 
     def test_determine_reboot_cause_software(self):
-        with mock.patch("determine_reboot_cause.determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value=None):
-            with mock.patch("determine_reboot_cause.determine_reboot_cause.find_software_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
-                with mock.patch("determine_reboot_cause.determine_reboot_cause.find_hardware_reboot_cause", return_value=EXPECTED_NON_HARDWARE_REBOOT_CAUSE):
+        with mock.patch("determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value=None):
+            with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
+                with mock.patch("determine_reboot_cause.find_hardware_reboot_cause", return_value=EXPECTED_NON_HARDWARE_REBOOT_CAUSE):
                     previous_reboot_cause, additional_info = determine_reboot_cause.determine_reboot_cause()
                     assert previous_reboot_cause == EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER
                     assert additional_info == "N/A"
 
     def test_determine_reboot_cause_cmdline_software(self):
-        with mock.patch("determine_reboot_cause.determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value=EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE):
-            with mock.patch("determine_reboot_cause.determine_reboot_cause.find_software_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
-                with mock.patch("determine_reboot_cause.determine_reboot_cause.find_hardware_reboot_cause", return_value=EXPECTED_NON_HARDWARE_REBOOT_CAUSE):
+        with mock.patch("determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value=EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE):
+            with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER):
+                with mock.patch("determine_reboot_cause.find_hardware_reboot_cause", return_value=EXPECTED_NON_HARDWARE_REBOOT_CAUSE):
                     previous_reboot_cause, additional_info = determine_reboot_cause.determine_reboot_cause()
                     assert previous_reboot_cause == EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER
                     assert additional_info == "N/A"
 
     def test_determine_reboot_cause_cmdline_no_software(self):
-        with mock.patch("determine_reboot_cause.determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value=EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE):
-            with mock.patch("determine_reboot_cause.determine_reboot_cause.find_software_reboot_cause", return_value=REBOOT_CAUSE_UNKNOWN):
-                with mock.patch("determine_reboot_cause.determine_reboot_cause.find_hardware_reboot_cause", return_value=EXPECTED_NON_HARDWARE_REBOOT_CAUSE):
+        with mock.patch("determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value=EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE):
+            with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value=REBOOT_CAUSE_UNKNOWN):
+                with mock.patch("determine_reboot_cause.find_hardware_reboot_cause", return_value=EXPECTED_NON_HARDWARE_REBOOT_CAUSE):
                     previous_reboot_cause, additional_info = determine_reboot_cause.determine_reboot_cause()
                     assert previous_reboot_cause == EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE
                     assert additional_info == "N/A"
 
     def test_determine_reboot_cause_cmdline_hardware(self):
-        with mock.patch("determine_reboot_cause.determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value=EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE):
-            with mock.patch("determine_reboot_cause.determine_reboot_cause.find_software_reboot_cause", return_value=REBOOT_CAUSE_UNKNOWN):
-                with mock.patch("determine_reboot_cause.determine_reboot_cause.find_hardware_reboot_cause", return_value=EXPECTED_HARDWARE_REBOOT_CAUSE):
+        with mock.patch("determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value=EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE):
+            with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value=REBOOT_CAUSE_UNKNOWN):
+                with mock.patch("determine_reboot_cause.find_hardware_reboot_cause", return_value=EXPECTED_HARDWARE_REBOOT_CAUSE):
                     previous_reboot_cause, additional_info = determine_reboot_cause.determine_reboot_cause()
                     assert previous_reboot_cause == EXPECTED_HARDWARE_REBOOT_CAUSE
                     assert additional_info == EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE


### PR DESCRIPTION
Why I did it
Add the hardware reboot cause when the previous software reboot failed

How I did it
Check both hardware reboot cause and software reboot cause.
Add the hardware reboot as actual reboot cause
if any hardware reboot cause is available for any software reboot.

How to verify it
Perform fast/warm/soft-reboot, cold reboot and hardware reboots and check the reboot-cause