### PR TITLE
Enable TACACS accounting when enable TACACS authentication.

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -549,7 +549,7 @@ class AaaCfg(object):
                 self.authentication['failthrough'] = is_true(data['failthrough'])
             if 'debug' in data:
                 self.debug = is_true(data['debug'])
-            if 'login' in data and 'tacacs+' in data['login']
+            if 'login' in data and 'tacacs+' in data['login']:
                 # enable tacacs+ accounting when enable tacacs+ authentication
                 run_cmd("config aaa accounting 'tacacs+ local'")
         if key == 'authorization':

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -551,7 +551,7 @@ class AaaCfg(object):
                 self.debug = is_true(data['debug'])
             if 'login' in data and data['login'] == 'tacacs+':
                 # enable tacacs+ accounting when enable tacacs+ authentication
-                self.accounting['login'] = 'tacacs+'
+                run_cmd("config aaa accounting tacacs+")
         if key == 'authorization':
             self.authorization = data
         if key == 'accounting':

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -549,6 +549,9 @@ class AaaCfg(object):
                 self.authentication['failthrough'] = is_true(data['failthrough'])
             if 'debug' in data:
                 self.debug = is_true(data['debug'])
+            if 'login' in data and data['login'] == 'tacacs+':
+                # enable tacacs+ accounting when enable tacacs+ authentication
+                self.accounting['login'] = 'tacacs+'
         if key == 'authorization':
             self.authorization = data
         if key == 'accounting':

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -549,7 +549,7 @@ class AaaCfg(object):
                 self.authentication['failthrough'] = is_true(data['failthrough'])
             if 'debug' in data:
                 self.debug = is_true(data['debug'])
-            if 'login' in data and data['login'] == 'tacacs+':
+            if 'login' in data and 'tacacs+' in data['login']
                 # enable tacacs+ accounting when enable tacacs+ authentication
                 run_cmd("config aaa accounting 'tacacs+ local'")
         if key == 'authorization':

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -551,7 +551,7 @@ class AaaCfg(object):
                 self.debug = is_true(data['debug'])
             if 'login' in data and data['login'] == 'tacacs+':
                 # enable tacacs+ accounting when enable tacacs+ authentication
-                run_cmd("config aaa accounting tacacs+")
+                run_cmd("config aaa accounting 'tacacs+ local'")
         if key == 'authorization':
             self.authorization = data
         if key == 'accounting':

--- a/tests/hostcfgd/hostcfgd_tacacs_test.py
+++ b/tests/hostcfgd/hostcfgd_tacacs_test.py
@@ -114,3 +114,27 @@ class TestHostcfgdTACACS(TestCase):
         self.check_config(test_name, test_data, "config_db_local_and_tacacs")
         # test disable accounting
         self.check_config(test_name, test_data, "config_db_disable_accounting")
+
+    def test_hostcfgd_tacacs_enable_accounting(self):
+        """
+            Test TACACS hostcfd daemon enable accounting when enable authentication
+
+            Returns:
+                None
+        """
+        host_config_daemon = hostcfgd.HostConfigDaemon()
+
+        # mock run_cmd
+        command = ""
+        def mock_run_cmd(cmd, log_err=True, raise_exception=False):
+            command = cmd
+
+        host_config_daemon.run_cmd = mock_run_cmd
+
+        # check enable authentication will also enable accounting
+        config_data = {
+            'login': 'tacacs+'
+        }
+        host_config_daemon.aaacfg.aaa_update("authentication",config_data)
+
+        self.assertEqual(command, "config aaa accounting 'tacacs+ local'")

--- a/tests/hostcfgd/hostcfgd_tacacs_test.py
+++ b/tests/hostcfgd/hostcfgd_tacacs_test.py
@@ -124,6 +124,7 @@ class TestHostcfgdTACACS(TestCase):
         """
         command = None
         def mock_run_cmd(cmd, log_err=True, raise_exception=False):
+            global command
             command = cmd
 
         hostcfgd.run_cmd = mock_run_cmd

--- a/tests/hostcfgd/hostcfgd_tacacs_test.py
+++ b/tests/hostcfgd/hostcfgd_tacacs_test.py
@@ -129,12 +129,11 @@ class TestHostcfgdTACACS(TestCase):
         def mock_run_cmd(cmd, log_err=True, raise_exception=False):
             command = cmd
 
-        host_config_daemon.run_cmd = mock_run_cmd
+        with mock.patch("hostcfgd.run_cmd") as mock_run_cmd:
+            # check enable authentication will also enable accounting
+            config_data = {
+                'login': 'tacacs+'
+            }
+            host_config_daemon.aaacfg.aaa_update("authentication",config_data)
 
-        # check enable authentication will also enable accounting
-        config_data = {
-            'login': 'tacacs+'
-        }
-        host_config_daemon.aaacfg.aaa_update("authentication",config_data)
-
-        self.assertEqual(command, "config aaa accounting 'tacacs+ local'")
+            self.assertEqual(command, "config aaa accounting 'tacacs+ local'")

--- a/tests/hostcfgd/hostcfgd_tacacs_test.py
+++ b/tests/hostcfgd/hostcfgd_tacacs_test.py
@@ -34,6 +34,8 @@ hostcfgd.ConfigDBConnector = MockConfigDb
 hostcfgd.DBConnector = MockDBConnector
 hostcfgd.Table = mock.Mock()
 
+hostcfgd_command = None
+
 class TestHostcfgdTACACS(TestCase):
     """
         Test hostcfd daemon - TACACS
@@ -122,10 +124,9 @@ class TestHostcfgdTACACS(TestCase):
             Returns:
                 None
         """
-        command = None
         def mock_run_cmd(cmd, log_err=True, raise_exception=False):
-            global command
-            command = cmd
+            global hostcfgd_command
+            hostcfgd_command = cmd
 
         hostcfgd.run_cmd = mock_run_cmd
 
@@ -136,4 +137,4 @@ class TestHostcfgdTACACS(TestCase):
         host_config_daemon = hostcfgd.HostConfigDaemon()
         host_config_daemon.aaacfg.aaa_update("authentication",config_data)
 
-        self.assertEqual(command, "config aaa accounting 'tacacs+ local'")
+        self.assertEqual(hostcfgd_command, "config aaa accounting 'tacacs+ local'")

--- a/tests/hostcfgd/hostcfgd_tacacs_test.py
+++ b/tests/hostcfgd/hostcfgd_tacacs_test.py
@@ -122,18 +122,17 @@ class TestHostcfgdTACACS(TestCase):
             Returns:
                 None
         """
-        host_config_daemon = hostcfgd.HostConfigDaemon()
-
-        # mock run_cmd
-        command = ""
+        command = None
         def mock_run_cmd(cmd, log_err=True, raise_exception=False):
             command = cmd
 
-        with mock.patch("hostcfgd.run_cmd") as mock_run_cmd:
-            # check enable authentication will also enable accounting
-            config_data = {
-                'login': 'tacacs+'
-            }
-            host_config_daemon.aaacfg.aaa_update("authentication",config_data)
+        hostcfgd.run_cmd = mock_run_cmd
 
-            self.assertEqual(command, "config aaa accounting 'tacacs+ local'")
+        # check enable authentication will also enable accounting
+        config_data = {
+            'login': 'tacacs+'
+        }
+        host_config_daemon = hostcfgd.HostConfigDaemon()
+        host_config_daemon.aaacfg.aaa_update("authentication",config_data)
+
+        self.assertEqual(command, "config aaa accounting 'tacacs+ local'")


### PR DESCRIPTION

#### Why I did it
To enable TACACS accounting when enable TACACS authentication.

#### How I did it
Listen TACACS authentication enable event and enable TACACS accounting when receive event.

#### How to verify it
Manually test.
Pass all E2E test case.

#### Which release branch to backport (provide reason below if selected)

#### Description for the changelog
Enable TACACS accounting when enable TACACS authentication.

#### A picture of a cute animal (not mandatory but encouraged)