### PR TITLE
[caclmgrd][chassis]: Fix missing acl rules to allow internal docker traffic from fabric namespaces

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -141,15 +141,15 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
             self.update_thread[back_asic_namespace] = None
             self.lock[back_asic_namespace] = threading.Lock()
             self.num_changes[back_asic_namespace] = 0
-            self.update_docket_mgmt_ip_acl(back_asic_namespace)
+            self.update_docker_mgmt_ip_acl(back_asic_namespace)
        
         for fabric_asic_namespace in namespaces['fabric_ns']:
             self.update_thread[fabric_asic_namespace] = None
             self.lock[fabric_asic_namespace] = threading.Lock()
             self.num_changes[fabric_asic_namespace] = 0
-            self.update_docket_mgmt_ip_acl(fabric_asic_namespace)
+            self.update_docker_mgmt_ip_acl(fabric_asic_namespace)
 
-    def update_docket_mgmt_ip_acl(self, namespace):
+    def update_docker_mgmt_ip_acl(self, namespace):
             self.iptables_cmd_ns_prefix[namespace] = "ip netns exec " + namespace + " "
             self.namespace_docker_mgmt_ip[namespace] = self.get_namespace_mgmt_ip(self.iptables_cmd_ns_prefix[namespace],
                                                                                              namespace)

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -135,22 +135,26 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
 
             self.config_db_map[front_asic_namespace] = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=front_asic_namespace)
             self.config_db_map[front_asic_namespace].connect()
-            self.iptables_cmd_ns_prefix[front_asic_namespace] = "ip netns exec " + front_asic_namespace + " "
-            self.namespace_docker_mgmt_ip[front_asic_namespace] = self.get_namespace_mgmt_ip(self.iptables_cmd_ns_prefix[front_asic_namespace],
-                                                                                              front_asic_namespace)
-            self.namespace_docker_mgmt_ipv6[front_asic_namespace] = self.get_namespace_mgmt_ipv6(self.iptables_cmd_ns_prefix[front_asic_namespace],
-                                                                                              front_asic_namespace)
+            self.update_docker_mgmt_ip_acl(front_asic_namespace)
 
         for back_asic_namespace in namespaces['back_ns']:
             self.update_thread[back_asic_namespace] = None
             self.lock[back_asic_namespace] = threading.Lock()
             self.num_changes[back_asic_namespace] = 0
+            self.update_docket_mgmt_ip_acl(back_asic_namespace)
+       
+        for fabric_asic_namespace in namespaces['fabric_ns']:
+            self.update_thread[fabric_asic_namespace] = None
+            self.lock[fabric_asic_namespace] = threading.Lock()
+            self.num_changes[fabric_asic_namespace] = 0
+            self.update_docket_mgmt_ip_acl(fabric_asic_namespace)
 
-            self.iptables_cmd_ns_prefix[back_asic_namespace] = "ip netns exec " + back_asic_namespace + " "
-            self.namespace_docker_mgmt_ip[back_asic_namespace] = self.get_namespace_mgmt_ip(self.iptables_cmd_ns_prefix[back_asic_namespace],
-                                                                                             back_asic_namespace)
-            self.namespace_docker_mgmt_ipv6[back_asic_namespace] = self.get_namespace_mgmt_ipv6(self.iptables_cmd_ns_prefix[back_asic_namespace],
-                                                                                             back_asic_namespace)
+    def update_docket_mgmt_ip_acl(self, namespace):
+            self.iptables_cmd_ns_prefix[namespace] = "ip netns exec " + namespace + " "
+            self.namespace_docker_mgmt_ip[namespace] = self.get_namespace_mgmt_ip(self.iptables_cmd_ns_prefix[namespace],
+                                                                                             namespace)
+            self.namespace_docker_mgmt_ipv6[namespace] = self.get_namespace_mgmt_ipv6(self.iptables_cmd_ns_prefix[namespace],
+                                                                                             namespace)
 
     def get_namespace_mgmt_ip(self, iptable_ns_cmd_prefix, namespace):
         ip_address_get_command = iptable_ns_cmd_prefix + "ip -4 -o addr show " + ("eth0" if namespace else "docker0") +\

--- a/tests/caclmgrd/caclmgrd_namespace_docker_ip_test.py
+++ b/tests/caclmgrd/caclmgrd_namespace_docker_ip_test.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+from sonic_py_common.general import load_module_from_source
+from unittest import TestCase, mock
+
+class TestCaclmgrdNamespaceDockerIP(TestCase):
+    """
+        Test caclmgrd Namespace docker management IP
+    """
+    def setUp(self):
+        test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        modules_path = os.path.dirname(test_path)
+        scripts_path = os.path.join(modules_path, "scripts")
+        sys.path.insert(0, modules_path)
+        caclmgrd_path = os.path.join(scripts_path, 'caclmgrd')
+        self.caclmgrd = load_module_from_source('caclmgrd', caclmgrd_path)
+        self.maxDiff = None
+
+    def test_caclmgrd_namespace_docker_ip(self):
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ip = mock.MagicMock(return_value=[])
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ipv6 = mock.MagicMock(return_value=[])
+        with mock.patch('sonic_py_common.multi_asic.get_all_namespaces',
+                return_value={'front_ns': ['asic0'], 'back_ns': ['asic1'], 'fabric_ns': ['asic2']}):
+            caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
+            self.assertTrue('asic0' in caclmgrd_daemon.namespace_docker_mgmt_ip)
+            self.assertTrue('asic1' in caclmgrd_daemon.namespace_docker_mgmt_ip)
+            self.assertTrue('asic2' in caclmgrd_daemon.namespace_docker_mgmt_ip)
+            self.assertListEqual(caclmgrd_daemon.namespace_docker_mgmt_ip['asic0'], [])


### PR DESCRIPTION

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>
Requires https://github.com/sonic-net/sonic-buildimage/pull/11793
test_cacl_application fails on VoQ chassis Supervisor with the error:
Failed: Missing expected iptables rules: set(['-A INPUT -s 240.127.1.1/32 -d 240.127.1.1/32 -j ACCEPT', '-A INPUT -s 240.127.1.3/32 -d 240.127.1.1/32 -j ACCEPT', '-A INPUT -s 240.127.1.2/32 -d 240.127.1.1/32 -j ACCEPT'])
This failure is seen because acl rules to allow traffic from fabric namespaces is missing.
This PR is to include fabric namespace docker mgmt ips so that acl rules to allow traffic from namespace is added for fabric namespace as well.
Initial PR which added support for multi-asic for reference: https://github.com/sonic-net/sonic-buildimage/pull/5022