### PR TITLE
python http-server host service implementation

### DIFF
--- a/scripts/http-server
+++ b/scripts/http-server
@@ -1,0 +1,148 @@
+#!/usr/bin/python3
+# 
+###########################################################################
+# http-server.py
+# 
+# Python HTTP Server service.
+# This service runs based on the configuration provided in
+# device/<platform>/platform_env.conf
+#
+# Configuration parameters provided by platform_env.conf are as follows:
+#
+# start_http_server: if "yes" or "1", http-server will be started on this
+#     node
+# http_server_ip   : IP address for http-server. The service also writes this
+#     entry in /etc/hosts to map to http-server host name
+# http_server_port : Port to bind to, default: 8000
+# http_server_dir  : HTTP server home directory path, default: /var/www/
+#
+###########################################################################
+# Copyright (c) 2021 Cisco Systems, Inc. and its affiliates.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###########################################################################
+
+# Example of config on Supervisor node:
+'''
+start_http_server=yes
+http_server_ip=127.0.0.10
+http_server_port=8001
+http_server_dir=/var/www/tftp
+'''
+# Example of config on Line Card:
+'''
+http_server_ip=127.0.0.10
+'''
+
+import argparse
+import http.server
+import os
+import socketserver
+import subprocess
+import syslog
+
+from pathlib import Path
+
+HTTP_DEFAULT_BIND_PORT = "8000"
+HTTP_DEFAULT_DIR_PATH = '/var/www'
+http_dir = None
+
+ETC_HOSTS_FILE = '/etc/hosts'
+
+class HTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=http_dir, **kwargs)
+
+class HttpServer():
+    ''' HTTP server class implementation '''
+
+    def __init__(self, args, **kw):
+        self.http_config = {}
+        self.start_http_server = None
+
+        if args.config_file:
+            # Use config file provided from command line
+            platform_conf = args.config_file
+        else:
+            # get platform_env.conf path based on platform type
+            self.get_platform()
+            platform_conf=os.path.join('/usr/share/sonic/device', self.platform, 'platform_env.conf')
+
+        syslog.syslog(syslog.LOG_INFO,'HTTP Server config file:{}'.format(platform_conf))
+        if os.path.isfile(platform_conf):
+            with open(platform_conf) as f:
+                for line in f.readlines():
+                    (key, _, value) = line.strip().replace('"','').partition("=")
+                    self.http_config[key] = value
+        else:
+            syslog.syslog(syslog.LOG_INFO, 'HTTP server config file {} not present - exiting...'.format(platform_conf))
+            exit(0)
+
+        self.http_server_ip = self.http_config.get('http_server_ip')
+        if self.http_server_ip:
+            global http_dir
+            self.start_http_server = self.http_config.get('start_http_server')
+            http_dir = self.http_config.get('http_server_dir', HTTP_DEFAULT_DIR_PATH)
+
+            # Get Server port from config
+            self.http_server_port = int(self.http_config.get('http_server_port', HTTP_DEFAULT_BIND_PORT))
+            # write 'http-server' hostname mapping in ETC_HOSTS_FILE if the hostname is not present
+            syslog.syslog(syslog.LOG_INFO, 'write http-server hostname entry to {}'.format(ETC_HOSTS_FILE))
+            with open(ETC_HOSTS_FILE) as f:
+                if 'http-server' not in f.read():
+                    etc_hosts_data = '{} {}\n'.format(self.http_server_ip, 'http-server')
+                    f = open(ETC_HOSTS_FILE, 'a')
+                    f.write(etc_hosts_data)
+
+            # Create HTTP home dir path if not present
+            path = Path(http_dir)
+            path.mkdir(parents=True, exist_ok=True)
+
+    def get_platform(self):
+        ''' Get the platform type from DEVICE_METADATA '''
+
+        SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
+        PLATFORM_KEY = 'DEVICE_METADATA.localhost.platform'
+
+        proc = subprocess.Popen([SONIC_CFGGEN_PATH, '-H', '-v', PLATFORM_KEY],
+                            stdout=subprocess.PIPE,
+                            shell=False,
+                            stderr=subprocess.STDOUT)
+        outp = proc.communicate()[0]
+        proc.wait()
+        self.platform = outp.decode().rstrip('\n')
+
+    def run(self):
+        ''' start the http-server if start_http_server is set in config file '''
+
+        if self.start_http_server == 'yes' or self.start_http_server == '1':
+            # Start the http-server, generally on the Supervisor card.
+            syslog.syslog(syslog.LOG_INFO, 'start_http_server is set, starting http-server')
+            if self.http_config:
+                with socketserver.TCPServer(('http-server', self.http_server_port), HTTPRequestHandler) as httpd:
+                    syslog.syslog(syslog.LOG_INFO, 'HTTP Server Port:{} home:{}'.format(self.http_server_port, http_dir))
+                    httpd.serve_forever()
+        else:
+            syslog.syslog(syslog.LOG_INFO, 'start_http_server is not set, exiting...')
+
+def main():
+    parser = argparse.ArgumentParser(description='Python3 HTTP Server')
+    parser.add_argument('--config-file', help='HTTP Server config yaml file', default=None)
+    args = parser.parse_args()
+
+    HttpServer(args).run()
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(
         'scripts/procdockerstatsd',
         'scripts/determine-reboot-cause',
         'scripts/process-reboot-cause',
-        'scripts/sonic-host-server'
+        'scripts/sonic-host-server',
+        'scripts/http-server'
     ],
     install_requires = [
         'dbus-python',


### PR DESCRIPTION
Signed-off-by: anamehra [anamehra@cisco.com](mailto:anamehra@cisco.com)
```
# Python HTTP Server service.
# This service runs based the configuration provided in
# device/<platform>/platform_env.conf
#
# Configuration parameters provided by platform_env.conf are as follows:
#
# start_http_server: if "yes" or "1", http-server will be started on this
#     node
# http_server_ip   : IP address for http-server. The service also writes this
#     entry in /etc/hosts to map to http-server host name
# http_server_port : Port to bind to, default: 8000
# http_server_dir  : HTTP server home directory path, default: /var/www/
#

# Example of config on Supervisor node:
'''
start_http_server=yes
http_server_ip=127.0.0.10
http_server_port=8001
http_server_dir=/var/www/tftp
'''
# Example of config on Line Card:
'''
http_server_ip=127.0.0.10
'''
```
**Why I did it**
Enable http-server as host service on Chassis supervisor to enable LCs to download image and config files from Supervisor.

**How I did it**
Added http-server as host service.
The service starts a python based http-server on the midplane network.

**How to verify it**
Add device//platform_env.conf with following data:
start_http_server=yes
http_server_ip=127.0.0.10
http_server_port=8001
http_server_dir=/var/www/tftp

Boot with the image with the above data.

put an image file at /var/www/tftp/filename
check 'systemctl status http-service'
curl http://http-server:8000/filename -o out_file
compare file_out with /var/www/tftp/filename