### PR TITLE
Install libyang to azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,6 +71,7 @@ stages:
         sudo dpkg -i libnl-route-3-200_*.deb
         sudo dpkg -i libnl-nf-3-200_*.deb
         sudo dpkg -i libhiredis0.14_*.deb
+        sudo dpkg -i libyang_1.0.73_*.deb
       workingDirectory: $(Pipeline.Workspace)/target/debs/buster/
       displayName: 'Install Debian dependencies'
 


### PR DESCRIPTION
#### Why I did it
sonic-swss-common lib will add dependency to libyang soon, so need install libyang lib to prevent build and UT break.

#### How I did it
Modify azure pipeline to install libyang in azure pipeline steps.

#### How to verify it
Pass all UT.

#### Which release branch to backport (provide reason below if selected)

#### Description for the changelog
Modify azure pipeline to install libyang in azure pipeline steps.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

