### PR TITLE
[multi-asic] Fix the issue where if dest port is not specified in ACL rule than caclmgrd gets exception

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -314,27 +314,28 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                 nat_source_ipv6_set = acl_source_ip_map[acl_service]["ipv6"] if acl_source_ip_map and acl_source_ip_map[acl_service]["ipv6"] else { "::/0" }
 
                 for ip_protocol in self.ACL_SERVICES[acl_service]["ip_protocols"]:
-                    for dst_port in  self.ACL_SERVICES[acl_service]["dst_ports"]: 
-                        for ipv4_src_ip in nat_source_ipv4_set:
-                            # IPv4 rules
-                            fwd_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
-                                                               "iptables -t nat -A PREROUTING -p {} -s {} --dport {}  -j DNAT --to-destination {}".format
-                                                               (ip_protocol, ipv4_src_ip, dst_port,
-                                                                self.namespace_mgmt_ip))
-                            fwd_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
-                                                               "iptables -t nat -A POSTROUTING -p {} -s {} --dport {} -j SNAT --to-source {}".format
-                                                               (ip_protocol, ipv4_src_ip, dst_port,
-                                                                self.namespace_docker_mgmt_ip[namespace]))
-                        for ipv6_src_ip in nat_source_ipv6_set:
-                            # IPv6 rules
-                            fwd_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
-                                                               "ip6tables -t nat -A PREROUTING -p {} -s {} --dport {}  -j DNAT --to-destination {}".format
-                                                               (ip_protocol, ipv6_src_ip, dst_port,
-                                                                self.namespace_mgmt_ipv6))
-                            fwd_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
-                                                               "ip6tables -t nat -A POSTROUTING -p {} -s {} --dport {} -j SNAT --to-source {}".format
-                                                               (ip_protocol,ipv6_src_ip, dst_port,
-                                                                self.namespace_docker_mgmt_ipv6[namespace]))
+                    if "dst_ports" in self.ACL_SERVICES[acl_service]:
+                        for dst_port in  self.ACL_SERVICES[acl_service]["dst_ports"]:
+                            for ipv4_src_ip in nat_source_ipv4_set:
+                                # IPv4 rules
+                                fwd_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+                                                                   "iptables -t nat -A PREROUTING -p {} -s {} --dport {}  -j DNAT --to-destination {}".format
+                                                                   (ip_protocol, ipv4_src_ip, dst_port,
+                                                                    self.namespace_mgmt_ip))
+                                fwd_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+                                                                   "iptables -t nat -A POSTROUTING -p {} -s {} --dport {} -j SNAT --to-source {}".format
+                                                                   (ip_protocol, ipv4_src_ip, dst_port,
+                                                                    self.namespace_docker_mgmt_ip[namespace]))
+                            for ipv6_src_ip in nat_source_ipv6_set:
+                                # IPv6 rules
+                                fwd_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+                                                                   "ip6tables -t nat -A PREROUTING -p {} -s {} --dport {}  -j DNAT --to-destination {}".format
+                                                                   (ip_protocol, ipv6_src_ip, dst_port,
+                                                                    self.namespace_mgmt_ipv6))
+                                fwd_traffic_from_namespace_to_host_cmds.append(self.iptables_cmd_ns_prefix[namespace] +
+                                                                   "ip6tables -t nat -A POSTROUTING -p {} -s {} --dport {} -j SNAT --to-source {}".format
+                                                                   (ip_protocol,ipv6_src_ip, dst_port,
+                                                                    self.namespace_docker_mgmt_ipv6[namespace]))
 
         return fwd_traffic_from_namespace_to_host_cmds
 

--- a/tests/caclmgrd/caclmgrd_external_client_acl_test.py
+++ b/tests/caclmgrd/caclmgrd_external_client_acl_test.py
@@ -42,3 +42,10 @@ class TestCaclmgrdExternalClientAcl(TestCase):
 
         iptables_rules_ret, _ = caclmgrd_daemon.get_acl_rules_and_translate_to_iptables_commands('')
         self.assertEqual(set(test_data["return"]).issubset(set(iptables_rules_ret)), True)
+        caclmgrd_daemon.iptables_cmd_ns_prefix['asic0'] = 'ip netns exec asic0'
+        caclmgrd_daemon.namespace_docker_mgmt_ip['asic0'] = '1.1.1.1'
+        caclmgrd_daemon.namespace_mgmt_ip = '2.2.2.2'
+        caclmgrd_daemon.namespace_docker_mgmt_ipv6['asic0'] = 'fd::01'
+        caclmgrd_daemon.namespace_mgmt_ipv6 = 'fd::02'
+
+        _ = caclmgrd_daemon.generate_fwd_traffic_from_namespace_to_host_commands('asic0', None)

--- a/tests/caclmgrd/test_external_client_acl_vectors.py
+++ b/tests/caclmgrd/test_external_client_acl_vectors.py
@@ -5,6 +5,41 @@ from unittest.mock import call
 """
 EXTERNAL_CLIENT_ACL_TEST_VECTOR = [
     [
+        "Test for EXTERNAL_CLIENT_ACL with no dest port configured.",
+        {
+            "config_db": {
+                "ACL_TABLE": {
+                    "EXTERNAL_CLIENT_ACL": {
+                        "stage": "INGRESS",
+                        "type": "CTRLPLANE",
+                        "services": [
+                            "EXTERNAL_CLIENT"
+                        ]
+                    }
+                },
+                "ACL_RULE": {
+                    "EXTERNAL_CLIENT_ACL|DEFAULT_RULE": {
+                        "ETHER_TYPE": "2048",
+                        "PACKET_ACTION": "DROP",
+                        "PRIORITY": "1"
+                    },
+                    "EXTERNAL_CLIENT_ACL|RULE_1": {
+                        "PACKET_ACTION": "ACCEPT",
+                        "PRIORITY": "9998",
+                        "SRC_IP": "20.0.0.55/32"
+                    },
+                },
+                "DEVICE_METADATA": {
+                    "localhost": {
+                    }
+                },
+                "FEATURE": {},
+            },
+            "return": [
+            ],
+        }
+    ],
+    [
         "Test single IPv4 dst port + src ip for EXTERNAL_CLIENT_ACL",
         {
             "config_db": {


### PR DESCRIPTION
What I did:
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/12179

Why I did:
Fix the issue where if dest port is not specified in ACL rule than for multi-asic where we create NAT rule to forward traffic from Namespace to host fail with exception.

How I verify:-
Added UT for the scenario. 