### PR TITLE
[Chassis][Supervisor] Modify hostcfgd to remove all unsupported feature dockers after masking the services on Supervisor card

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -312,6 +312,19 @@ class FeatureHandler(object):
 
         return True
 
+    def is_docker_exist(self, docker_name):
+        """ 
+        Check if docker exists
+        """
+        command ="docker inspect {} --format {{.State.Pid}}".format(docker_name)
+        proc = subprocess.Popen(command, shell=True, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate() 
+        if proc.returncode != 0:
+            return False
+        else:
+           return True
+                
+
     def sync_feature_asic_scope(self, feature_config):
         """Updates the has_per_asic_scope field in the FEATURE|* tables as the field
         might have to be rendered based on DEVICE_METADATA table or Device Running configuration.
@@ -325,7 +338,7 @@ class FeatureHandler(object):
             None.
         """
 
-        cmds = []
+
         feature_names, feature_suffixes = self.get_multiasic_feature_instances(feature_config, True)
         for feature_name in feature_names:
             if '@' not in feature_name:
@@ -334,10 +347,15 @@ class FeatureHandler(object):
             if not unit_file_state:
                 continue
             if unit_file_state != "disabled" and not feature_config.has_per_asic_scope:
+                cmds = []
                 for suffix in reversed(feature_suffixes):
                     cmds.append("sudo systemctl stop {}.{}".format(feature_name, suffix))
                     cmds.append("sudo systemctl disable {}.{}".format(feature_name, feature_suffixes[-1]))
                     cmds.append("sudo systemctl mask {}.{}".format(feature_name, feature_suffixes[-1]))
+                    if device_info.is_supervisor() and suffix != "timer":
+                        docker_name =  feature_name.replace("@","")
+                        if self.is_docker_exist(docker_name):
+                           cmds.append("sudo docker rm {}".format(docker_name))  
                 for cmd in cmds:
                     syslog.syslog(syslog.LOG_INFO, "Running cmd: '{}'".format(cmd))
                     try:
@@ -421,14 +439,13 @@ class FeatureHandler(object):
         return props["UnitFileState"]
 
     def enable_feature(self, feature):
-        cmds = []
         feature_names, feature_suffixes = self.get_multiasic_feature_instances(feature)
         for feature_name in feature_names:
             # Check if it is already enabled, if yes skip the system call
             unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
             if unit_file_state == "enabled" or not unit_file_state:
                 continue
-
+            cmds = []    
             for suffix in feature_suffixes:
                 cmds.append("sudo systemctl unmask {}.{}".format(feature_name, suffix))
 
@@ -451,18 +468,22 @@ class FeatureHandler(object):
         self.set_feature_state(feature, self.FEATURE_STATE_ENABLED)
 
     def disable_feature(self, feature):
-        cmds = []
         feature_names, feature_suffixes = self.get_multiasic_feature_instances(feature)
         for feature_name in feature_names:
             # Check if it is already disabled, if yes skip the system call
             unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
             if unit_file_state in ("disabled", "masked") or not unit_file_state:
                 continue
-
+            cmds = []
             for suffix in reversed(feature_suffixes):
                 cmds.append("sudo systemctl stop {}.{}".format(feature_name, suffix))
                 cmds.append("sudo systemctl disable {}.{}".format(feature_name, feature_suffixes[-1]))
                 cmds.append("sudo systemctl mask {}.{}".format(feature_name, feature_suffixes[-1]))
+                if device_info.is_supervisor() and suffix != "timer":
+                    docker_name =  feature_name.replace("@","")
+                    if self.is_docker_exist(docker_name):
+                        cmds.append("sudo docker rm {}".format(docker_name))
+
             for cmd in cmds:
                 syslog.syslog(syslog.LOG_INFO, "Running cmd: '{}'".format(cmd))
                 try:


### PR DESCRIPTION
#### Description
On supervisor card, there is NO front-panel ports, bgp, team and lldp are not supported.  The services will be disabled, and the corresponding containers will be shown as in the "exited" state.  This will fail the sanity check of the OC testing.   This PR modifies the hostcfgd to remove the dockers/conainers when their service is stop and masked. 

This change applicable to 202205 branch

[x] 202205


### How to Verify 

1) Install an image on Supervisor card.
2) execute the "sudo config load_minigraph"
3) after the system is stabilized, execute the "docker ps -a" command to verify the dockers. 
```
admin@ixre-cpm-chassis15:~$ docker ps -a
CONTAINER ID   IMAGE                                COMMAND                  CREATED        STATUS        PORTS     NAMES
bd6081ba0a9d   docker-snmp:latest                   "/usr/local/bin/supe\u2026"   24 hours ago   Up 24 hours             snmp
4ef5bf0ec67c   docker-sonic-mgmt-framework:latest   "/usr/local/bin/supe\u2026"   24 hours ago   Up 24 hours             mgmt-framework
3281acdcc0d6   docker-sonic-telemetry:latest        "/usr/local/bin/supe\u2026"   24 hours ago   Up 24 hours             telemetry
17456a359cf1   docker-syncd-brcm-dnx:latest         "/usr/local/bin/supe\u2026"   24 hours ago   Up 24 hours             syncd7
11eaa455aa5b   docker-orchagent:latest              "/usr/bin/docker-ini\u2026"   24 hours ago   Up 24 hours             swss6
320782fbd312   docker-syncd-brcm-dnx:latest         "/usr/local/bin/supe\u2026"   24 hours ago   Up 24 hours             syncd6
304f8d8a7858   docker-orchagent:latest              "/usr/bin/docker-ini\u2026"   24 hours ago   Up 24 hours             swss7
e0f63ec678a9   docker-lldp:latest                   "/usr/bin/docker-lld\u2026"   24 hours ago   Up 24 hours             lldp
1e4c1f357a4f   docker-platform-monitor:latest       "/usr/bin/docker_ini\u2026"   24 hours ago   Up 24 hours             pmon
8ad50838fb4f   docker-router-advertiser:latest      "/usr/bin/docker-ini\u2026"   24 hours ago   Up 24 hours             radv
97270bd92d8b   docker-eventd:latest                 "/usr/local/bin/supe\u2026"   24 hours ago   Up 24 hours             eventd
63d59c773a86   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database7
675080150ec7   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database6
d14b070cbb3f   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database13
4386212def85   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database8
4eece88712e6   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database9
44c5b6c1c019   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database2
fb2e94887256   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database4
65cc7605bcb5   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database5
d1d1bbe2c10b   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database12
437e01f2cc44   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database10
12ba329d82a9   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database3
e86d289b01fa   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database15
bd901dbfde80   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database1
982bbc609e84   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database14
0dbc23726434   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database11
ffccf0f3f904   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database0
187c3f0441f6   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database
b5740f439099   docker-database:latest               "/usr/local/bin/dock\u2026"   24 hours ago   Up 24 hours             database-chassis
```


