### PR TITLE
[Supervisor][multiasic][hostcfgd] Optimize the hostcfgs by moving the definition cmds into the loop to optimize the enable/disable service command run.

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -325,7 +325,7 @@ class FeatureHandler(object):
             None.
         """
 
-        cmds = []
+
         feature_names, feature_suffixes = self.get_multiasic_feature_instances(feature_config, True)
         for feature_name in feature_names:
             if '@' not in feature_name:
@@ -334,6 +334,7 @@ class FeatureHandler(object):
             if not unit_file_state:
                 continue
             if unit_file_state != "disabled" and not feature_config.has_per_asic_scope:
+                cmds = []
                 for suffix in reversed(feature_suffixes):
                     cmds.append("sudo systemctl stop {}.{}".format(feature_name, suffix))
                     cmds.append("sudo systemctl disable {}.{}".format(feature_name, feature_suffixes[-1]))
@@ -421,14 +422,13 @@ class FeatureHandler(object):
         return props["UnitFileState"]
 
     def enable_feature(self, feature):
-        cmds = []
         feature_names, feature_suffixes = self.get_multiasic_feature_instances(feature)
         for feature_name in feature_names:
             # Check if it is already enabled, if yes skip the system call
             unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
             if unit_file_state == "enabled" or not unit_file_state:
                 continue
-
+            cmds = []    
             for suffix in feature_suffixes:
                 cmds.append("sudo systemctl unmask {}.{}".format(feature_name, suffix))
 
@@ -451,14 +451,13 @@ class FeatureHandler(object):
         self.set_feature_state(feature, self.FEATURE_STATE_ENABLED)
 
     def disable_feature(self, feature):
-        cmds = []
         feature_names, feature_suffixes = self.get_multiasic_feature_instances(feature)
         for feature_name in feature_names:
             # Check if it is already disabled, if yes skip the system call
             unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
             if unit_file_state in ("disabled", "masked") or not unit_file_state:
                 continue
-
+            cmds = []
             for suffix in reversed(feature_suffixes):
                 cmds.append("sudo systemctl stop {}.{}".format(feature_name, suffix))
                 cmds.append("sudo systemctl disable {}.{}".format(feature_name, feature_suffixes[-1]))


### PR DESCRIPTION
### Description
The cmds list is defined outsize of the for loop, which results that the "systemctl .." commands executed multiple times (based on number of ASICs).  This causes the system takes a longer time to be stabilized.

### How to verify it
Boot the image on Supervisor card, after the system is stabilized, the check the log file. For the same service command, it should not be executed more than once 
```
Dec  5 17:50:44.401100 ixre-cpm-chassis7 INFO hostcfgd: Running cmd: 'sudo systemctl stop bgp@0.service'
Dec  5 17:50:45.085547 ixre-cpm-chassis7 INFO hostcfgd: Running cmd: 'sudo systemctl disable bgp@0.service'
Dec  5 17:50:45.433360 ixre-cpm-chassis7 INFO hostcfgd: Running cmd: 'sudo systemctl mask bgp@0.service'
```
  