### PR TITLE
Replace /dev/stdin

### DIFF
--- a/host_modules/config_engine.py
+++ b/host_modules/config_engine.py
@@ -2,6 +2,7 @@
 
 from host_modules import host_service
 import subprocess
+import os
 
 MOD_NAME = 'config'
 DEFAULT_CONFIG = '/etc/sonic/config_db.json'
@@ -15,11 +16,16 @@ class Config(host_service.HostModule):
 
         cmd = ['/usr/local/bin/config', 'reload', '-y']
         if config_db_json and len(config_db_json.strip()):
-            cmd.append('/dev/stdin')
-            input_bytes = (config_db_json + '\n').encode('utf-8')
-            result = subprocess.run(cmd, input=input_bytes, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        else:
-            result = subprocess.run(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            config_file = '/tmp/config_db.json'
+            try:
+                if (os.path.exists(config_file)):
+                    os.remove(config_file)
+                with open(config_file, 'w') as fp:
+                    fp.write(config_db_json)
+            except Exception as err:
+                return -1, "Fail to create config file: %s"%str(err)
+            cmd.append(config_file)
+        result = subprocess.run(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         msg = ''
         if result.returncode:
             lines = result.stderr.decode().split('\n')

--- a/host_modules/gcu.py
+++ b/host_modules/gcu.py
@@ -11,10 +11,16 @@ class GCU(host_service.HostModule):
     """
     @host_service.method(host_service.bus_name(MOD_NAME), in_signature='s', out_signature='is')
     def apply_patch_db(self, patch_text):
-        input_bytes = (patch_text + '\n').encode('utf-8')
-        cmd = ['/usr/local/bin/config', 'apply-patch', '-f', 'CONFIGDB', '/dev/stdin']
+        patch_file_path = '/tmp/config_db.patch'
+        try:
+            with open(patch_file_path, 'w') as fp:
+                fp.write(patch_text)
+        except Exception as err:
+            return -1, "Fail to create patch file: %s"%str(err)
 
-        result = subprocess.run(cmd, input=input_bytes, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        cmd = ['/usr/local/bin/config', 'apply-patch', '-f', 'CONFIGDB', patch_file_path]
+
+        result = subprocess.run(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         msg = ''
         if result.returncode:
             lines = result.stderr.decode().split('\n')
@@ -26,10 +32,16 @@ class GCU(host_service.HostModule):
 
     @host_service.method(host_service.bus_name(MOD_NAME), in_signature='s', out_signature='is')
     def apply_patch_yang(self, patch_text):
-        input_bytes = (patch_text + '\n').encode('utf-8')
-        cmd = ['/usr/local/bin/config', 'apply-patch', '-f', 'SONICYANG', '/dev/stdin']
+        patch_file_path = '/tmp/config_yang.patch'
+        try:
+            with open(patch_file_path, 'w') as fp:
+                fp.write(patch_text)
+        except Exception as err:
+            return -1, "Fail to create patch file: %s"%str(err)
 
-        result = subprocess.run(cmd, input=input_bytes, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        cmd = ['/usr/local/bin/config', 'apply-patch', '-f', 'SONICYANG', patch_file_path]
+
+        result = subprocess.run(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         msg = ''
         if result.returncode:
             lines = result.stderr.decode().split('\n')

--- a/tests/host_modules/config_test.py
+++ b/tests/host_modules/config_test.py
@@ -40,6 +40,12 @@ class TestConfigEngine(object):
             assert config_file in call_args
             assert ret == test_ret, "Return value is wrong"
             assert msg == "Error: this is the test message", "Return message is wrong"
+        with mock.patch("builtins.open") as mock_open:
+            mock_open.side_effect = Exception('Boom!')
+            config_db_json = "{}"
+            config_stub = config_engine.Config(config_engine.MOD_NAME)
+            ret, msg = config_stub.reload(config_db_json)
+            assert ret != 0, "Should fail for exception"
 
     @mock.patch("dbus.SystemBus")
     @mock.patch("dbus.service.BusName")

--- a/tests/host_modules/config_test.py
+++ b/tests/host_modules/config_test.py
@@ -9,6 +9,7 @@ class TestConfigEngine(object):
     @mock.patch("dbus.service.BusName")
     @mock.patch("dbus.service.Object.__init__")
     def test_reload(self, MockInit, MockBusName, MockSystemBus):
+        config_file = "/tmp/config_db.json"
         with mock.patch("subprocess.run") as mock_run:
             res_mock = mock.Mock()
             test_ret = 0
@@ -21,7 +22,7 @@ class TestConfigEngine(object):
             ret, msg = config_stub.reload(config_db_json)
             call_args = mock_run.call_args[0][0]
             assert "reload" in call_args
-            assert "/dev/stdin" in call_args
+            assert config_file in call_args
             assert ret == test_ret, "Return value is wrong"
             assert msg == "", "Return message is wrong"
         with mock.patch("subprocess.run") as mock_run:
@@ -36,7 +37,7 @@ class TestConfigEngine(object):
             ret, msg = config_stub.reload(config_db_json)
             call_args = mock_run.call_args[0][0]
             assert "reload" in call_args
-            assert "/dev/stdin" in call_args
+            assert config_file in call_args
             assert ret == test_ret, "Return value is wrong"
             assert msg == "Error: this is the test message", "Return message is wrong"
 

--- a/tests/host_modules/gcu_test.py
+++ b/tests/host_modules/gcu_test.py
@@ -22,7 +22,7 @@ class TestGCU(object):
             call_args = mock_run.call_args[0][0]
             assert "apply-patch" in call_args
             assert "CONFIGDB" in call_args
-            assert '/dev/stdin' in call_args
+            assert '/tmp/config_db.patch' in call_args
             assert ret == test_ret, "Return value is wrong"
             assert msg == "", "Return message is wrong"
         with mock.patch("subprocess.run") as mock_run:
@@ -38,7 +38,7 @@ class TestGCU(object):
             call_args = mock_run.call_args[0][0]
             assert "apply-patch" in call_args
             assert "CONFIGDB" in call_args
-            assert '/dev/stdin' in call_args
+            assert '/tmp/config_db.patch' in call_args
             assert ret == test_ret, "Return value is wrong"
             assert msg == "Error: this is the test message", "Return message is wrong"
 
@@ -59,7 +59,7 @@ class TestGCU(object):
             call_args = mock_run.call_args[0][0]
             assert "apply-patch" in call_args
             assert "SONICYANG" in call_args
-            assert '/dev/stdin' in call_args
+            assert '/tmp/config_yang.patch' in call_args
             assert ret == test_ret, "Return value is wrong"
             assert msg == "", "Return message is wrong"
         with mock.patch("subprocess.run") as mock_run:
@@ -75,7 +75,7 @@ class TestGCU(object):
             call_args = mock_run.call_args[0][0]
             assert "apply-patch" in call_args
             assert "SONICYANG" in call_args
-            assert '/dev/stdin' in call_args
+            assert '/tmp/config_yang.patch' in call_args
             assert ret == test_ret, "Return value is wrong"
             assert msg == "Error: this is the test message", "Return message is wrong"
 

--- a/tests/host_modules/gcu_test.py
+++ b/tests/host_modules/gcu_test.py
@@ -41,6 +41,12 @@ class TestGCU(object):
             assert '/tmp/config_db.patch' in call_args
             assert ret == test_ret, "Return value is wrong"
             assert msg == "Error: this is the test message", "Return message is wrong"
+        with mock.patch("builtins.open") as mock_open:
+            mock_open.side_effect = Exception('Boom!')
+            patch_text = "{}"
+            gcu_stub = gcu.GCU(gcu.MOD_NAME)
+            ret, msg = gcu_stub.apply_patch_db(patch_text)
+            assert ret != 0, "Should fail for exception"
 
     @mock.patch("dbus.SystemBus")
     @mock.patch("dbus.service.BusName")
@@ -78,6 +84,12 @@ class TestGCU(object):
             assert '/tmp/config_yang.patch' in call_args
             assert ret == test_ret, "Return value is wrong"
             assert msg == "Error: this is the test message", "Return message is wrong"
+        with mock.patch("builtins.open") as mock_open:
+            mock_open.side_effect = Exception('Boom!')
+            patch_text = "{}"
+            gcu_stub = gcu.GCU(gcu.MOD_NAME)
+            ret, msg = gcu_stub.apply_patch_db(patch_text)
+            assert ret != 0, "Should fail for exception"
 
     @mock.patch("dbus.SystemBus")
     @mock.patch("dbus.service.BusName")


### PR DESCRIPTION
# Why I did it

When we use /dev/stdin as input file, CLI command can only read file for one time.
https://github.com/sonic-net/sonic-utilities/pull/2529
This PR will validate config file at first, and then CLI command will read config file for more than one time, so /dev/stdin does not work with latest code.

# How I did it

Use temp file to replace /dev/stdin

# How to verify it

Run unit test.