### PR TITLE
Pin deepdiff to version 6.2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'pytest',
         'pyfakefs',
         'sonic-py-common',
-        'deepdiff'
+        'deepdiff==6.2.2'
     ],
     classifiers = [
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
The deepdiff python package was recently updated to 6.2.3. As part of this, a dependency was introduced on orjson. There's no armv8l python wheel available for orjson, which means it needs to be built from source. However, building it requires rust (which Bullseye doesn't have a new enough version of) and maturin.

As a quick fix, pin this to version 6.2.2, before the orjson dependency is introduced.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>