### PR TITLE
[sonic-host-server] Simplify `register_dbus`

### DIFF
--- a/host_modules/config_engine.py
+++ b/host_modules/config_engine.py
@@ -46,7 +46,3 @@ class Config(host_service.HostModule):
                     break
         return result.returncode, msg
 
-def register():
-    """Return class and module name"""
-    return Config, MOD_NAME
-

--- a/host_modules/gcu.py
+++ b/host_modules/gcu.py
@@ -69,7 +69,3 @@ class GCU(host_service.HostModule):
                     break
         return result.returncode, msg
 
-def register():
-    """Return class and module name"""
-    return GCU, MOD_NAME
-

--- a/host_modules/host_service.py
+++ b/host_modules/host_service.py
@@ -30,5 +30,3 @@ class HostModule(dbus.service.Object):
         self.bus_name = dbus.service.BusName(bus_name(mod_name), self.bus)
         super(HostModule, self).__init__(self.bus_name, bus_path(mod_name))
 
-def register():
-    return HostService, "host_service"

--- a/host_modules/showtech.py
+++ b/host_modules/showtech.py
@@ -44,7 +44,3 @@ class Showtech(host_service.HostModule):
         output_filename = output_file_match.group()
         return result.returncode, output_filename
 
-def register():
-    """Return the class name"""
-    return Showtech, MOD_NAME
-

--- a/scripts/sonic-host-server
+++ b/scripts/sonic-host-server
@@ -12,33 +12,19 @@ import dbus.service
 import dbus.mainloop.glib
 
 from gi.repository import GObject
+from host_modules import config_engine, gcu, host_service, showtech
 
-def find_module_path():
-    """Find path for host_moduels"""
-    try:
-        from host_modules import host_service
-        return os.path.dirname(host_service.__file__)
-    except ImportError as e:
-        return None
 
-def register_modules(mod_path):
-    """Register all host modules"""
-    sys.path.append(mod_path)
-    for mod_file in glob.glob(os.path.join(mod_path, '*.py')):
-        if os.path.isfile(mod_file) and not mod_file.endswith('__init__.py'):
-            mod_name = os.path.basename(mod_file)[:-3]
-            module = importlib.import_module(mod_name)
-
-            register_cb = getattr(module, 'register', None)
-            if not register_cb:
-                raise Exception('Missing register function for ' + mod_name)
-
-            register_dbus(register_cb)
-
-def register_dbus(register_cb):
+def register_dbus():
     """Register DBus handlers for individual modules"""
-    handler_class, mod_name = register_cb()
-    handlers[mod_name] = handler_class(mod_name)
+    mod_dict = {
+            'config': config_engine.Config('config'),
+            'gcu': gcu.GCU('gcu'),
+            'host_service': host_service.HostService('host_service'),
+            'showtech': showtech.Showtech('showtech')
+            }
+    for mod_name, handler_class in mod_dict.items():
+        handlers[mod_name] = handler_class
 
 # Create a main loop reactor
 GObject.threads_init()
@@ -69,9 +55,7 @@ class SignalManager(object):
         loop.quit()
 
 sigmgr = SignalManager()
-mod_path = find_module_path()
-if mod_path is not None:
-    register_modules(mod_path)
+register_dbus()
 
 # Only run if we actually have some handlers
 if handlers:


### PR DESCRIPTION
The goal is to prevent use `importlib.import_module` function.
Verified by manual test.