### PR TITLE
Added IP Table rule to allow eth1-midplane traffic for chassis

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -296,17 +296,23 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
 
         return block_ip2me_cmds
 
-    def check_chassis_midplane_interface_exist(self):
-        ip_link_cmd0 = ['ip', 'link', 'show']
-        ip_link_cmd1 = ['grep', '-w', "eth1-midplane"]
-
-        return self.run_commands_pipe(ip_link_cmd0, ip_link_cmd1)
+    def get_chassis_midplane_interface_ip(self):
+        ip_address_cmd0 = ['ip', '-4', '-o', 'addr', 'show', "eth1-midplane"]
+        ip_address_cmd1 = ['awk', '{print $4}']
+        ip_address_cmd2 = ['cut', '-d', '/', '-f1']
+        ip_address_cmd3 = ['head', '-1']
+        return self.run_commands_pipe(ip_address_cmd0, ip_address_cmd1, ip_address_cmd2, ip_address_cmd3)
 
     def generate_allow_internal_chasis_midplane_traffic(self, namespace):
-        if not namespace and self.check_chassis_midplane_interface_exist():
-            return [['iptables', '-A', 'INPUT', '-i', 'eth1-midplane', '-j', 'ACCEPT']]
-        else:
-            return []
+        allow_internal_chassis_midplane_traffic = []
+        if not namespace:
+            chassis_midplane_ip = self.get_chassis_midplane_interface_ip()
+            if not chassis_midplane_ip:
+                return allow_internal_chassis_midplane_traffic
+            allow_internal_chassis_midplane_traffic.append(['iptables', '-A', 'INPUT', '-s', chassis_midplane_ip, '-d', chassis_midplane_ip, '-j', 'ACCEPT'])
+            allow_internal_chassis_midplane_traffic.append(['iptables', '-A', 'INPUT', '-i', 'eth1-midplane', '-j', 'ACCEPT'])
+
+        return allow_internal_chassis_midplane_traffic
 
     def generate_allow_internal_docker_ip_traffic_commands(self, namespace):
         allow_internal_docker_ip_cmds = []

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -296,6 +296,9 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
 
         return block_ip2me_cmds
 
+    def check_chassis_midplane_interface_exist(self):
+        return self.run_commands(["ip link show" + " | grep -w 'eth1-midplane'" ])
+
     def generate_allow_internal_docker_ip_traffic_commands(self, namespace):
         allow_internal_docker_ip_cmds = []
 
@@ -535,6 +538,11 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
 
         # Add iptables commands to allow internal docker traffic
         iptables_cmds += self.generate_allow_internal_docker_ip_traffic_commands(namespace)
+
+        # Add iptable rules to allow traffic coming on eth1-midplane for chassis.
+        # Internal traffic is all IPv4.
+        if not namespace and self.check_chassis_midplane_interface_exist():
+            iptables_cmds.append("iptables -A INPUT -i eth1-midplane -j ACCEPT")
 
         # Add iptables/ip6tables commands to allow all incoming packets from established
         # connections or new connections which are related to established connections

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -297,7 +297,16 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         return block_ip2me_cmds
 
     def check_chassis_midplane_interface_exist(self):
-        return self.run_commands(["ip link show" + " | grep -w 'eth1-midplane'" ])
+        ip_link_cmd0 = ['ip', 'link', 'show']
+        ip_link_cmd1 = ['grep', '-w', "eth1-midplane"]
+
+        return self.run_commands_pipe(ip_link_cmd0, ip_link_cmd1)
+
+    def generate_allow_internal_chasis_midplane_traffic(self, namespace):
+        if not namespace and self.check_chassis_midplane_interface_exist():
+            return [['iptables', '-A', 'INPUT', '-i', 'eth1-midplane', '-j', 'ACCEPT']]
+        else:
+            return []
 
     def generate_allow_internal_docker_ip_traffic_commands(self, namespace):
         allow_internal_docker_ip_cmds = []
@@ -539,10 +548,8 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         # Add iptables commands to allow internal docker traffic
         iptables_cmds += self.generate_allow_internal_docker_ip_traffic_commands(namespace)
 
-        # Add iptable rules to allow traffic coming on eth1-midplane for chassis.
-        # Internal traffic is all IPv4.
-        if not namespace and self.check_chassis_midplane_interface_exist():
-            iptables_cmds.append("iptables -A INPUT -i eth1-midplane -j ACCEPT")
+        # Add iptables commands to allow internal chasiss midplane traffic
+        iptables_cmds += self.generate_allow_internal_chasis_midplane_traffic(namespace)
 
         # Add iptables/ip6tables commands to allow all incoming packets from established
         # connections or new connections which are related to established connections

--- a/tests/caclmgrd/caclmgrd_chassis_midplane_test.py
+++ b/tests/caclmgrd/caclmgrd_chassis_midplane_test.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+from swsscommon import swsscommon
+from parameterized import parameterized
+from sonic_py_common.general import load_module_from_source
+from unittest import TestCase, mock
+from pyfakefs.fake_filesystem_unittest import patchfs
+
+from .test_chassis_midplane_vectors import CACLMGRD_CHASSIS_MIDPLANE_TEST_VECTOR
+from tests.common.mock_configdb import MockConfigDb
+
+
+DBCONFIG_PATH = '/var/run/redis/sonic-db/database_config.json'
+
+
+class TestCaclmgrdChassisMidplane(TestCase):
+    """
+        Test caclmgrd Chassis Midplane
+    """
+    def setUp(self):
+        swsscommon.ConfigDBConnector = MockConfigDb
+        test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        modules_path = os.path.dirname(test_path)
+        scripts_path = os.path.join(modules_path, "scripts")
+        sys.path.insert(0, modules_path)
+        caclmgrd_path = os.path.join(scripts_path, 'caclmgrd')
+        self.caclmgrd = load_module_from_source('caclmgrd', caclmgrd_path)
+        self.maxDiff = None
+
+    @parameterized.expand(CACLMGRD_CHASSIS_MIDPLANE_TEST_VECTOR)
+    @patchfs
+    def test_caclmgrd_chassis_midplane(self, test_name, test_data, fs):
+        if not os.path.exists(DBCONFIG_PATH):
+            fs.create_file(DBCONFIG_PATH) # fake database_config.json
+
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ip = mock.MagicMock()
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ipv6 = mock.MagicMock()
+        self.caclmgrd.ControlPlaneAclManager.check_chassis_midplane_interface_exist = mock.MagicMock(return_value=True)
+        caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
+        ret = caclmgrd_daemon.generate_allow_internal_chasis_midplane_traffic('')
+        self.assertListEqual(test_data["return"], ret)

--- a/tests/caclmgrd/caclmgrd_chassis_midplane_test.py
+++ b/tests/caclmgrd/caclmgrd_chassis_midplane_test.py
@@ -34,9 +34,9 @@ class TestCaclmgrdChassisMidplane(TestCase):
         if not os.path.exists(DBCONFIG_PATH):
             fs.create_file(DBCONFIG_PATH) # fake database_config.json
 
-        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ip = mock.MagicMock()
-        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ipv6 = mock.MagicMock()
-        self.caclmgrd.ControlPlaneAclManager.check_chassis_midplane_interface_exist = mock.MagicMock(return_value=True)
-        caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
-        ret = caclmgrd_daemon.generate_allow_internal_chasis_midplane_traffic('')
-        self.assertListEqual(test_data["return"], ret)
+        with mock.patch("caclmgrd.ControlPlaneAclManager.run_commands_pipe", return_value='1.0.0.33'):
+            caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
+            ret = caclmgrd_daemon.generate_allow_internal_chasis_midplane_traffic('')
+            self.assertListEqual(test_data["return"], ret)
+            ret = caclmgrd_daemon.generate_allow_internal_chasis_midplane_traffic('asic0')
+            self.assertListEqual([], ret)

--- a/tests/caclmgrd/caclmgrd_external_client_acl_test.py
+++ b/tests/caclmgrd/caclmgrd_external_client_acl_test.py
@@ -38,6 +38,7 @@ class TestCaclmgrdExternalClientAcl(TestCase):
         self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ipv6 = mock.MagicMock()
         self.caclmgrd.ControlPlaneAclManager.generate_block_ip2me_traffic_iptables_commands = mock.MagicMock(return_value=[])
         self.caclmgrd.ControlPlaneAclManager.get_chain_list = mock.MagicMock(return_value=["INPUT", "FORWARD", "OUTPUT"])
+        self.caclmgrd.ControlPlaneAclManager.check_chassis_midplane_interface_exist = mock.MagicMock(return_value=False)
         caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
 
         iptables_rules_ret, _ = caclmgrd_daemon.get_acl_rules_and_translate_to_iptables_commands('')

--- a/tests/caclmgrd/caclmgrd_external_client_acl_test.py
+++ b/tests/caclmgrd/caclmgrd_external_client_acl_test.py
@@ -38,7 +38,7 @@ class TestCaclmgrdExternalClientAcl(TestCase):
         self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ipv6 = mock.MagicMock()
         self.caclmgrd.ControlPlaneAclManager.generate_block_ip2me_traffic_iptables_commands = mock.MagicMock(return_value=[])
         self.caclmgrd.ControlPlaneAclManager.get_chain_list = mock.MagicMock(return_value=["INPUT", "FORWARD", "OUTPUT"])
-        self.caclmgrd.ControlPlaneAclManager.check_chassis_midplane_interface_exist = mock.MagicMock(return_value=False)
+        self.caclmgrd.ControlPlaneAclManager.get_chassis_midplane_interface_ip = mock.MagicMock(return_value='')
         caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
 
         iptables_rules_ret, _ = caclmgrd_daemon.get_acl_rules_and_translate_to_iptables_commands('')

--- a/tests/caclmgrd/test_chassis_midplane_vectors.py
+++ b/tests/caclmgrd/test_chassis_midplane_vectors.py
@@ -1,0 +1,15 @@
+from unittest.mock import call
+
+"""
+    caclmgrd chassis midplane test vector
+"""
+CACLMGRD_CHASSIS_MIDPLANE_TEST_VECTOR = [
+    [
+        "Allow chassis midlane traffic",
+        {
+            "return": [
+                ['iptables', '-A', 'INPUT', '-i', 'eth1-midplane', '-j', 'ACCEPT']
+            ]
+        }
+    ]
+]

--- a/tests/caclmgrd/test_chassis_midplane_vectors.py
+++ b/tests/caclmgrd/test_chassis_midplane_vectors.py
@@ -8,6 +8,7 @@ CACLMGRD_CHASSIS_MIDPLANE_TEST_VECTOR = [
         "Allow chassis midlane traffic",
         {
             "return": [
+                ['iptables', '-A', 'INPUT', '-s', '1.0.0.33', '-d', '1.0.0.33', '-j', 'ACCEPT'],
                 ['iptables', '-A', 'INPUT', '-i', 'eth1-midplane', '-j', 'ACCEPT']
             ]
         }


### PR DESCRIPTION
What I did:
Added IP Table rule to make sure we do not drop chassis internal traffic on eth1-midpplane when Control Plane ACL's are installed.

Why I did:
When Control Plane ACL's are installed there is  default Catch All rule is added to drop all traffic that is not white-listed explicitly https://github.com/sonic-net/sonic-host-services/blob/master/scripts/caclmgrd#L735. In this case Internal Traffic between Supervisor and LC will get drop. To fix this added explicit rule to allow all traffic coming from `eth1-midplane`.

Also added rule to allow traffic with source and destination as eth1-midplane ip which is used in redis communication on chassis supervisor.

How I verify:
Manually Verified rule is getting installed
sonic-mgmt case will be updated to account for this new iptable rule.