### PR TITLE
Check SONiC dependencies before installation.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,23 @@
+from __future__ import print_function
+import sys
 from setuptools import setup
+import pkg_resources
+from packaging import version
+
+# sonic_dependencies, version requirement only supports '>='
+sonic_dependencies = ['sonic-py-common']
+for package in sonic_dependencies:
+    try:
+        package_dist = pkg_resources.get_distribution(package.split(">=")[0])
+    except pkg_resources.DistributionNotFound:
+        print(package + " is not found!", file=sys.stderr)
+        print("Please build and install SONiC python wheels dependencies from sonic-buildimage", file=sys.stderr)
+        exit(1)
+    if ">=" in package:
+        if version.parse(package_dist.version) >= version.parse(package.split(">=")[1]):
+            continue
+        print(package + " version not match!", file=sys.stderr)
+        exit(1)
 
 setup(
     name = 'sonic-host-services',
@@ -27,8 +46,7 @@ setup(
         'systemd-python',
         'Jinja2>=2.10',
         'PyGObject',
-        'sonic-py-common'
-    ],
+    ] + sonic_dependencies,
     setup_requires = [
         'pytest-runner',
         'wheel'


### PR DESCRIPTION
Why I did it
SONiC related packages shouldn't be intalled from Pypi.
It is security compliance requirement.

How I did it
Check SONiC related packages when using setup.py.