### PR TITLE
[reboot-cause] Fix a broken symlink of previous-reboot-cause file removal issue

### DIFF
--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -223,7 +223,7 @@ def main():
         os.makedirs(REBOOT_CAUSE_DIR)
 
     # Remove stale PREVIOUS_REBOOT_CAUSE_FILE if it exists
-    if os.path.exists(PREVIOUS_REBOOT_CAUSE_FILE):
+    if os.path.exists(PREVIOUS_REBOOT_CAUSE_FILE) or os.path.islink(PREVIOUS_REBOOT_CAUSE_FILE):
         os.remove(PREVIOUS_REBOOT_CAUSE_FILE)
 
     previous_reboot_cause, additional_reboot_info = determine_reboot_cause()

--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -222,10 +222,6 @@ def main():
     if not os.path.exists(REBOOT_CAUSE_DIR):
         os.makedirs(REBOOT_CAUSE_DIR)
 
-    # Remove stale PREVIOUS_REBOOT_CAUSE_FILE if it exists
-    if os.path.exists(PREVIOUS_REBOOT_CAUSE_FILE) or os.path.islink(PREVIOUS_REBOOT_CAUSE_FILE):
-        os.remove(PREVIOUS_REBOOT_CAUSE_FILE)
-
     previous_reboot_cause, additional_reboot_info = determine_reboot_cause()
 
     # Current time
@@ -244,6 +240,10 @@ def main():
     # Write the previous reboot cause to REBOOT_CAUSE_HISTORY_FILE as a JSON format
     with open(REBOOT_CAUSE_HISTORY_FILE, "w") as reboot_cause_history_file:
         json.dump(reboot_cause_dict, reboot_cause_history_file)
+ 
+    # Remove stale PREVIOUS_REBOOT_CAUSE_FILE if it exists
+    if os.path.exists(PREVIOUS_REBOOT_CAUSE_FILE) or os.path.islink(PREVIOUS_REBOOT_CAUSE_FILE):
+        os.remove(PREVIOUS_REBOOT_CAUSE_FILE)
 
     # Create a symbolic link to previous-reboot-cause.json file
     os.symlink(REBOOT_CAUSE_HISTORY_FILE, PREVIOUS_REBOOT_CAUSE_FILE)

--- a/tests/determine-reboot-cause_test.py
+++ b/tests/determine-reboot-cause_test.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import shutil
 import pytest
 
 from swsscommon import swsscommon
@@ -69,6 +70,7 @@ EXPECTED_WATCHDOG_REBOOT_CAUSE_DICT = {'comment': '', 'gen_time': '2020_10_22_03
 EXPECTED_USER_REBOOT_CAUSE_DICT = {'comment': '', 'gen_time': '2020_10_22_03_14_07', 'cause': 'reboot', 'user': 'admin', 'time': 'Thu Oct 22 03:11:08 UTC 2020'}
 EXPECTED_KERNEL_PANIC_REBOOT_CAUSE_DICT = {'comment': '', 'gen_time': '2021_3_28_13_48_49', 'cause': 'Kernel Panic', 'user': 'N/A', 'time': 'Sun Mar 28 13:45:12 UTC 2021'}
 
+REBOOT_CAUSE_DIR="host/reboot-cause/"
 
 class TestDetermineRebootCause(object):
     def test_parse_warmfast_reboot_from_proc_cmdline(self):
@@ -176,12 +178,24 @@ class TestDetermineRebootCause(object):
                     assert previous_reboot_cause == EXPECTED_HARDWARE_REBOOT_CAUSE
                     assert additional_info == EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER
 
-    @mock.patch('determine_reboot_cause.REBOOT_CAUSE_DIR', os.path.join(os.getcwd(), 'host/reboot-cause/'))
+    @mock.patch('determine_reboot_cause.REBOOT_CAUSE_DIR', os.path.join(os.getcwd(), REBOOT_CAUSE_DIR))
     @mock.patch('determine_reboot_cause.REBOOT_CAUSE_HISTORY_DIR', os.path.join(os.getcwd(), 'host/reboot-cause/history/'))
     @mock.patch('determine_reboot_cause.PREVIOUS_REBOOT_CAUSE_FILE', os.path.join(os.getcwd(), 'host/reboot-cause/previous-reboot-cause.json'))
     @mock.patch('determine_reboot_cause.REBOOT_CAUSE_FILE', os.path.join(os.getcwd(),'host/reboot-cause/reboot-cause.txt'))
-    def test_determine_reboot_cause_main(self):
+    def test_determine_reboot_cause_main_without_reboot_cause_dir(self):
+        if os.path.exists(REBOOT_CAUSE_DIR):
+            shutil.rmtree(REBOOT_CAUSE_DIR)
         with mock.patch("os.geteuid", return_value=0):
             determine_reboot_cause.main()
             assert os.path.exists("host/reboot-cause/reboot-cause.txt") == True
             assert os.path.exists("host/reboot-cause/previous-reboot-cause.json") == True
+
+    @mock.patch('determine_reboot_cause.REBOOT_CAUSE_DIR', os.path.join(os.getcwd(), REBOOT_CAUSE_DIR))
+    @mock.patch('determine_reboot_cause.REBOOT_CAUSE_HISTORY_DIR', os.path.join(os.getcwd(), 'host/reboot-cause/history/'))
+    @mock.patch('determine_reboot_cause.PREVIOUS_REBOOT_CAUSE_FILE', os.path.join(os.getcwd(), 'host/reboot-cause/previous-reboot-cause.json'))
+    @mock.patch('determine_reboot_cause.REBOOT_CAUSE_FILE', os.path.join(os.getcwd(),'host/reboot-cause/reboot-cause.txt'))
+    def test_determine_reboot_cause_main_with_reboot_cause_dir(self):
+        with mock.patch("os.geteuid", return_value=0):
+            determine_reboot_cause.main()
+            assert os.path.exists("host/reboot-cause/reboot-cause.txt") == True
+            assert os.path.exists("host/reboot-cause/previous-reboot-cause.json") == True   

--- a/tests/determine-reboot-cause_test.py
+++ b/tests/determine-reboot-cause_test.py
@@ -176,3 +176,12 @@ class TestDetermineRebootCause(object):
                     assert previous_reboot_cause == EXPECTED_HARDWARE_REBOOT_CAUSE
                     assert additional_info == EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER
 
+    @mock.patch('determine_reboot_cause.REBOOT_CAUSE_DIR', os.path.join(os.getcwd(), 'host/reboot-cause/'))
+    @mock.patch('determine_reboot_cause.REBOOT_CAUSE_HISTORY_DIR', os.path.join(os.getcwd(), 'host/reboot-cause/history/'))
+    @mock.patch('determine_reboot_cause.PREVIOUS_REBOOT_CAUSE_FILE', os.path.join(os.getcwd(), 'host/reboot-cause/previous-reboot-cause.json'))
+    @mock.patch('determine_reboot_cause.REBOOT_CAUSE_FILE', os.path.join(os.getcwd(),'host/reboot-cause/reboot-cause.txt'))
+    def test_determine_reboot_cause_main(self):
+        with mock.patch("os.geteuid", return_value=0):
+            determine_reboot_cause.main()
+            assert os.path.exists("host/reboot-cause/reboot-cause.txt") == True
+            assert os.path.exists("host/reboot-cause/previous-reboot-cause.json") == True


### PR DESCRIPTION
### Why I did it
"show reboot-cause history" shows  empty history.  When the previous-reboot-cause has a broken symlink,  And rebooting the system will not be able to generate a new symlink of the new previous-reboot-cause. 
```
admin@sonic:~$ show reboot-cause history 
Name    Cause    Time    User    Comment
------  -------  ------  ------  ---------
```
#### How I did it
Somehow, when the  symlink file /host/reboot-cause/previous-reboot-cause is broken (which its destination files doesn't exist in this case),  the current condition check "if os.path,exists(PREVIOUS_REBOOT_CAUSE_FILE)" will return False in determine-reboot-cause script.  Hence, the current previous-reboot-cause is not been removed and the recreation of the new previous-reboot-cause failed.  In case of previous-reboot-cause is a broken synlink file, add condition os.path.islink(PREVIOUS_REBOOT_CAUSE) to check and allow the remove operation happens.

#### How to verify it
1) Manually make the /host/reboot-cause/previous-reboot-cause to be a broken symlink file by removing its destination file
2) reboot the system.  "show reboot-cause history" should show the correct info
```
admin@ixre-egl-board25:~$ show reboot-cause history 
Name                 Cause                                    Time                             User     Comment
-------------------  ---------------------------------------  -------------------------------  -------  ----------
2023_03_01_17_41_31  reboot                                   Wed 01 Mar 2023 05:39:27 PM UTC  admin    N/A
2023_03_01_17_14_47  reboot                                   Wed 01 Mar 2023 05:12:05 PM UTC  admin    N/A
2023_03_01_17_14_18  reboot                                   Wed 01 Mar 2023 05:12:05 PM UTC  admin    N/A
2023_03_01_16_20_52  reboot                                   Wed 01 Mar 2023 04:18:22 PM UTC  admin    N/A
2023_03_01_16_20_27  reboot                                   Wed 01 Mar 2023 04:18:22 PM UTC  admin    N/A
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

