### PR TITLE
It shouldn't skip mask service when the unit file state is disabled.

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -466,7 +466,7 @@ class FeatureHandler(object):
         for feature_name in feature_names:
             # Check if it is already disabled, if yes skip the system call
             unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
-            if unit_file_state in ("disabled", "masked") or not unit_file_state:
+            if unit_file_state == "masked" or not unit_file_state:
                 continue
             cmds = []
             for suffix in reversed(feature_suffixes):


### PR DESCRIPTION
If the unit file state is disabled, it still can be run.

```
root@as5835-54x-32u:/# systemctl show dhcp_relay.service --property UnitFileState
UnitFileState=masked
root@as5835-54x-32u:/# systemctl unmask dhcp_relay.service
Removed /etc/systemd/system/dhcp_relay.service.
root@as5835-54x-32u:/#
root@as5835-54x-32u:/# systemctl show dhcp_relay.service --property UnitFileState
UnitFileState=disabled
root@as5835-54x-32u:/# systemctl start dhcp_relay.service
root@as5835-54x-32u:/# systemctl status dhcp_relay.service
● dhcp_relay.service - dhcp_relay container
     Loaded: loaded (/lib/systemd/system/dhcp_relay.service; disabled; vendor preset: enabled)
    Drop-In: /etc/systemd/system/dhcp_relay.service.d
             mqauto_restart.conf
     Active: active (running) since Thu 2023-03-02 02:46:19 UTC; 6s ago
    Process: 26430 ExecStartPre=/usr/local/bin/dhcp_relay.sh start (code=exited)
   Main PID: 26513 (dhcp_relay.sh)
      Tasks: 3 (limit: 19130)
     Memory: 18.9M
     CGroup: /system.slice/dhcp_relay.service
             tq26513 /bin/bash /usr/local/bin/dhcp_relay.sh wait
             tq26524 /bin/bash /usr/bin/dhcp_relay.sh wait
             mq26525 /usr/bin/python3 /usr/local/bin/container wait dhcp_relay
```
Reproduce Step:
1. load sonic-broadcom.bin (The defualt setting is to disable the dhcp_relay)
2. systemctl unmask dhcp_relay.service
3. config reload (The config should disable dhcp_relay)
4. The dhcp_relay.service would be running.
```
Feb 25 16:09:04.617093 as7726-32x-3 INFO hostcfgd: Updating feature 'dhcp_relay' systemd config file related to auto-restart ...
Feb 25 16:09:04.617173 as7726-32x-3 INFO hostcfgd: Feautre 'dhcp_relay' systemd config file related to auto-restart is updated!
Feb 25 16:09:04.617240 as7726-32x-3 INFO hostcfgd: Reloading systemd configuration files ...
Feb 25 16:09:04.994542 as7726-32x-3 INFO hostcfgd: Systemd configuration files are reloaded!
Feb 25 16:09:05.032365 as7726-32x-3 INFO hostcfgd: Feature dhcp_relay is stopped and disabled
Feb 25 16:09:05.058786 as7726-32x-3 INFO systemd[1]: Reloading.
Feb 25 16:09:05.337951 as7726-32x-3 INFO hostcfgd: Systemd configuration files are reloaded!
Feb 25 16:09:07.446986 as7726-32x-3 INFO swss.sh[504204]: Starting existing swss container with HWSKU Accton-AS7726-32X
Feb 25 16:09:11.320827 as7726-32x-3 NOTICE root: Starting dhcp_relay service...
Feb 25 16:09:11.651858 as7726-32x-3 INFO dhcp_relay.sh[505396]: Starting existing dhcp_relay container with HWSKU Accton-AS7726-32X
```