### PR TITLE
skip generating auto_restart.conf for syncd

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -383,6 +383,10 @@ class FeatureHandler(object):
         # On multi-ASIC device, creates systemd configuration file for each feature instance
         # residing in difference namespace.
         for feature_name in feature_names:
+            # As to syncd service, swss will monitor its stop and restart it, don't need systemd to auto-restart it.
+            if "syncd" in feature_name:
+                continue
+
             syslog.syslog(syslog.LOG_INFO, "Updating feature '{}' systemd config file related to auto-restart ..."
                           .format(feature_name))
             feature_systemd_config_dir_path = self.SYSTEMD_SERVICE_CONF_DIR.format(feature_name)


### PR DESCRIPTION
[Issue Desc]
When kill critical process inside syncd container, it will trigger restart of syncd/swss and other containers.
During the process, we see the following ERR messages in syslog:
 
Mar 21 02:36:12.410980 dut-400g ERR syncd#syncd: :- listFailedAttributes: SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE = false
Mar 21 02:36:12.410980 dut-400g ERR syncd#syncd: :- listFailedAttributes: SAI_LAG_MEMBER_ATTR_INGRESS_DISABLE = false
Mar 21 02:36:12.410980 dut-400g ERR syncd#syncd: :- listFailedAttributes: SAI_LAG_MEMBER_ATTR_LAG_ID = oid:0x200000000000007
Mar 21 02:36:12.410980 dut-400g ERR syncd#syncd: :- listFailedAttributes: SAI_LAG_MEMBER_ATTR_PORT_ID = oid:0x10000000000000f
Mar 21 02:36:12.410980 dut-400g ERR syncd#syncd: :- processSingleVid: failed to create object SAI_OBJECT_TYPE_LAG_MEMBER: SAI_STATUS_OBJECT_IN_USE
 
In fact, besides the above ERR messages, there are some other ERR messages related to syncd.
 
[Rootcause Analysis]
After killing one critical process, for example “syncd” inside syncd container, the supervisor monitor “supervisor-proc-exit-listener” gets the event.
The monitor then tries to send SIGTERM to its parent to stop all other processes inside syncd container.  
When syncd is stopped,  these tun interfaces “EthernetXX” inside host become Down and are removed.  We can see many following logs during this period:
 
Mar 21 04:48:32.976780 dut-400g NOTICE swss#portsyncd: :- onMsg: nlmsg type:16 key:Ethernet232 admin:0 oper:0 addr:a4:78:06:a1:5a:00 ifindex:183 master:0 type:tun
Mar 21 04:48:32.981504 dut-400g NOTICE swss#portsyncd: :- onMsg: Publish Ethernet232(ok:down) to state db
Mar 21 04:48:32.981504 dut-400g NOTICE swss#portsyncd: :- onMsg: nlmsg type:17 key:Ethernet232 admin:0 oper:0 addr:a4:78:06:a1:5a:00 ifindex:183 master:0 type:tun
Mar 21 04:48:32.981661 dut-400g NOTICE swss#portsyncd: :- onMsg: Delete Ethernet232(ok) from state db
Mar 21 04:48:33.032850 dut-400g NOTICE swss#portsyncd: :- onMsg: nlmsg type:16 key:Ethernet216 admin:0 oper:0 addr:a4:78:06:a1:5a:00 ifindex:182 master:0 type:tun
Mar 21 04:48:33.035246 dut-400g NOTICE swss#portsyncd: :- onMsg: Publish Ethernet216(ok:down) to state db
Mar 21 04:48:33.035347 dut-400g NOTICE swss#portsyncd: :- onMsg: nlmsg type:17 key:Ethernet216 admin:0 oper:0 addr:a4:78:06:a1:5a:00 ifindex:182 master:0 type:tun
Mar 21 04:48:33.035572 dut-400g NOTICE swss#portsyncd: :- onMsg: Delete Ethernet216(ok) from state db
 
Once the syncd container is stopped, the systemd tries to run its syncd stop script according to the “ExecStop” setting to do some postStop handling.
Later, the swss service tries stop itself by “docker-wait-any” since its peer syncd exited.  
At the same time, the syncd tries to auto-restart by systemd since its auto-restart is TRUE. Yet it need lock “/tmp/swss-syncd-lock” before initializing.
 
After swss stops all process inside its container, it unlocks the “/tmp/swss-syncd-lock” and tries to stop its dependent and peer services in turn.  
The syncd got the lock and begin to initializing. During this process of syncd initializing, we hit some syncd ERR msgs reported by this Jira.
 
After a while, the swss script tries to stop its peer service : syncd service. 
After stopped all its dependent and peer services, the swss is auto-restarted by systemd. 
After swss container is started, it then tries to start its dependent and peer service, include syncd service. Then the system recovers to normal.
 
 
According to the above analysis of the whole process, these syncd ERR messages happen during the period of the first syncd auto-restart.
As to this restart, the DB is not flushed, especially ASIC_DB.  Since the stop of syncd triggers tun interfaces Down and remove, which could affect the state DB and ASIC DB.
Then, this incorrect ASIC DB could affect the initializing of syncd.  
 
[Solution]
The syncd should avoid using this intermediate incorrect DB.
There are two possible solutions for this issue:
1.	when stop swss, flush ASIC_DB for non-warm stop.
2.	Don't auto-restart syncd by itself,  let its peer swss watch and start it. ( same as 202012)
As to option 1, we can flush ASIC_DB when executing STOP for swss service if it’s not a WARM case. After flushing the ASIC_DB, the syncd could initialize from a clean DB.
As to option 2, it’s same as 202012 branch,  we should remove the auto-restart config for syncd service, i.e, the following file:
                    /etc/systemd/system/syncd.service.d/auto_restart.conf
 
This auto_restart config file is generated by “src/sonic-host-services/scripts/hostcfgd”, imported by 
[[hostcfgd] Initialize `Restart=` in feature's systemd config by the v… · sonic-net/sonic-buildimage@8a76cdc (github.com)](https://github.com/sonic-net/sonic-buildimage/commit/8a76cdc66e046a93150e20942c5f7bfe030b5432)
 
The 202012 branch doesn’t have this merge.
We can simply skip “syncd” in “hostcfgd” when generating “auto_restart.conf”.
 
Since the status of syncd service is monitored by swss service, we can always let swss service take charge of the restart of syncd service.
 

We choose solution 2 here.
 
 
[Similar issue]
Marvell reported a similar issue, which should have the same rootcause:
[syslog errors observed during syncd init process · Issue #1248 · sonic-net/SONiC (github.com)](https://github.com/sonic-net/SONiC/issues/1248)
 
Our fix solution could resolve this kinda issue together.