### PR TITLE
Fix caclmgrd crash issue when applying scale cacl rules

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -356,7 +356,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
             loopback_address = get_ip_from_interface_table(loopback_table, loopback_name)
             vlan_name = 'Vlan'
             vlan_table = config_db_connector.get_table(self.VLAN_INTF_TABLE)
-            
+
             vlan_address = get_ip_from_interface_table(vlan_table, vlan_name)
             fwd_dualtor_grpc_traffic_from_host_to_soc_cmds.append(self.iptables_cmd_ns_prefix[namespace] + 
                     ['iptables', '-t', 'nat', '--flush', 'POSTROUTING'])

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -265,7 +265,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
             for k, v in feature_tb_info.items():
                 self.feature_present[k] = True
 
-    def generate_block_ip2me_traffic_iptables_commands(self, namespace, new_config_db_connector=None):
+    def generate_block_ip2me_traffic_iptables_commands(self, namespace, config_db_connector):
         INTERFACE_TABLE_NAME_LIST = [
             "LOOPBACK_INTERFACE",
             "VLAN_INTERFACE",
@@ -277,10 +277,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
 
         # Add iptables rules to drop all packets destined for peer-to-peer interface IP addresses
         for iface_table_name in INTERFACE_TABLE_NAME_LIST:
-            if new_config_db_connector:
-                iface_table = new_config_db_connector.get_table(iface_table_name)
-            else:
-                iface_table = self.config_db_map[namespace].get_table(iface_table_name)
+            iface_table = config_db_connector.get_table(iface_table_name)
             if iface_table:
                 for key, _ in iface_table.items():
                     if not _ip_prefix_in_key(key):
@@ -350,30 +347,22 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         return allow_internal_docker_ip_cmds
 
 
-    def generate_fwd_traffic_from_host_to_soc(self, namespace, new_config_db_connector=None):
+    def generate_fwd_traffic_from_host_to_soc(self, namespace, config_db_connector):
 
         fwd_dualtor_grpc_traffic_from_host_to_soc_cmds = []
         if self.DualToR:
-            if new_config_db_connector:
-                loopback_table = new_config_db_connector.get_table(self.LOOPBACK_TABLE)
-            else:
-                loopback_table = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.LOOPBACK_TABLE)
+            loopback_table = config_db_connector.get_table(self.LOOPBACK_TABLE)
             loopback_name = 'Loopback3'
             loopback_address = get_ip_from_interface_table(loopback_table, loopback_name)
             vlan_name = 'Vlan'
-            if new_config_db_connector:
-                vlan_table = new_config_db_connector.get_table(self.VLAN_INTF_TABLE)
-            else:
-                vlan_table = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.VLAN_INTF_TABLE)
+            vlan_table = config_db_connector.get_table(self.VLAN_INTF_TABLE)
+            
             vlan_address = get_ip_from_interface_table(vlan_table, vlan_name)
             fwd_dualtor_grpc_traffic_from_host_to_soc_cmds.append(self.iptables_cmd_ns_prefix[namespace] + 
                     ['iptables', '-t', 'nat', '--flush', 'POSTROUTING'])
             
             if loopback_address is not None:
-                if new_config_db_connector:
-                    mux_table = new_config_db_connector.get_table(self.CONFIG_MUX_CABLE)
-                else:
-                    mux_table = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.CONFIG_MUX_CABLE)
+                mux_table = config_db_connector.get_table(self.CONFIG_MUX_CABLE)
                 mux_table_keys = mux_table.keys()
                 for key in mux_table_keys:
                     kvp = mux_table.get(key)
@@ -530,7 +519,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                 subprocess.call(insert_cmd)
                 self.log_info("Update DHCP chain: {}".format(' '.join(insert_cmd)))
 
-    def get_acl_rules_and_translate_to_iptables_commands(self, namespace, new_config_db_connector=None):
+    def get_acl_rules_and_translate_to_iptables_commands(self, namespace, config_db_connector):
         """
         Retrieves current ACL tables and rules from Config DB, translates
         control plane ACLs into a list of iptables commands that can be run
@@ -616,12 +605,9 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-A', 'INPUT', '-p', 'tcp', '--dport', '179', '-j', 'ACCEPT'])
 
         # Get current ACL tables and rules from Config DB
-        if new_config_db_connector:
-            self._tables_db_info = new_config_db_connector.get_table(self.ACL_TABLE)
-            self._rules_db_info = new_config_db_connector.get_table(self.ACL_RULE)
-        else:
-            self._tables_db_info = self.config_db_map[namespace].get_table(self.ACL_TABLE)
-            self._rules_db_info = self.config_db_map[namespace].get_table(self.ACL_RULE)
+
+        self._tables_db_info = config_db_connector.get_table(self.ACL_TABLE)
+        self._rules_db_info = config_db_connector.get_table(self.ACL_RULE)
 
         num_ctrl_plane_acl_rules = 0
 
@@ -762,7 +748,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                 service_to_source_ip_map.update({ acl_service:{ "ipv4":ipv4_src_ip_set, "ipv6":ipv6_src_ip_set } })
 
         # Add iptables commands to block ip2me traffic
-        iptables_cmds += self.generate_block_ip2me_traffic_iptables_commands(namespace, new_config_db_connector)
+        iptables_cmds += self.generate_block_ip2me_traffic_iptables_commands(namespace, config_db_connector)
 
         # Add iptables/ip6tables commands to allow all incoming packets with TTL of 0 or 1
         # This allows the device to respond to tools like tcptraceroute
@@ -777,22 +763,22 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
 
         return iptables_cmds, service_to_source_ip_map
 
-    def update_control_plane_acls(self, namespace, new_config_db_connector=None):
+    def update_control_plane_acls(self, namespace, config_db_connector):
         """
         Convenience wrapper which retrieves current ACL tables and rules from
         Config DB, translates control plane ACLs into a list of iptables
         commands and runs them.
         """
-        iptables_cmds, service_to_source_ip_map  = self.get_acl_rules_and_translate_to_iptables_commands(namespace, new_config_db_connector)
+        iptables_cmds, service_to_source_ip_map  = self.get_acl_rules_and_translate_to_iptables_commands(namespace, config_db_connector)
         self.log_info("Issuing the following iptables commands:")
         for cmd in iptables_cmds:
             self.log_info("  " + ' '.join(cmd))
 
         self.run_commands(iptables_cmds)
 
-        self.update_control_plane_nat_acls(namespace, service_to_source_ip_map, new_config_db_connector)
+        self.update_control_plane_nat_acls(namespace, service_to_source_ip_map, config_db_connector)
 
-    def update_control_plane_nat_acls(self, namespace, service_to_source_ip_map, new_config_db_connector=None):
+    def update_control_plane_nat_acls(self, namespace, service_to_source_ip_map, config_db_connector):
         """
         Convenience wrapper for multi-asic platforms 
         which programs the NAT rules for redirecting the
@@ -809,7 +795,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         self.run_commands(iptables_cmds)
 
         if self.DualToR:
-            dualtor_iptables_cmds = self.generate_fwd_traffic_from_host_to_soc(namespace, new_config_db_connector)
+            dualtor_iptables_cmds = self.generate_fwd_traffic_from_host_to_soc(namespace, config_db_connector)
             for cmd in dualtor_iptables_cmds:
                 self.log_info("  " + ' '.join(cmd))
             self.run_commands(dualtor_iptables_cmds)
@@ -826,8 +812,8 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         iptables using the current ACL rules.
         """
         # ConfigDBConnector is not multi thread safe. In child thread, we use another new DB connector.
-        config_db_connector = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
-        config_db_connector.connect()
+        new_config_db_connector = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        new_config_db_connector.connect()
         while True:
             # Sleep for our delay interval
             time.sleep(self.UPDATE_DELAY_SECS)
@@ -844,7 +830,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                     if num_changes == self.num_changes[namespace] and num_changes > 0:
                         self.log_info("ACL config for namespace '{}' has not changed for {} seconds. Applying updates ..."
                                  .format(namespace, self.UPDATE_DELAY_SECS))
-                        self.update_control_plane_acls(namespace, config_db_connector)
+                        self.update_control_plane_acls(namespace, new_config_db_connector)
                     else:
                         self.log_error("Error updating ACLs for namespace '{}'".format(namespace))
 
@@ -964,7 +950,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         # Loop through all asic namespaces (if present) and host namespace (DEFAULT_NAMESPACE)
         for namespace in list(self.config_db_map.keys()):
             # Unconditionally update control plane ACLs once at start on given namespace
-            self.update_control_plane_acls(namespace)
+            self.update_control_plane_acls(namespace, self.config_db_map[namespace])
             # Connect to Config DB of given namespace
             acl_db_connector = swsscommon.DBConnector("CONFIG_DB", 0, False, namespace)
             # Subscribe to notifications when ACL tables changes

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -837,6 +837,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                     # Re-initialize
                     self.num_changes[namespace] = 0
                     self.update_thread[namespace] = None
+                    new_config_db_connector.close("CONFIG_DB")
                     return
 
     def allow_bfd_protocol(self, namespace):

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -838,13 +838,9 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                         # Re-initialize
                         self.num_changes[namespace] = 0
                         self.update_thread[namespace] = None
-                        new_config_db_connector.close("CONFIG_DB")
                         return
-        except Exception as e:
-            self.log_error("Error in check_and_update_control_plane_acls: {}".format(repr(e)))
         finally:
-            self.num_changes[namespace] = 0
-            self.update_thread[namespace] = None
+            new_config_db_connector.close("CONFIG_DB")
 
     def allow_bfd_protocol(self, namespace):
         iptables_cmds = []

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -811,34 +811,40 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         updates were received during the delay window, at which point it will update
         iptables using the current ACL rules.
         """
-        # ConfigDBConnector is not multi thread safe. In child thread, we use another new DB connector.
-        new_config_db_connector = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
-        new_config_db_connector.connect()
-        while True:
-            # Sleep for our delay interval
-            time.sleep(self.UPDATE_DELAY_SECS)
+        try:
+            # ConfigDBConnector is not multi thread safe. In child thread, we use another new DB connector.
+            new_config_db_connector = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+            new_config_db_connector.connect()
+            while True:
+                # Sleep for our delay interval
+                time.sleep(self.UPDATE_DELAY_SECS)
 
-            with self.lock[namespace]:
-                if self.num_changes[namespace] > num_changes:
-                    # More ACL table changes occurred since this thread was spawned
-                    # spawn a new thread with the current number of changes
-                    new_changes = self.num_changes[namespace] - num_changes
-                    self.log_info("ACL config not stable for namespace '{}': {} changes detected in the past {} seconds. Skipping update ..."
-                             .format(namespace, new_changes, self.UPDATE_DELAY_SECS))
-                    num_changes = self.num_changes[namespace]
-                else:
-                    if num_changes == self.num_changes[namespace] and num_changes > 0:
-                        self.log_info("ACL config for namespace '{}' has not changed for {} seconds. Applying updates ..."
-                                 .format(namespace, self.UPDATE_DELAY_SECS))
-                        self.update_control_plane_acls(namespace, new_config_db_connector)
+                with self.lock[namespace]:
+                    if self.num_changes[namespace] > num_changes:
+                        # More ACL table changes occurred since this thread was spawned
+                        # spawn a new thread with the current number of changes
+                        new_changes = self.num_changes[namespace] - num_changes
+                        self.log_info("ACL config not stable for namespace '{}': {} changes detected in the past {} seconds. Skipping update ..."
+                                .format(namespace, new_changes, self.UPDATE_DELAY_SECS))
+                        num_changes = self.num_changes[namespace]
                     else:
-                        self.log_error("Error updating ACLs for namespace '{}'".format(namespace))
+                        if num_changes == self.num_changes[namespace] and num_changes > 0:
+                            self.log_info("ACL config for namespace '{}' has not changed for {} seconds. Applying updates ..."
+                                    .format(namespace, self.UPDATE_DELAY_SECS))
+                            self.update_control_plane_acls(namespace, new_config_db_connector)
+                        else:
+                            self.log_error("Error updating ACLs for namespace '{}'".format(namespace))
 
-                    # Re-initialize
-                    self.num_changes[namespace] = 0
-                    self.update_thread[namespace] = None
-                    new_config_db_connector.close("CONFIG_DB")
-                    return
+                        # Re-initialize
+                        self.num_changes[namespace] = 0
+                        self.update_thread[namespace] = None
+                        new_config_db_connector.close("CONFIG_DB")
+                        return
+        except Exception as e:
+            self.log_error("Error in check_and_update_control_plane_acls: {}".format(repr(e)))
+        finally:
+            self.num_changes[namespace] = 0
+            self.update_thread[namespace] = None
 
     def allow_bfd_protocol(self, namespace):
         iptables_cmds = []

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -817,10 +817,8 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         iptables using the current ACL rules.
         """
         # ConfigDBConnector is not multi thread safe. In child thread, we use another new DB connector.
-        self.log_info("Before connect to config_db_connector in check_and_update_control_plane_acls")
         config_db_connector = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
         config_db_connector.connect()
-        self.log_info("After connect to config_db_connector in check_and_update_control_plane_acls")
         while True:
             # Sleep for our delay interval
             time.sleep(self.UPDATE_DELAY_SECS)

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -347,21 +347,23 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         return allow_internal_docker_ip_cmds
 
 
-    def generate_fwd_traffic_from_host_to_soc(self, namespace):
+    def generate_fwd_traffic_from_host_to_soc(self, namespace, new_config_db_connector=None):
 
         fwd_dualtor_grpc_traffic_from_host_to_soc_cmds = []
+        if not new_config_db_connector:
+            new_config_db_connector = self.config_db_map[DEFAULT_NAMESPACE]
         if self.DualToR:
-            loopback_table = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.LOOPBACK_TABLE)
+            loopback_table = new_config_db_connector.get_table(self.LOOPBACK_TABLE)
             loopback_name = 'Loopback3'
             loopback_address = get_ip_from_interface_table(loopback_table, loopback_name)
             vlan_name = 'Vlan'
-            vlan_table = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.VLAN_INTF_TABLE)
+            vlan_table = new_config_db_connector.get_table(self.VLAN_INTF_TABLE)
             vlan_address = get_ip_from_interface_table(vlan_table, vlan_name)
             fwd_dualtor_grpc_traffic_from_host_to_soc_cmds.append(self.iptables_cmd_ns_prefix[namespace] + 
                     ['iptables', '-t', 'nat', '--flush', 'POSTROUTING'])
             
             if loopback_address is not None:
-                mux_table = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.CONFIG_MUX_CABLE)
+                mux_table = new_config_db_connector.get_table(self.CONFIG_MUX_CABLE)
                 mux_table_keys = mux_table.keys()
                 for key in mux_table_keys:
                     kvp = mux_table.get(key)
@@ -518,7 +520,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                 subprocess.call(insert_cmd)
                 self.log_info("Update DHCP chain: {}".format(' '.join(insert_cmd)))
 
-    def get_acl_rules_and_translate_to_iptables_commands(self, namespace):
+    def get_acl_rules_and_translate_to_iptables_commands(self, namespace, new_config_db_connector=None):
         """
         Retrieves current ACL tables and rules from Config DB, translates
         control plane ACLs into a list of iptables commands that can be run
@@ -604,8 +606,10 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-A', 'INPUT', '-p', 'tcp', '--dport', '179', '-j', 'ACCEPT'])
 
         # Get current ACL tables and rules from Config DB
-        self._tables_db_info = self.config_db_map[namespace].get_table(self.ACL_TABLE)
-        self._rules_db_info = self.config_db_map[namespace].get_table(self.ACL_RULE)
+        if not new_config_db_connector:
+            new_config_db_connector = self.config_db_map[namespace]
+        self._tables_db_info = new_config_db_connector.get_table(self.ACL_TABLE)
+        self._rules_db_info = new_config_db_connector.get_table(self.ACL_RULE)
 
         num_ctrl_plane_acl_rules = 0
 
@@ -761,22 +765,22 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
 
         return iptables_cmds, service_to_source_ip_map
 
-    def update_control_plane_acls(self, namespace):
+    def update_control_plane_acls(self, namespace, new_config_db_connector=None):
         """
         Convenience wrapper which retrieves current ACL tables and rules from
         Config DB, translates control plane ACLs into a list of iptables
         commands and runs them.
         """
-        iptables_cmds, service_to_source_ip_map  = self.get_acl_rules_and_translate_to_iptables_commands(namespace)
+        iptables_cmds, service_to_source_ip_map  = self.get_acl_rules_and_translate_to_iptables_commands(namespace, new_config_db_connector)
         self.log_info("Issuing the following iptables commands:")
         for cmd in iptables_cmds:
             self.log_info("  " + ' '.join(cmd))
 
         self.run_commands(iptables_cmds)
 
-        self.update_control_plane_nat_acls(namespace, service_to_source_ip_map)
+        self.update_control_plane_nat_acls(namespace, service_to_source_ip_map, new_config_db_connector)
 
-    def update_control_plane_nat_acls(self, namespace, service_to_source_ip_map):
+    def update_control_plane_nat_acls(self, namespace, service_to_source_ip_map, new_config_db_connector=None):
         """
         Convenience wrapper for multi-asic platforms 
         which programs the NAT rules for redirecting the
@@ -786,14 +790,14 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         # Add iptables commands to allow front panel traffic
         iptables_cmds = self.generate_fwd_traffic_from_namespace_to_host_commands(namespace, service_to_source_ip_map)
 
-        self.log_info("Issuing the following iptables commands:")
+        self.log_info("Issuing the following iptables commands: in update_control_plane_nat_acls")
         for cmd in iptables_cmds:
             self.log_info("  " + ' '.join(cmd))
 
         self.run_commands(iptables_cmds)
 
         if self.DualToR:
-            dualtor_iptables_cmds = self.generate_fwd_traffic_from_host_to_soc(namespace)
+            dualtor_iptables_cmds = self.generate_fwd_traffic_from_host_to_soc(namespace, new_config_db_connector)
             for cmd in dualtor_iptables_cmds:
                 self.log_info("  " + ' '.join(cmd))
             self.run_commands(dualtor_iptables_cmds)
@@ -809,6 +813,11 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         updates were received during the delay window, at which point it will update
         iptables using the current ACL rules.
         """
+        # ConfigDBConnector is not multi thread safe. In child thread, we use another new DB connector.
+        self.log_info("Before connect to config_db_connector in check_and_update_control_plane_acls")
+        config_db_connector = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        config_db_connector.connect()
+        self.log_info("After connect to config_db_connector in check_and_update_control_plane_acls")
         while True:
             # Sleep for our delay interval
             time.sleep(self.UPDATE_DELAY_SECS)
@@ -825,7 +834,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                     if num_changes == self.num_changes[namespace] and num_changes > 0:
                         self.log_info("ACL config for namespace '{}' has not changed for {} seconds. Applying updates ..."
                                  .format(namespace, self.UPDATE_DELAY_SECS))
-                        self.update_control_plane_acls(namespace)
+                        self.update_control_plane_acls(namespace, config_db_connector)
                     else:
                         self.log_error("Error updating ACLs for namespace '{}'".format(namespace))
 

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -265,7 +265,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
             for k, v in feature_tb_info.items():
                 self.feature_present[k] = True
 
-    def generate_block_ip2me_traffic_iptables_commands(self, namespace):
+    def generate_block_ip2me_traffic_iptables_commands(self, namespace, new_config_db_connector=None):
         INTERFACE_TABLE_NAME_LIST = [
             "LOOPBACK_INTERFACE",
             "VLAN_INTERFACE",
@@ -274,10 +274,13 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         ]
 
         block_ip2me_cmds = []
+        # Get current ACL tables and rules from Config DB
+        if not new_config_db_connector:
+            new_config_db_connector = self.config_db_map[namespace]
 
         # Add iptables rules to drop all packets destined for peer-to-peer interface IP addresses
         for iface_table_name in INTERFACE_TABLE_NAME_LIST:
-            iface_table = self.config_db_map[namespace].get_table(iface_table_name)
+            iface_table = new_config_db_connector.get_table(iface_table_name)
             if iface_table:
                 for key, _ in iface_table.items():
                     if not _ip_prefix_in_key(key):
@@ -750,7 +753,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                 service_to_source_ip_map.update({ acl_service:{ "ipv4":ipv4_src_ip_set, "ipv6":ipv6_src_ip_set } })
 
         # Add iptables commands to block ip2me traffic
-        iptables_cmds += self.generate_block_ip2me_traffic_iptables_commands(namespace)
+        iptables_cmds += self.generate_block_ip2me_traffic_iptables_commands(namespace, new_config_db_connector)
 
         # Add iptables/ip6tables commands to allow all incoming packets with TTL of 0 or 1
         # This allows the device to respond to tools like tcptraceroute
@@ -790,7 +793,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         # Add iptables commands to allow front panel traffic
         iptables_cmds = self.generate_fwd_traffic_from_namespace_to_host_commands(namespace, service_to_source_ip_map)
 
-        self.log_info("Issuing the following iptables commands: in update_control_plane_nat_acls")
+        self.log_info("Issuing the following iptables commands:")
         for cmd in iptables_cmds:
             self.log_info("  " + ' '.join(cmd))
 

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -274,13 +274,13 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         ]
 
         block_ip2me_cmds = []
-        # Get current ACL tables and rules from Config DB
-        if not new_config_db_connector:
-            new_config_db_connector = self.config_db_map[namespace]
 
         # Add iptables rules to drop all packets destined for peer-to-peer interface IP addresses
         for iface_table_name in INTERFACE_TABLE_NAME_LIST:
-            iface_table = new_config_db_connector.get_table(iface_table_name)
+            if new_config_db_connector:
+                iface_table = new_config_db_connector.get_table(iface_table_name)
+            else:
+                iface_table = self.config_db_map[namespace].get_table(iface_table_name)
             if iface_table:
                 for key, _ in iface_table.items():
                     if not _ip_prefix_in_key(key):
@@ -353,20 +353,27 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
     def generate_fwd_traffic_from_host_to_soc(self, namespace, new_config_db_connector=None):
 
         fwd_dualtor_grpc_traffic_from_host_to_soc_cmds = []
-        if not new_config_db_connector:
-            new_config_db_connector = self.config_db_map[DEFAULT_NAMESPACE]
         if self.DualToR:
-            loopback_table = new_config_db_connector.get_table(self.LOOPBACK_TABLE)
+            if new_config_db_connector:
+                loopback_table = new_config_db_connector.get_table(self.LOOPBACK_TABLE)
+            else:
+                loopback_table = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.LOOPBACK_TABLE)
             loopback_name = 'Loopback3'
             loopback_address = get_ip_from_interface_table(loopback_table, loopback_name)
             vlan_name = 'Vlan'
-            vlan_table = new_config_db_connector.get_table(self.VLAN_INTF_TABLE)
+            if new_config_db_connector:
+                vlan_table = new_config_db_connector.get_table(self.VLAN_INTF_TABLE)
+            else:
+                vlan_table = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.VLAN_INTF_TABLE)
             vlan_address = get_ip_from_interface_table(vlan_table, vlan_name)
             fwd_dualtor_grpc_traffic_from_host_to_soc_cmds.append(self.iptables_cmd_ns_prefix[namespace] + 
                     ['iptables', '-t', 'nat', '--flush', 'POSTROUTING'])
             
             if loopback_address is not None:
-                mux_table = new_config_db_connector.get_table(self.CONFIG_MUX_CABLE)
+                if new_config_db_connector:
+                    mux_table = new_config_db_connector.get_table(self.CONFIG_MUX_CABLE)
+                else:
+                    mux_table = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.CONFIG_MUX_CABLE)
                 mux_table_keys = mux_table.keys()
                 for key in mux_table_keys:
                     kvp = mux_table.get(key)
@@ -609,10 +616,12 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-A', 'INPUT', '-p', 'tcp', '--dport', '179', '-j', 'ACCEPT'])
 
         # Get current ACL tables and rules from Config DB
-        if not new_config_db_connector:
-            new_config_db_connector = self.config_db_map[namespace]
-        self._tables_db_info = new_config_db_connector.get_table(self.ACL_TABLE)
-        self._rules_db_info = new_config_db_connector.get_table(self.ACL_RULE)
+        if new_config_db_connector:
+            self._tables_db_info = new_config_db_connector.get_table(self.ACL_TABLE)
+            self._rules_db_info = new_config_db_connector.get_table(self.ACL_RULE)
+        else:
+            self._tables_db_info = self.config_db_map[namespace].get_table(self.ACL_TABLE)
+            self._rules_db_info = self.config_db_map[namespace].get_table(self.ACL_RULE)
 
         num_ctrl_plane_acl_rules = 0
 

--- a/tests/caclmgrd/caclmgrd_external_client_acl_test.py
+++ b/tests/caclmgrd/caclmgrd_external_client_acl_test.py
@@ -41,7 +41,7 @@ class TestCaclmgrdExternalClientAcl(TestCase):
         self.caclmgrd.ControlPlaneAclManager.get_chassis_midplane_interface_ip = mock.MagicMock(return_value='')
         caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
 
-        iptables_rules_ret, _ = caclmgrd_daemon.get_acl_rules_and_translate_to_iptables_commands('')
+        iptables_rules_ret, _ = caclmgrd_daemon.get_acl_rules_and_translate_to_iptables_commands('', MockConfigDb())
         test_data['return'] = [tuple(i) for i in test_data['return']]
         iptables_rules_ret = [tuple(i) for i in iptables_rules_ret]
         self.assertEqual(set(test_data["return"]).issubset(set(iptables_rules_ret)), True)

--- a/tests/caclmgrd/caclmgrd_ip2me_test.py
+++ b/tests/caclmgrd/caclmgrd_ip2me_test.py
@@ -38,5 +38,5 @@ class TestCaclmgrdIP2Me(TestCase):
         self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ip = mock.MagicMock()
         self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ipv6 = mock.MagicMock()
         caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
-        ret = caclmgrd_daemon.generate_block_ip2me_traffic_iptables_commands('')
+        ret = caclmgrd_daemon.generate_block_ip2me_traffic_iptables_commands('', MockConfigDb())
         self.assertListEqual(test_data["return"], ret)

--- a/tests/caclmgrd/caclmgrd_scale_test.py
+++ b/tests/caclmgrd/caclmgrd_scale_test.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import swsscommon
+
+from parameterized import parameterized
+from sonic_py_common.general import load_module_from_source
+from unittest import TestCase, mock
+from pyfakefs.fake_filesystem_unittest import patchfs
+
+from .test_scale_vectors import CACLMGRD_SCALE_TEST_VECTOR
+from tests.common.mock_configdb import MockConfigDb
+from unittest.mock import MagicMock, patch
+
+DBCONFIG_PATH = '/var/run/redis/sonic-db/database_config.json'
+
+class TestCaclmgrdScale(TestCase):
+    """
+        Test caclmgrd with scale cacl rules
+    """
+    def setUp(self):
+        swsscommon.swsscommon.ConfigDBConnector = MockConfigDb
+        test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        modules_path = os.path.dirname(test_path)
+        scripts_path = os.path.join(modules_path, "scripts")
+        sys.path.insert(0, modules_path)
+        caclmgrd_path = os.path.join(scripts_path, 'caclmgrd')
+        self.caclmgrd = load_module_from_source('caclmgrd', caclmgrd_path)
+
+    @parameterized.expand(CACLMGRD_SCALE_TEST_VECTOR)
+    @patchfs
+    def test_caclmgrd_scale(self, test_name, test_data, fs):
+        if not os.path.exists(DBCONFIG_PATH):
+            fs.create_file(DBCONFIG_PATH) # fake database_config.json
+
+        MockConfigDb.set_config_db(test_data["config_db"])
+
+        with mock.patch("caclmgrd.ControlPlaneAclManager.run_commands_pipe", return_value='sonic'):
+            with mock.patch("caclmgrd.subprocess") as mocked_subprocess:
+                popen_mock = mock.Mock()
+                popen_attrs = test_data["popen_attributes"]
+                popen_mock.configure_mock(**popen_attrs)
+                mocked_subprocess.Popen.return_value = popen_mock
+                mocked_subprocess.PIPE = -1
+
+                call_rc = test_data["call_rc"]
+                mocked_subprocess.call.return_value = call_rc
+
+                caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
+                caclmgrd_daemon.num_changes[''] = 150
+                caclmgrd_daemon.check_and_update_control_plane_acls('', 150)
+                mocked_subprocess.Popen.assert_has_calls(test_data["expected_subprocess_calls"], any_order=True)

--- a/tests/caclmgrd/caclmgrd_soc_rules_test.py
+++ b/tests/caclmgrd/caclmgrd_soc_rules_test.py
@@ -48,7 +48,7 @@ class TestCaclmgrdSoc(TestCase):
                 mocked_subprocess.call.return_value = call_rc
 
                 caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
-                caclmgrd_daemon.update_control_plane_nat_acls('', {})
+                caclmgrd_daemon.update_control_plane_nat_acls('', {}, MockConfigDb())
                 mocked_subprocess.Popen.assert_has_calls(test_data["expected_subprocess_calls"], any_order=True)
 
     def test_get_ip_from_interface_table(self):

--- a/tests/caclmgrd/test_scale_vectors.py
+++ b/tests/caclmgrd/test_scale_vectors.py
@@ -1,0 +1,1009 @@
+from unittest.mock import call
+import subprocess
+
+"""
+    caclmgrd bfd test vector
+"""
+CACLMGRD_SCALE_TEST_VECTOR = [
+    [
+        "SCALE_SESSION_TEST",
+        {
+            "config_db": {
+                "DEVICE_METADATA": {
+                    "localhost": {
+                        "type": "ToRRouter",
+                    }
+                },
+                "LOOPBACK_INTERFACE": {},
+                "VLAN_INTERFACE": {},
+                "PORTCHANNEL_INTERFACE": {},
+                "INTERFACE": {},
+                "FEATURE": {},
+              "ACL_RULE": {
+                  "NTP_ACL|RULE_1": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9999",
+                      "SRC_IPV6": "2001::2/128"
+                  },
+                  "NTP_ACL|RULE_2": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9998",
+                      "SRC_IPV6": "2001::3/128"
+                  },
+                  "NTP_ACL|RULE_3": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9997",
+                      "SRC_IPV6": "2001::4/128"
+                  },
+                  "NTP_ACL|RULE_4": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9996",
+                      "SRC_IPV6": "2001::5/128"
+                  },
+                  "NTP_ACL|RULE_5": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9995",
+                      "SRC_IPV6": "2001::6/128"
+                  },
+                  "NTP_ACL|RULE_6": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9994",
+                      "SRC_IPV6": "2001::7/128"
+                  },
+                  "NTP_ACL|RULE_7": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9993",
+                      "SRC_IPV6": "2001::8/128"
+                  },
+                  "NTP_ACL|RULE_8": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9992",
+                      "SRC_IPV6": "2001::9/128"
+                  },
+                  "NTP_ACL|RULE_9": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9991",
+                      "SRC_IPV6": "2001::10/128"
+                  },
+                  "NTP_ACL|RULE_10": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9990",
+                      "SRC_IPV6": "2001::11/128"
+                  },
+                  "NTP_ACL|RULE_11": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9989",
+                      "SRC_IPV6": "2001::12/128"
+                  },
+                  "NTP_ACL|RULE_12": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9988",
+                      "SRC_IPV6": "2001::13/128"
+                  },
+                  "NTP_ACL|RULE_13": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9987",
+                      "SRC_IPV6": "2001::14/128"
+                  },
+                  "NTP_ACL|RULE_14": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9986",
+                      "SRC_IPV6": "2001::15/128"
+                  },
+                  "NTP_ACL|RULE_15": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9985",
+                      "SRC_IPV6": "2001::16/128"
+                  },
+                  "NTP_ACL|RULE_16": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9984",
+                      "SRC_IPV6": "2001::17/128"
+                  },
+                  "NTP_ACL|RULE_17": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9983",
+                      "SRC_IPV6": "2001::18/128"
+                  },
+                  "NTP_ACL|RULE_18": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9982",
+                      "SRC_IPV6": "2001::19/128"
+                  },
+                  "NTP_ACL|RULE_19": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9981",
+                      "SRC_IPV6": "2001::20/128"
+                  },
+                  "NTP_ACL|RULE_20": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9980",
+                      "SRC_IPV6": "2001::21/128"
+                  },
+                  "NTP_ACL|RULE_21": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9979",
+                      "SRC_IPV6": "2001::22/128"
+                  },
+                  "NTP_ACL|RULE_22": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9978",
+                      "SRC_IPV6": "2001::23/128"
+                  },
+                  "NTP_ACL|RULE_23": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9977",
+                      "SRC_IPV6": "2001::24/128"
+                  },
+                  "NTP_ACL|RULE_24": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9976",
+                      "SRC_IPV6": "2001::25/128"
+                  },
+                  "NTP_ACL|RULE_25": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9975",
+                      "SRC_IPV6": "2001::26/128"
+                  },
+                  "NTP_ACL|RULE_26": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9974",
+                      "SRC_IPV6": "2001::27/128"
+                  },
+                  "NTP_ACL|RULE_27": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9973",
+                      "SRC_IPV6": "2001::28/128"
+                  },
+                  "NTP_ACL|RULE_28": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9972",
+                      "SRC_IPV6": "2001::29/128"
+                  },
+                  "NTP_ACL|RULE_29": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9971",
+                      "SRC_IPV6": "2001::30/128"
+                  },
+                  "NTP_ACL|RULE_30": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9970",
+                      "SRC_IPV6": "2001::31/128"
+                  },
+                  "NTP_ACL|RULE_31": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9969",
+                      "SRC_IPV6": "2001::32/128"
+                  },
+                  "NTP_ACL|RULE_32": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9968",
+                      "SRC_IPV6": "2001::33/128"
+                  },
+                  "NTP_ACL|RULE_33": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9967",
+                      "SRC_IPV6": "2001::34/128"
+                  },
+                  "NTP_ACL|RULE_34": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9966",
+                      "SRC_IPV6": "2001::35/128"
+                  },
+                  "NTP_ACL|RULE_35": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9965",
+                      "SRC_IPV6": "2001::36/128"
+                  },
+                  "NTP_ACL|RULE_36": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9964",
+                      "SRC_IPV6": "2001::37/128"
+                  },
+                  "NTP_ACL|RULE_37": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9963",
+                      "SRC_IPV6": "2001::38/128"
+                  },
+                  "NTP_ACL|RULE_38": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9962",
+                      "SRC_IPV6": "2001::39/128"
+                  },
+                  "NTP_ACL|RULE_39": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9961",
+                      "SRC_IPV6": "2001::40/128"
+                  },
+                  "NTP_ACL|RULE_40": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9960",
+                      "SRC_IPV6": "2001::41/128"
+                  },
+                  "NTP_ACL|RULE_41": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9959",
+                      "SRC_IPV6": "2001::42/128"
+                  },
+                  "NTP_ACL|RULE_42": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9958",
+                      "SRC_IPV6": "2001::43/128"
+                  },
+                  "NTP_ACL|RULE_43": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9957",
+                      "SRC_IPV6": "2001::44/128"
+                  },
+                  "NTP_ACL|RULE_44": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9956",
+                      "SRC_IPV6": "2001::45/128"
+                  },
+                  "NTP_ACL|RULE_45": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9955",
+                      "SRC_IPV6": "2001::46/128"
+                  },
+                  "NTP_ACL|RULE_46": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9954",
+                      "SRC_IPV6": "2001::47/128"
+                  },
+                  "NTP_ACL|RULE_47": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9953",
+                      "SRC_IPV6": "2001::48/128"
+                  },
+                  "NTP_ACL|RULE_48": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9952",
+                      "SRC_IPV6": "2001::49/128"
+                  },
+                  "NTP_ACL|RULE_49": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9951",
+                      "SRC_IPV6": "2001::50/128"
+                  },
+                  "NTP_ACL|RULE_50": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9950",
+                      "SRC_IPV6": "2001::51/128"
+                  },
+                  "SNMP_ACL|RULE_1": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9999",
+                      "SRC_IPV6": "2001::2/128"
+                  },
+                  "SNMP_ACL|RULE_2": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9998",
+                      "SRC_IPV6": "2001::3/128"
+                  },
+                  "SNMP_ACL|RULE_3": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9997",
+                      "SRC_IPV6": "2001::4/128"
+                  },
+                  "SNMP_ACL|RULE_4": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9996",
+                      "SRC_IPV6": "2001::5/128"
+                  },
+                  "SNMP_ACL|RULE_5": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9995",
+                      "SRC_IPV6": "2001::6/128"
+                  },
+                  "SNMP_ACL|RULE_6": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9994",
+                      "SRC_IPV6": "2001::7/128"
+                  },
+                  "SNMP_ACL|RULE_7": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9993",
+                      "SRC_IPV6": "2001::8/128"
+                  },
+                  "SNMP_ACL|RULE_8": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9992",
+                      "SRC_IPV6": "2001::9/128"
+                  },
+                  "SNMP_ACL|RULE_9": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9991",
+                      "SRC_IPV6": "2001::10/128"
+                  },
+                  "SNMP_ACL|RULE_10": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9990",
+                      "SRC_IPV6": "2001::11/128"
+                  },
+                  "SNMP_ACL|RULE_11": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9989",
+                      "SRC_IPV6": "2001::12/128"
+                  },
+                  "SNMP_ACL|RULE_12": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9988",
+                      "SRC_IPV6": "2001::13/128"
+                  },
+                  "SNMP_ACL|RULE_13": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9987",
+                      "SRC_IPV6": "2001::14/128"
+                  },
+                  "SNMP_ACL|RULE_14": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9986",
+                      "SRC_IPV6": "2001::15/128"
+                  },
+                  "SNMP_ACL|RULE_15": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9985",
+                      "SRC_IPV6": "2001::16/128"
+                  },
+                  "SNMP_ACL|RULE_16": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9984",
+                      "SRC_IPV6": "2001::17/128"
+                  },
+                  "SNMP_ACL|RULE_17": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9983",
+                      "SRC_IPV6": "2001::18/128"
+                  },
+                  "SNMP_ACL|RULE_18": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9982",
+                      "SRC_IPV6": "2001::19/128"
+                  },
+                  "SNMP_ACL|RULE_19": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9981",
+                      "SRC_IPV6": "2001::20/128"
+                  },
+                  "SNMP_ACL|RULE_20": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9980",
+                      "SRC_IPV6": "2001::21/128"
+                  },
+                  "SNMP_ACL|RULE_21": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9979",
+                      "SRC_IPV6": "2001::22/128"
+                  },
+                  "SNMP_ACL|RULE_22": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9978",
+                      "SRC_IPV6": "2001::23/128"
+                  },
+                  "SNMP_ACL|RULE_23": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9977",
+                      "SRC_IPV6": "2001::24/128"
+                  },
+                  "SNMP_ACL|RULE_24": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9976",
+                      "SRC_IPV6": "2001::25/128"
+                  },
+                  "SNMP_ACL|RULE_25": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9975",
+                      "SRC_IPV6": "2001::26/128"
+                  },
+                  "SNMP_ACL|RULE_26": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9974",
+                      "SRC_IPV6": "2001::27/128"
+                  },
+                  "SNMP_ACL|RULE_27": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9973",
+                      "SRC_IPV6": "2001::28/128"
+                  },
+                  "SNMP_ACL|RULE_28": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9972",
+                      "SRC_IPV6": "2001::29/128"
+                  },
+                  "SNMP_ACL|RULE_29": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9971",
+                      "SRC_IPV6": "2001::30/128"
+                  },
+                  "SNMP_ACL|RULE_30": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9970",
+                      "SRC_IPV6": "2001::31/128"
+                  },
+                  "SNMP_ACL|RULE_31": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9969",
+                      "SRC_IPV6": "2001::32/128"
+                  },
+                  "SNMP_ACL|RULE_32": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9968",
+                      "SRC_IPV6": "2001::33/128"
+                  },
+                  "SNMP_ACL|RULE_33": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9967",
+                      "SRC_IPV6": "2001::34/128"
+                  },
+                  "SNMP_ACL|RULE_34": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9966",
+                      "SRC_IPV6": "2001::35/128"
+                  },
+                  "SNMP_ACL|RULE_35": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9965",
+                      "SRC_IPV6": "2001::36/128"
+                  },
+                  "SNMP_ACL|RULE_36": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9964",
+                      "SRC_IPV6": "2001::37/128"
+                  },
+                  "SNMP_ACL|RULE_37": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9963",
+                      "SRC_IPV6": "2001::38/128"
+                  },
+                  "SNMP_ACL|RULE_38": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9962",
+                      "SRC_IPV6": "2001::39/128"
+                  },
+                  "SNMP_ACL|RULE_39": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9961",
+                      "SRC_IPV6": "2001::40/128"
+                  },
+                  "SNMP_ACL|RULE_40": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9960",
+                      "SRC_IPV6": "2001::41/128"
+                  },
+                  "SNMP_ACL|RULE_41": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9959",
+                      "SRC_IPV6": "2001::42/128"
+                  },
+                  "SNMP_ACL|RULE_42": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9958",
+                      "SRC_IPV6": "2001::43/128"
+                  },
+                  "SNMP_ACL|RULE_43": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9957",
+                      "SRC_IPV6": "2001::44/128"
+                  },
+                  "SNMP_ACL|RULE_44": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9956",
+                      "SRC_IPV6": "2001::45/128"
+                  },
+                  "SNMP_ACL|RULE_45": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9955",
+                      "SRC_IPV6": "2001::46/128"
+                  },
+                  "SNMP_ACL|RULE_46": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9954",
+                      "SRC_IPV6": "2001::47/128"
+                  },
+                  "SNMP_ACL|RULE_47": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9953",
+                      "SRC_IPV6": "2001::48/128"
+                  },
+                  "SNMP_ACL|RULE_48": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9952",
+                      "SRC_IPV6": "2001::49/128"
+                  },
+                  "SNMP_ACL|RULE_49": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9951",
+                      "SRC_IPV6": "2001::50/128"
+                  },
+                  "SNMP_ACL|RULE_50": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9950",
+                      "SRC_IPV6": "2001::51/128"
+                  },
+                  "SSH_ONLY|RULE_1": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9999",
+                      "SRC_IPV6": "2001::2/128"
+                  },
+                  "SSH_ONLY|RULE_2": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9998",
+                      "SRC_IPV6": "2001::3/128"
+                  },
+                  "SSH_ONLY|RULE_3": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9997",
+                      "SRC_IPV6": "2001::4/128"
+                  },
+                  "SSH_ONLY|RULE_4": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9996",
+                      "SRC_IPV6": "2001::5/128"
+                  },
+                  "SSH_ONLY|RULE_5": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9995",
+                      "SRC_IPV6": "2001::6/128"
+                  },
+                  "SSH_ONLY|RULE_6": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9994",
+                      "SRC_IPV6": "2001::7/128"
+                  },
+                  "SSH_ONLY|RULE_7": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9993",
+                      "SRC_IPV6": "2001::8/128"
+                  },
+                  "SSH_ONLY|RULE_8": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9992",
+                      "SRC_IPV6": "2001::9/128"
+                  },
+                  "SSH_ONLY|RULE_9": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9991",
+                      "SRC_IPV6": "2001::10/128"
+                  },
+                  "SSH_ONLY|RULE_10": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9990",
+                      "SRC_IPV6": "2001::11/128"
+                  },
+                  "SSH_ONLY|RULE_11": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9989",
+                      "SRC_IPV6": "2001::12/128"
+                  },
+                  "SSH_ONLY|RULE_12": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9988",
+                      "SRC_IPV6": "2001::13/128"
+                  },
+                  "SSH_ONLY|RULE_13": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9987",
+                      "SRC_IPV6": "2001::14/128"
+                  },
+                  "SSH_ONLY|RULE_14": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9986",
+                      "SRC_IPV6": "2001::15/128"
+                  },
+                  "SSH_ONLY|RULE_15": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9985",
+                      "SRC_IPV6": "2001::16/128"
+                  },
+                  "SSH_ONLY|RULE_16": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9984",
+                      "SRC_IPV6": "2001::17/128"
+                  },
+                  "SSH_ONLY|RULE_17": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9983",
+                      "SRC_IPV6": "2001::18/128"
+                  },
+                  "SSH_ONLY|RULE_18": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9982",
+                      "SRC_IPV6": "2001::19/128"
+                  },
+                  "SSH_ONLY|RULE_19": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9981",
+                      "SRC_IPV6": "2001::20/128"
+                  },
+                  "SSH_ONLY|RULE_20": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9980",
+                      "SRC_IPV6": "2001::21/128"
+                  },
+                  "SSH_ONLY|RULE_21": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9979",
+                      "SRC_IPV6": "2001::22/128"
+                  },
+                  "SSH_ONLY|RULE_22": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9978",
+                      "SRC_IPV6": "2001::23/128"
+                  },
+                  "SSH_ONLY|RULE_23": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9977",
+                      "SRC_IPV6": "2001::24/128"
+                  },
+                  "SSH_ONLY|RULE_24": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9976",
+                      "SRC_IPV6": "2001::25/128"
+                  },
+                  "SSH_ONLY|RULE_25": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9975",
+                      "SRC_IPV6": "2001::26/128"
+                  },
+                  "SSH_ONLY|RULE_26": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9974",
+                      "SRC_IPV6": "2001::27/128"
+                  },
+                  "SSH_ONLY|RULE_27": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9973",
+                      "SRC_IPV6": "2001::28/128"
+                  },
+                  "SSH_ONLY|RULE_28": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9972",
+                      "SRC_IPV6": "2001::29/128"
+                  },
+                  "SSH_ONLY|RULE_29": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9971",
+                      "SRC_IPV6": "2001::30/128"
+                  },
+                  "SSH_ONLY|RULE_30": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9970",
+                      "SRC_IPV6": "2001::31/128"
+                  },
+                  "SSH_ONLY|RULE_31": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9969",
+                      "SRC_IPV6": "2001::32/128"
+                  },
+                  "SSH_ONLY|RULE_32": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9968",
+                      "SRC_IPV6": "2001::33/128"
+                  },
+                  "SSH_ONLY|RULE_33": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9967",
+                      "SRC_IPV6": "2001::34/128"
+                  },
+                  "SSH_ONLY|RULE_34": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9966",
+                      "SRC_IPV6": "2001::35/128"
+                  },
+                  "SSH_ONLY|RULE_35": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9965",
+                      "SRC_IPV6": "2001::36/128"
+                  },
+                  "SSH_ONLY|RULE_36": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9964",
+                      "SRC_IPV6": "2001::37/128"
+                  },
+                  "SSH_ONLY|RULE_37": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9963",
+                      "SRC_IPV6": "2001::38/128"
+                  },
+                  "SSH_ONLY|RULE_38": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9962",
+                      "SRC_IPV6": "2001::39/128"
+                  },
+                  "SSH_ONLY|RULE_39": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9961",
+                      "SRC_IPV6": "2001::40/128"
+                  },
+                  "SSH_ONLY|RULE_40": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9960",
+                      "SRC_IPV6": "2001::41/128"
+                  },
+                  "SSH_ONLY|RULE_41": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9959",
+                      "SRC_IPV6": "2001::42/128"
+                  },
+                  "SSH_ONLY|RULE_42": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9958",
+                      "SRC_IPV6": "2001::43/128"
+                  },
+                  "SSH_ONLY|RULE_43": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9957",
+                      "SRC_IPV6": "2001::44/128"
+                  },
+                  "SSH_ONLY|RULE_44": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9956",
+                      "SRC_IPV6": "2001::45/128"
+                  },
+                  "SSH_ONLY|RULE_45": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9955",
+                      "SRC_IPV6": "2001::46/128"
+                  },
+                  "SSH_ONLY|RULE_46": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9954",
+                      "SRC_IPV6": "2001::47/128"
+                  },
+                  "SSH_ONLY|RULE_47": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9953",
+                      "SRC_IPV6": "2001::48/128"
+                  },
+                  "SSH_ONLY|RULE_48": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9952",
+                      "SRC_IPV6": "2001::49/128"
+                  },
+                  "SSH_ONLY|RULE_49": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9951",
+                      "SRC_IPV6": "2001::50/128"
+                  },
+                  "SSH_ONLY|RULE_50": {
+                      "PACKET_ACTION": "DROP",
+                      "PRIORITY": "9950",
+                      "SRC_IPV6": "2001::51/128"
+                  }
+              },
+              "ACL_TABLE": {
+        "NTP_ACL": {
+            "policy_desc": "NTP_ACL",
+            "services": [
+                "NTP"
+            ],
+            "stage": "ingress",
+            "type": "CTRLPLANE"
+        },
+        "SNMP_ACL": {
+            "policy_desc": "SNMP_ACL",
+            "services": [
+                "SNMP"
+            ],
+            "stage": "ingress",
+            "type": "CTRLPLANE"
+        },
+        "SSH_ONLY": {
+            "policy_desc": "SSH_ONLY",
+            "services": [
+                "SSH"
+            ],
+            "stage": "ingress",
+            "type": "CTRLPLANE"
+        }
+    },
+            },
+            "expected_subprocess_calls": [
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::2/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::3/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::4/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::5/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::6/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::7/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::8/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::9/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::10/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::11/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::12/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::13/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::14/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::15/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::16/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::17/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::18/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::19/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::20/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::21/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::22/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::23/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::24/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::25/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::26/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::27/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::28/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::29/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::30/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::31/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::32/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::33/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::34/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::35/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::36/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::37/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::38/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::39/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::40/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::41/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::42/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::43/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::44/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::45/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::46/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::47/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::48/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::49/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::50/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::51/128', '--dport', '123', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::2/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::2/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::3/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::3/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::4/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::4/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::5/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::5/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::6/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::6/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::7/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::7/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::8/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::8/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::9/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::9/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::10/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::10/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::11/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::11/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::12/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::12/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::13/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::13/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::14/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::14/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::15/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::15/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::16/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::16/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::17/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::17/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::18/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::18/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::19/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::19/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::20/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::20/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::21/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::21/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::22/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::22/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::23/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::23/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::24/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::24/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::25/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::25/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::26/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::26/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::27/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::27/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::28/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::28/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::29/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::29/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::30/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::30/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::31/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::31/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::32/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::32/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::33/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::33/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::34/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::34/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::35/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::35/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::36/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::36/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::37/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::37/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::38/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::38/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::39/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::39/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::40/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::40/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::41/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::41/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::42/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::42/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::43/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::43/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::44/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::44/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::45/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::45/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::46/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::46/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::47/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::47/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::48/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::48/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::49/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::49/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::50/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::50/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::51/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'udp', '-s', '2001::51/128', '--dport', '161', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::2/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::3/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::4/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::5/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::6/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::7/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::8/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::9/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::10/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::11/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::12/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::13/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::14/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::15/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::16/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::17/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::18/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::19/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::20/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::21/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::22/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::23/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::24/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::25/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::26/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::27/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::28/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::29/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::30/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::31/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::32/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::33/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::34/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::35/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::36/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::37/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::38/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::39/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::40/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::41/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::42/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::43/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::44/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::45/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::46/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::47/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::48/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::49/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::50/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE),
+                call(['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::51/128', '--dport', '22', '-j', 'DROP'], universal_newlines=True, stdout=subprocess.PIPE)
+            ],
+            "popen_attributes": {
+                'communicate.return_value': ('output', 'error'),
+            },
+            "call_rc": 0,
+        }
+    ]
+]

--- a/tests/common/mock_configdb.py
+++ b/tests/common/mock_configdb.py
@@ -29,6 +29,9 @@ class MockConfigDb(object):
     def connect(self, wait_for_init=True, retry_on=True):
         pass
 
+    def close(self, db_name):
+        pass
+
     def get(self, db_id, key, field):
         return MockConfigDb.CONFIG_DB[key][field]
 


### PR DESCRIPTION
Fix the issue https://github.com/sonic-net/sonic-buildimage/issues/10883.
For performance reason, libswsscommon is not thread safe by design.
caclmgrd share config DB connection cross thread, so change to use new db connector in child thread.