### PR TITLE
Add eth1-midplane IP Table rule only if the device type is chassis.

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -558,7 +558,8 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         iptables_cmds += self.generate_allow_internal_docker_ip_traffic_commands(namespace)
 
         # Add iptables commands to allow internal chasiss midplane traffic
-        iptables_cmds += self.generate_allow_internal_chasis_midplane_traffic(namespace)
+        if device_info.is_chassis():
+            iptables_cmds += self.generate_allow_internal_chasis_midplane_traffic(namespace)
 
         # Add iptables/ip6tables commands to allow all incoming packets from established
         # connections or new connections which are related to established connections

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -308,7 +308,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
 
     def generate_allow_internal_chasis_midplane_traffic(self, namespace):
         allow_internal_chassis_midplane_traffic = []
-        if not namespace:
+        if device_info.is_chassis() and not namespace:
             chassis_midplane_ip = self.get_chassis_midplane_interface_ip()
             if not chassis_midplane_ip:
                 return allow_internal_chassis_midplane_traffic
@@ -558,8 +558,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         iptables_cmds += self.generate_allow_internal_docker_ip_traffic_commands(namespace)
 
         # Add iptables commands to allow internal chasiss midplane traffic
-        if device_info.is_chassis():
-            iptables_cmds += self.generate_allow_internal_chasis_midplane_traffic(namespace)
+        iptables_cmds += self.generate_allow_internal_chasis_midplane_traffic(namespace)
 
         # Add iptables/ip6tables commands to allow all incoming packets from established
         # connections or new connections which are related to established connections

--- a/tests/caclmgrd/caclmgrd_chassis_midplane_test.py
+++ b/tests/caclmgrd/caclmgrd_chassis_midplane_test.py
@@ -34,9 +34,10 @@ class TestCaclmgrdChassisMidplane(TestCase):
         if not os.path.exists(DBCONFIG_PATH):
             fs.create_file(DBCONFIG_PATH) # fake database_config.json
 
-        with mock.patch("caclmgrd.ControlPlaneAclManager.run_commands_pipe", return_value='1.0.0.33'):
-            caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
-            ret = caclmgrd_daemon.generate_allow_internal_chasis_midplane_traffic('')
-            self.assertListEqual(test_data["return"], ret)
-            ret = caclmgrd_daemon.generate_allow_internal_chasis_midplane_traffic('asic0')
-            self.assertListEqual([], ret)
+        with mock.patch("sonic_py_common.device_info.is_chassis", return_value=True):
+            with mock.patch("caclmgrd.ControlPlaneAclManager.run_commands_pipe", return_value='1.0.0.33'):
+                caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
+                ret = caclmgrd_daemon.generate_allow_internal_chasis_midplane_traffic('')
+                self.assertListEqual(test_data["return"], ret)
+                ret = caclmgrd_daemon.generate_allow_internal_chasis_midplane_traffic('asic0')
+                self.assertListEqual([], ret)


### PR DESCRIPTION
What I did:
Add eth1-midplane IP Table rule only if the device type is chassis.

Why I did:
To prevent build failure on VS/KVM testbed as the Linux command to get `eth1-midplane` ip address fails (as expected) and it logs the error message which makes test case fails because of log analyzer check.

How I verify:
UT and PR Test should cover this change.