### PR TITLE
[202211][config reload] Config Reload Enhancement

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -10,6 +10,7 @@ import syslog
 import signal
 import re
 import jinja2
+import threading
 from sonic_py_common import device_info
 from sonic_py_common.general import check_output_pipe
 from swsscommon.swsscommon import ConfigDBConnector, DBConnector, Table, SonicDBConfig
@@ -61,6 +62,7 @@ CFG_DB = "CONFIG_DB"
 STATE_DB = "STATE_DB"
 HOSTCFGD_MAX_PRI = 10  # Used to enforce ordering b/w daemons under Hostcfgd
 DEFAULT_SELECT_TIMEOUT = 1000
+PORT_INIT_TIMEOUT_SEC = 180
 
 
 def safe_eval(val, default_value=False):
@@ -156,11 +158,15 @@ class Feature(object):
             feature_cfg (dict): Feature CONFIG_DB configuration
             deviec_config (dict): DEVICE_METADATA section of CONFIG_DB
         """
+        if 'has_timer' in feature_cfg:
+            err_str = "Invalid obsolete field 'has_timer' in FEATURE table. Please update configuration schema version"
+            syslog.syslog(syslog.LOG_ERR, err_str)
+            raise ValueError(err_str)
 
         self.name = feature_name
         self.state = self._get_feature_table_key_render_value(feature_cfg.get('state'), device_config or {}, ['enabled', 'disabled', 'always_enabled', 'always_disabled'])
         self.auto_restart = feature_cfg.get('auto_restart', 'disabled')
-        self.has_timer = safe_eval(feature_cfg.get('has_timer', 'False'))
+        self.delayed = safe_eval(feature_cfg.get('delayed', 'False'))
         self.has_global_scope = safe_eval(feature_cfg.get('has_global_scope', 'True'))
         self.has_per_asic_scope = safe_eval(self._get_feature_table_key_render_value(feature_cfg.get('has_per_asic_scope', 'False'), device_config or {}, ['True', 'False']))
 
@@ -204,12 +210,18 @@ class FeatureHandler(object):
     FEATURE_STATE_DISABLED = "disabled"
     FEATURE_STATE_FAILED = "failed"
 
-    def __init__(self, config_db, feature_state_table, device_config):
+    def __init__(self, config_db, feature_state_table, device_config, is_advanced_boot):
         self._config_db = config_db
         self._feature_state_table = feature_state_table
         self._device_config = device_config
         self._cached_config = {}
         self.is_multi_npu = device_info.is_multi_npu()
+        self.enable_delayed_service = False
+        self.is_advanced_boot = is_advanced_boot
+        self.lock = threading.Lock()
+        self.port_listener_thread = threading.Thread(target=self._portListener, name='port_listener_thread')
+        self.port_listener_thread.daemon = True
+        self.port_listener_thread.start()
         self._device_running_config = device_info.get_device_runtime_metadata()
         self.ns_cfg_db = {}
         self.ns_feature_state_tbl = {}
@@ -227,37 +239,78 @@ class FeatureHandler(object):
                 db_conn = DBConnector(STATE_DB, 0, False, ns);
                 self.ns_feature_state_tbl[ns] = Table(db_conn, 'FEATURE')
 
+    def _enableDelayedServices(self):
+        with self.lock:
+            self.enable_delayed_service = True
+            for feature_name in self._cached_config:
+                if self._cached_config[feature_name].delayed:
+                    self.update_feature_state(self._cached_config[feature_name])
+
+    def _portListener(self):
+        syslog.syslog(syslog.LOG_INFO, "Starting port listener")
+        appl_db_connector = DBConnector("APPL_DB", 0)
+        subscribe_port = swsscommon.SubscriberStateTable(appl_db_connector, "PORT_TABLE")
+        sel = swsscommon.Select()
+        sel.addSelectable(subscribe_port)
+
+        if self.is_advanced_boot:
+             syslog.syslog(syslog.LOG_INFO, "Updating delayed features after warm/fast boot")
+             self._enableDelayedServices()
+
+        while True:
+            (state, selectableObj) = sel.select(PORT_INIT_TIMEOUT_SEC*1000)
+            # Continue if select is timeout or selectable object is not return
+            if state == swsscommon.Select.ERROR:
+                if not self.enable_delayed_service:
+                    syslog.syslog(syslog.LOG_ERR, "Received unexpected error in waiting for port init. Restarting services")
+                    self._enableDelayedServices()
+                continue
+            if state != swsscommon.Select.OBJECT:
+                if not self.enable_delayed_service:
+                    syslog.syslog(syslog.LOG_INFO, "Updating delayed features after timeout")
+                    self._enableDelayedServices()
+                continue
+
+            key, op, fvs = subscribe_port.pop()
+            if not key:
+                break
+            if op == 'SET' and key == 'PortInitDone':
+                syslog.syslog(syslog.LOG_INFO, "Updating delayed features after port initialization")
+                self._enableDelayedServices()
+
     def handler(self, feature_name, op, feature_cfg):
-        if not feature_cfg:
-            syslog.syslog(syslog.LOG_INFO, "Deregistering feature {}".format(feature_name))
-            self._cached_config.pop(feature_name, None)
-            self._feature_state_table._del(feature_name)
-            return
+        with self.lock:
+            if not feature_cfg:
+                syslog.syslog(syslog.LOG_INFO, "Deregistering feature {}".format(feature_name))
+                self._cached_config.pop(feature_name, None)
+                self._feature_state_table._del(feature_name)
+                return
 
-        device_config = {}
-        device_config.update(self._device_config)
-        device_config.update(self._device_running_config)
+            device_config = {}
+            device_config.update(self._device_config)
+            device_config.update(self._device_running_config)
 
-        feature = Feature(feature_name, feature_cfg, device_config)
-        self._cached_config.setdefault(feature_name, Feature(feature_name, {}))
+            feature = Feature(feature_name, feature_cfg, device_config)
+            self._cached_config.setdefault(feature_name, Feature(feature_name, {}))
 
-        # Change auto-restart configuration first.
-        # If service reached failed state before this configuration applies (e.g. on boot)
-        # the next called self.update_feature_state will start it again. If it will fail
-        # again the auto restart will kick-in. Another order may leave it in failed state
-        # and not auto restart.
-        if self._cached_config[feature_name].auto_restart != feature.auto_restart:
-            syslog.syslog(syslog.LOG_INFO, "Auto-restart status of feature '{}' is changed from '{}' to '{}' ..."
-                          .format(feature_name, self._cached_config[feature_name].auto_restart, feature.auto_restart))
-            self.update_systemd_config(feature)
-            self._cached_config[feature_name].auto_restart = feature.auto_restart
+            # Change auto-restart configuration first.
+            # If service reached failed state before this configuration applies (e.g. on boot)
+            # the next called self.update_feature_state will start it again. If it will fail
+            # again the auto restart will kick-in. Another order may leave it in failed state
+            # and not auto restart.
+            if self._cached_config[feature_name].auto_restart != feature.auto_restart:
+                syslog.syslog(syslog.LOG_INFO, "Auto-restart status of feature '{}' is changed from '{}' to '{}' ..."
+                              .format(feature_name, self._cached_config[feature_name].auto_restart, feature.auto_restart))
+                self.update_systemd_config(feature)
+                self._cached_config[feature_name].auto_restart = feature.auto_restart
 
-        # Enable/disable the container service if the feature state was changed from its previous state.
-        if self._cached_config[feature_name].state != feature.state:
-            if self.update_feature_state(feature):
-                self._cached_config[feature_name].state = feature.state
-            else:
-                self.resync_feature_state(self._cached_config[feature_name])
+            # Enable/disable the container service if the feature state was changed from its previous state.
+            if self._cached_config[feature_name].state != feature.state:
+                if self.update_feature_state(feature):
+                    self.sync_feature_asic_scope(feature)
+                    self._cached_config[feature_name] = feature
+                else:
+                    self.resync_feature_state(self._cached_config[feature_name])
 
     def sync_state_field(self, feature_table):
         """
@@ -265,20 +318,22 @@ class FeatureHandler(object):
         Updates the state field in the FEATURE|* tables as the state field
         might have to be rendered based on DEVICE_METADATA table and generated Device Running Metadata
         """
-        for feature_name in feature_table.keys():
-            if not feature_name:
-                syslog.syslog(syslog.LOG_WARNING, "Feature is None")
-                continue
+        with self.lock:
+            for feature_name in feature_table.keys():
+                if not feature_name:
+                    syslog.syslog(syslog.LOG_WARNING, "Feature is None")
+                    continue
 
-            device_config = {}
-            device_config.update(self._device_config)
-            device_config.update(self._device_running_config)
-            feature = Feature(feature_name, feature_table[feature_name], device_config)
+                device_config = {}
+                device_config.update(self._device_config)
+                device_config.update(self._device_running_config)
+                feature = Feature(feature_name, feature_table[feature_name], device_config)
 
-            self._cached_config.setdefault(feature_name, feature)
-            self.update_systemd_config(feature)
-            self.update_feature_state(feature)
-            self.resync_feature_state(feature)
+                self._cached_config.setdefault(feature_name, feature)
+                self.update_systemd_config(feature)
+                self.update_feature_state(feature)
+                self.sync_feature_asic_scope(feature)
+                self.resync_feature_state(feature)
 
     def update_feature_state(self, feature):
         cached_feature = self._cached_config[feature.name]
@@ -311,6 +366,10 @@ class FeatureHandler(object):
                           .format(feature.state, feature.name))
             return False
 
+        if feature.delayed and not self.enable_delayed_service:
+            syslog.syslog(syslog.LOG_INFO, "Feature is {} delayed for port init".format(feature.name))
+            return True
+
         if enable:
             self.enable_feature(feature)
             syslog.syslog(syslog.LOG_INFO, "Feature {} is enabled and started".format(feature.name))
@@ -318,8 +377,6 @@ class FeatureHandler(object):
         if disable:
             self.disable_feature(feature)
             syslog.syslog(syslog.LOG_INFO, "Feature {} is stopped and disabled".format(feature.name))
-
-        self.sync_feature_asic_scope(feature)
 
         return True
 
@@ -393,7 +450,7 @@ class FeatureHandler(object):
             with open(feature_systemd_config_file_path, 'w') as feature_systemd_config_file_handler:
                 feature_systemd_config_file_handler.write(feature_systemd_config)
 
-            syslog.syslog(syslog.LOG_INFO, "Feautre '{}' systemd config file related to auto-restart is updated!"
+            syslog.syslog(syslog.LOG_INFO, "Feature '{}' systemd config file related to auto-restart is updated!"
                           .format(feature_name))
 
         try:
@@ -415,7 +472,7 @@ class FeatureHandler(object):
             syslog.syslog(syslog.LOG_ERR, "Feature '{}' service not available"
                           .format(feature.name))
 
-        feature_suffixes = ["service"] + (["timer"] if feature.has_timer else [])
+        feature_suffixes = ["service"]
 
         return feature_names, feature_suffixes
 
@@ -1591,9 +1648,13 @@ class SyslogCfg:
             return interval, burst
         return interval, burst
 
-
 class HostConfigDaemon:
     def __init__(self):
+        self.state_db_conn = DBConnector(STATE_DB, 0)
+        self.advanced_boot = False
+        if swsscommon.RestartWaiter.isAdvancedBootInProgress(self.state_db_conn):
+            self.advanced_boot = True
+            swsscommon.RestartWaiter.waitAdvancedBootDone()
         # Just a sanity check to verify if the CONFIG_DB has been initialized
         # before moving forward
         self.config_db = ConfigDBConnector()
@@ -1605,7 +1666,6 @@ class HostConfigDaemon:
         self.device_config['DEVICE_METADATA'] = self.config_db.get_table('DEVICE_METADATA')
 
         # Load feature state table
-        self.state_db_conn = DBConnector(STATE_DB, 0)
         feature_state_table = Table(self.state_db_conn, 'FEATURE')
 
         # Initialize KDump Config and set the config to default if nothing is provided
@@ -1615,7 +1675,7 @@ class HostConfigDaemon:
         self.iptables = Iptables()
 
         # Intialize Feature Handler
-        self.feature_handler = FeatureHandler(self.config_db, feature_state_table, self.device_config)
+        self.feature_handler = FeatureHandler(self.config_db, feature_state_table, self.device_config, self.advanced_boot)
 
         # Initialize Ntp Config Handler
         self.ntpcfg = NtpCfg()

--- a/tests/common/mock_configdb.py
+++ b/tests/common/mock_configdb.py
@@ -1,3 +1,4 @@
+import time
 class MockConfigDb(object):
     """
         Mock Config DB which responds to data tables requests and store updates to the data table
@@ -54,6 +55,79 @@ class MockConfigDb(object):
     def listen(self, init_data_handler=None):
         for e in MockConfigDb.event_queue:
             self.handlers[e[0]](e[0], e[1], self.get_entry(e[0], e[1]))
+
+class MockSelect():
+
+    event_queue = []
+    OBJECT = "OBJECT"
+    ERROR = ""
+
+    @staticmethod
+    def set_event_queue(Q):
+        MockSelect.event_queue = Q
+
+    @staticmethod
+    def get_event_queue():
+        return MockSelect.event_queue
+
+    @staticmethod
+    def reset_event_queue():
+        MockSelect.event_queue = []
+
+    def __init__(self):
+        self.sub_map = {}
+        self.TIMEOUT = "TIMEOUT"
+        self.ERROR = "ERROR"
+
+    def addSelectable(self, subscriber):
+        self.sub_map[subscriber.table] = subscriber
+
+    def select(self, TIMEOUT):
+        if not MockSelect.get_event_queue():
+            time.sleep(TIMEOUT/1000)
+            return "TIMEOUT", {}
+        table, key = MockSelect.get_event_queue().pop(0)
+        self.sub_map[table].nextKey(key)
+        self.reset_event_queue()
+        return "OBJECT", self.sub_map[table]
+
+
+class MockSubscriberStateTable():
+
+    FD_INIT = 0
+
+    @staticmethod
+    def generate_fd():
+        curr = MockSubscriberStateTable.FD_INIT
+        MockSubscriberStateTable.FD_INIT = curr + 1
+        return curr
+
+    @staticmethod
+    def reset_fd():
+        MockSubscriberStateTable.FD_INIT = 0
+
+    def __init__(self, conn, table, pop=None, pri=None):
+        self.fd = MockSubscriberStateTable.generate_fd()
+        self.next_key = ''
+        self.table = table
+
+    def getFd(self):
+        return self.fd
+
+    def nextKey(self, key):
+        print("next key")
+        self.next_key = key
+
+    def pop(self):
+        table = MockConfigDb.CONFIG_DB.get(self.table, {})
+        print(self.next_key)
+        if self.next_key not in table:
+            op = "DEL"
+            fvs = {}
+        else:
+            op = "SET"
+            fvs = table.get(self.next_key, {})
+        return self.next_key, op, fvs
 
 
 class MockDBConnector():

--- a/tests/common/mock_restart_waiter.py
+++ b/tests/common/mock_restart_waiter.py
@@ -1,0 +1,25 @@
+class MockRestartWaiter(object):
+    advancedReboot = False
+    """
+        Mock Config DB which responds to data tables requests and store updates to the data table
+    """
+    def waitAdvancedBootDone(maxWaitSec=180, dbTimeout=0, isTcpConn=False):
+        return True
+
+    def waitWarmBootDone(maxWaitSec=180, dbTimeout=0, isTcpConn=False):
+        return False
+
+    def waitFastBootDone(maxWaitSec=180, dbTimeout=0, isTcpConn=False):
+        return False
+
+    def isAdvancedBootInProgress(stateDb):
+        return MockRestartWaiter.advancedReboot
+
+    def isFastBootInProgress(stateDb):
+        return False
+
+    def isWarmBootInProgress(stateDb):
+        return False
+
+    def __init__(self):
+        pass

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 import swsscommon as swsscommon_package
 from sonic_py_common import device_info
 from swsscommon import swsscommon
@@ -10,7 +11,8 @@ from unittest import TestCase, mock
 
 from .test_vectors import HOSTCFG_DAEMON_INIT_CFG_DB
 from .test_vectors import HOSTCFGD_TEST_VECTOR, HOSTCFG_DAEMON_CFG_DB
-from tests.common.mock_configdb import MockConfigDb, MockDBConnector
+from tests.common.mock_configdb import MockConfigDb, MockDBConnector, MockSubscriberStateTable, MockSelect
+from tests.common.mock_restart_waiter import MockRestartWaiter
 
 from pyfakefs.fake_filesystem_unittest import patchfs
 from deepdiff import DeepDiff
@@ -27,6 +29,9 @@ hostcfgd = load_module_from_source('hostcfgd', hostcfgd_path)
 hostcfgd.ConfigDBConnector = MockConfigDb
 hostcfgd.DBConnector = MockDBConnector
 hostcfgd.Table = mock.Mock()
+swsscommon.Select = MockSelect
+swsscommon.SubscriberStateTable = MockSubscriberStateTable
+swsscommon.RestartWaiter = MockRestartWaiter
 
 class TestFeatureHandler(TestCase):
     """Test methods of `FeatureHandler` class.
@@ -136,7 +141,9 @@ class TestFeatureHandler(TestCase):
                             device_config['DEVICE_METADATA'] = MockConfigDb.CONFIG_DB['DEVICE_METADATA']
                             device_config.update(config_data['device_runtime_metadata'])
 
-                            feature_handler = hostcfgd.FeatureHandler(MockConfigDb(), feature_state_table_mock, device_config)
+                            feature_handler = hostcfgd.FeatureHandler(MockConfigDb(), feature_state_table_mock,
+                                                                      device_config, False)
+                            feature_handler.enable_delayed_service = True
                             feature_table = MockConfigDb.CONFIG_DB['FEATURE']
                             feature_handler.sync_state_field(feature_table)
 
@@ -197,7 +204,9 @@ class TestFeatureHandler(TestCase):
                         device_config = {}
                         device_config['DEVICE_METADATA'] = MockConfigDb.CONFIG_DB['DEVICE_METADATA']
                         device_config.update(config_data['device_runtime_metadata'])
-                        feature_handler = hostcfgd.FeatureHandler(MockConfigDb(), feature_state_table_mock, device_config)
+                        feature_handler = hostcfgd.FeatureHandler(MockConfigDb(), feature_state_table_mock,
+                                                                  device_config, False)
+                        feature_handler.enable_delayed_service = True
 
                         feature_table = MockConfigDb.CONFIG_DB['FEATURE']
 
@@ -218,7 +227,7 @@ class TestFeatureHandler(TestCase):
         swss_feature = hostcfgd.Feature('swss', {
             'state': 'enabled',
             'auto_restart': 'enabled',
-            'has_timer': 'True',
+            'delayed': 'True',
             'has_global_scope': 'False',
             'has_per_asic_scope': 'True',
         })
@@ -226,7 +235,7 @@ class TestFeatureHandler(TestCase):
         assert swss_feature.name == 'swss'
         assert swss_feature.state == 'enabled'
         assert swss_feature.auto_restart == 'enabled'
-        assert swss_feature.has_timer
+        assert swss_feature.delayed
         assert not swss_feature.has_global_scope
         assert swss_feature.has_per_asic_scope
 
@@ -238,7 +247,7 @@ class TestFeatureHandler(TestCase):
         assert swss_feature.name == 'swss'
         assert swss_feature.state == 'enabled'
         assert swss_feature.auto_restart == 'disabled'
-        assert not swss_feature.has_timer
+        assert not swss_feature.delayed
         assert swss_feature.has_global_scope
         assert not swss_feature.has_per_asic_scope
 
@@ -369,6 +378,7 @@ class TestHostcfgdDaemon(TestCase):
                                 ('FEATURE', 'mux'),
                                 ('FEATURE', 'telemetry')]
         daemon = hostcfgd.HostConfigDaemon()
+        daemon.feature_handler.enable_delayed_service = True
         daemon.register_callbacks()
         with mock.patch('hostcfgd.subprocess') as mocked_subprocess:
             popen_mock = mock.Mock()
@@ -389,9 +399,8 @@ class TestHostcfgdDaemon(TestCase):
                         call(['sudo', 'systemctl', 'start', 'mux.service']),
                         call(['sudo', 'systemctl', 'daemon-reload']),
                         call(['sudo', 'systemctl', 'unmask', 'telemetry.service']),
-                        call(['sudo', 'systemctl', 'unmask', 'telemetry.timer']),
-                        call(['sudo', 'systemctl', 'enable', 'telemetry.timer']),
-                        call(['sudo', 'systemctl', 'start', 'telemetry.timer'])]
+                        call(['sudo', 'systemctl', 'enable', 'telemetry.service']),
+                        call(['sudo', 'systemctl', 'start', 'telemetry.service'])]
             mocked_subprocess.check_call.assert_has_calls(expected)
 
             # Change the state to disabled
@@ -401,13 +410,115 @@ class TestHostcfgdDaemon(TestCase):
                 daemon.start()
             except TimeoutError:
                 pass
-            expected = [call(['sudo', 'systemctl', 'stop', 'telemetry.timer']),
-                        call(['sudo', 'systemctl', 'disable', 'telemetry.timer']),
-                        call(['sudo', 'systemctl', 'mask', 'telemetry.timer']),
-                        call(['sudo', 'systemctl', 'stop', 'telemetry.service']),
-                        call(['sudo', 'systemctl', 'disable', 'telemetry.timer']),
-                        call(['sudo', 'systemctl', 'mask', 'telemetry.timer'])]
+            expected = [call(['sudo', 'systemctl', 'stop', 'telemetry.service']),
+                        call(['sudo', 'systemctl', 'disable', 'telemetry.service']),
+                        call(['sudo', 'systemctl', 'mask', 'telemetry.service'])]
             mocked_subprocess.check_call.assert_has_calls(expected)
+            MockConfigDb.CONFIG_DB['FEATURE']['telemetry']['state'] = 'enabled'
+
+    @patchfs
+    def test_delayed_service(self, fs):
+        fs.create_dir(hostcfgd.FeatureHandler.SYSTEMD_SYSTEM_DIR)
+        MockConfigDb.event_queue = [('FEATURE', 'dhcp_relay'),
+                                ('FEATURE', 'mux'),
+                                ('FEATURE', 'telemetry')]
+        MockConfigDb.CONFIG_DB['PORT_TABLE'] = {'PortInitDone': {'lanes': '0'}, 'PortConfigDone': {'val': 'true'}}
+        MockSelect.event_queue = [('PORT_TABLE', 'PortInitDone')]
+        daemon = hostcfgd.HostConfigDaemon()
+        daemon.register_callbacks()
+        with mock.patch('hostcfgd.subprocess') as mocked_subprocess:
+            popen_mock = mock.Mock()
+            attrs = {'communicate.return_value': ('output', 'error')}
+            popen_mock.configure_mock(**attrs)
+            mocked_subprocess.Popen.return_value = popen_mock
+            try:
+                daemon.start()
+            except TimeoutError:
+                pass
+            expected = [call(['sudo', 'systemctl', 'daemon-reload']),
+                        call(['sudo', 'systemctl', 'unmask', 'dhcp_relay.service']),
+                        call(['sudo', 'systemctl', 'enable', 'dhcp_relay.service']),
+                        call(['sudo', 'systemctl', 'start', 'dhcp_relay.service']),
+                        call(['sudo', 'systemctl', 'daemon-reload']),
+                        call(['sudo', 'systemctl', 'unmask', 'mux.service']),
+                        call(['sudo', 'systemctl', 'enable', 'mux.service']),
+                        call(['sudo', 'systemctl', 'start', 'mux.service']),
+                        call(['sudo', 'systemctl', 'daemon-reload']),
+                        call(['sudo', 'systemctl', 'unmask', 'telemetry.service']),
+                        call(['sudo', 'systemctl', 'enable', 'telemetry.service']),
+                        call(['sudo', 'systemctl', 'start', 'telemetry.service'])]
+
+            mocked_subprocess.check_call.assert_has_calls(expected)
+
+    @patchfs
+    def test_advanced_reboot(self, fs):
+        fs.create_dir(hostcfgd.FeatureHandler.SYSTEMD_SYSTEM_DIR)
+        MockConfigDb.event_queue = [('FEATURE', 'dhcp_relay'),
+                                ('FEATURE', 'mux'),
+                                ('FEATURE', 'telemetry')]
+        MockRestartWaiter.advancedReboot = True
+        daemon = hostcfgd.HostConfigDaemon()
+        daemon.register_callbacks()
+        with mock.patch('hostcfgd.subprocess') as mocked_subprocess:
+            popen_mock = mock.Mock()
+            attrs = {'communicate.return_value': ('output', 'error')}
+            popen_mock.configure_mock(**attrs)
+            mocked_subprocess.Popen.return_value = popen_mock
+            try:
+                daemon.start()
+            except TimeoutError:
+                pass
+            expected = [call(['sudo', 'systemctl', 'daemon-reload']),
+                        call(['sudo', 'systemctl', 'unmask', 'dhcp_relay.service']),
+                        call(['sudo', 'systemctl', 'enable', 'dhcp_relay.service']),
+                        call(['sudo', 'systemctl', 'start', 'dhcp_relay.service']),
+                        call(['sudo', 'systemctl', 'daemon-reload']),
+                        call(['sudo', 'systemctl', 'unmask', 'mux.service']),
+                        call(['sudo', 'systemctl', 'enable', 'mux.service']),
+                        call(['sudo', 'systemctl', 'start', 'mux.service']),
+                        call(['sudo', 'systemctl', 'daemon-reload']),
+                        call(['sudo', 'systemctl', 'unmask', 'telemetry.service']),
+                        call(['sudo', 'systemctl', 'enable', 'telemetry.service']),
+                        call(['sudo', 'systemctl', 'start', 'telemetry.service'])]
+
+            mocked_subprocess.check_call.assert_has_calls(expected)
+        MockRestartWaiter.advancedReboot = False
+
+    @patchfs
+    def test_portinit_timeout(self, fs):
+        fs.create_dir(hostcfgd.FeatureHandler.SYSTEMD_SYSTEM_DIR)
+        old_timeout = hostcfgd.PORT_INIT_TIMEOUT_SEC
+        MockConfigDb.event_queue = [('FEATURE', 'dhcp_relay'),
+                                    ('FEATURE', 'mux'),
+                                    ('FEATURE', 'telemetry')]
+        hostcfgd.PORT_INIT_TIMEOUT_SEC = 0.1
+        daemon = hostcfgd.HostConfigDaemon()
+        daemon.register_callbacks()
+        with mock.patch('hostcfgd.subprocess') as mocked_subprocess:
+            popen_mock = mock.Mock()
+            attrs = {'communicate.return_value': ('output', 'error')}
+            popen_mock.configure_mock(**attrs)
+            mocked_subprocess.Popen.return_value = popen_mock
+            try:
+                daemon.start()
+            except TimeoutError:
+                pass
+            time.sleep(hostcfgd.PORT_INIT_TIMEOUT_SEC * 2)
+            expected = [call(['sudo', 'systemctl', 'daemon-reload']),
+                        call(['sudo', 'systemctl', 'unmask', 'dhcp_relay.service']),
+                        call(['sudo', 'systemctl', 'enable', 'dhcp_relay.service']),
+                        call(['sudo', 'systemctl', 'start', 'dhcp_relay.service']),
+                        call(['sudo', 'systemctl', 'daemon-reload']),
+                        call(['sudo', 'systemctl', 'unmask', 'mux.service']),
+                        call(['sudo', 'systemctl', 'enable', 'mux.service']),
+                        call(['sudo', 'systemctl', 'start', 'mux.service']),
+                        call(['sudo', 'systemctl', 'daemon-reload']),
+                        call(['sudo', 'systemctl', 'unmask', 'telemetry.service']),
+                        call(['sudo', 'systemctl', 'enable', 'telemetry.service']),
+                        call(['sudo', 'systemctl', 'start', 'telemetry.service'])]
+
+            mocked_subprocess.check_call.assert_has_calls(expected)
+        hostcfgd.PORT_INIT_TIMEOUT_SEC = old_timeout
 
     def test_loopback_events(self):
         MockConfigDb.set_config_db(HOSTCFG_DAEMON_CFG_DB)

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -260,7 +260,7 @@ class TestFeatureHandler(TestCase):
         mock_db.mod_entry = mock.MagicMock()
         mock_feature_state_table = mock.MagicMock()
 
-        feature_handler = hostcfgd.FeatureHandler(mock_db, mock_feature_state_table, {})
+        feature_handler = hostcfgd.FeatureHandler(mock_db, mock_feature_state_table, {}, False)
         feature_table = {
             'sflow': {
                 'state': 'enabled',
@@ -275,14 +275,14 @@ class TestFeatureHandler(TestCase):
         mock_db.mod_entry.assert_called_with('FEATURE', 'sflow', {'state': 'enabled'})
         mock_db.mod_entry.reset_mock()
 
-        feature_handler = hostcfgd.FeatureHandler(mock_db, mock_feature_state_table, {})
+        feature_handler = hostcfgd.FeatureHandler(mock_db, mock_feature_state_table, {}, False)
         mock_db.get_entry.return_value = {
             'state': 'disabled',
         }
         feature_handler.sync_state_field(feature_table)
         mock_db.mod_entry.assert_not_called()
 
-        feature_handler = hostcfgd.FeatureHandler(mock_db, mock_feature_state_table, {})
+        feature_handler = hostcfgd.FeatureHandler(mock_db, mock_feature_state_table, {}, False)
         feature_table = {
             'sflow': {
                 'state': 'always_enabled',
@@ -296,7 +296,7 @@ class TestFeatureHandler(TestCase):
         mock_db.mod_entry.assert_called_with('FEATURE', 'sflow', {'state': 'always_enabled'})
         mock_db.mod_entry.reset_mock()
 
-        feature_handler = hostcfgd.FeatureHandler(mock_db, mock_feature_state_table, {})
+        feature_handler = hostcfgd.FeatureHandler(mock_db, mock_feature_state_table, {}, False)
         mock_db.get_entry.return_value = {
             'state': 'some template',
         }

--- a/tests/hostcfgd/test_passwh_vectors.py
+++ b/tests/hostcfgd/test_passwh_vectors.py
@@ -30,7 +30,7 @@ HOSTCFGD_TEST_PASSWH_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"
@@ -69,7 +69,7 @@ HOSTCFGD_TEST_PASSWH_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"
@@ -108,7 +108,7 @@ HOSTCFGD_TEST_PASSWH_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"
@@ -147,7 +147,7 @@ HOSTCFGD_TEST_PASSWH_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"
@@ -186,7 +186,7 @@ HOSTCFGD_TEST_PASSWH_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"
@@ -225,7 +225,7 @@ HOSTCFGD_TEST_PASSWH_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"

--- a/tests/hostcfgd/test_radius_vectors.py
+++ b/tests/hostcfgd/test_radius_vectors.py
@@ -18,7 +18,7 @@ HOSTCFGD_TEST_RADIUS_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"
@@ -73,7 +73,7 @@ HOSTCFGD_TEST_RADIUS_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"
@@ -129,7 +129,7 @@ HOSTCFGD_TEST_RADIUS_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"
@@ -160,7 +160,7 @@ HOSTCFGD_TEST_RADIUS_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"

--- a/tests/hostcfgd/test_tacacs_vectors.py
+++ b/tests/hostcfgd/test_tacacs_vectors.py
@@ -18,7 +18,7 @@ HOSTCFGD_TEST_TACACS_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"
@@ -80,7 +80,7 @@ HOSTCFGD_TEST_TACACS_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"
@@ -142,7 +142,7 @@ HOSTCFGD_TEST_TACACS_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"
@@ -204,7 +204,7 @@ HOSTCFGD_TEST_TACACS_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"

--- a/tests/hostcfgd/test_vectors.py
+++ b/tests/hostcfgd/test_vectors.py
@@ -31,7 +31,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] != 'ToRRouter') %}enabled{% else %}disabled{% endif %}"
@@ -40,7 +40,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "local",
                         "state": "{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %}enabled{% else %}always_disabled{% endif %}"
@@ -49,7 +49,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "True",
+                        "delayed": "True",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled",
@@ -63,7 +63,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"
@@ -72,7 +72,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "local",
                         "state": "enabled"
@@ -81,7 +81,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "True",
+                        "delayed": "True",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled",
@@ -97,9 +97,8 @@ HOSTCFGD_TEST_VECTOR = [
                 call(["sudo", "systemctl", "enable", "mux.service"]),
                 call(["sudo", "systemctl", "start", "mux.service"]),
                 call(["sudo", "systemctl", "unmask", "telemetry.service"]),
-                call(["sudo", "systemctl", "unmask", "telemetry.timer"]),
-                call(["sudo", "systemctl", "enable", "telemetry.timer"]),
-                call(["sudo", "systemctl", "start", "telemetry.timer"]),
+                call(["sudo", "systemctl", "enable", "telemetry.service"]),
+                call(["sudo", "systemctl", "start", "telemetry.service"]),
             ],
             "daemon_reload_subprocess_call": [
                 call(["sudo", "systemctl", "daemon-reload"]),
@@ -135,7 +134,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] != 'ToRRouter') %}enabled{% else %}disabled{% endif %}"
@@ -144,7 +143,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "local",
                         "state": "{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %}enabled{% else %}always_disabled{% endif %}"
@@ -153,7 +152,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "True",
+                        "delayed": "True",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled",
@@ -163,7 +162,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "local",
                         "state": "always_enabled"
@@ -176,7 +175,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "disabled"
@@ -185,7 +184,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "local",
                         "state": "always_disabled"
@@ -194,7 +193,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "True",
+                        "delayed": "True",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled",
@@ -204,7 +203,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "local",
                         "state": "always_enabled"
@@ -216,9 +215,8 @@ HOSTCFGD_TEST_VECTOR = [
                 call(["sudo", "systemctl", "disable", "mux.service"]),
                 call(["sudo", "systemctl", "mask", "mux.service"]),
                 call(["sudo", "systemctl", "unmask", "telemetry.service"]),
-                call(["sudo", "systemctl", "unmask", "telemetry.timer"]),
-                call(["sudo", "systemctl", "enable", "telemetry.timer"]),
-                call(["sudo", "systemctl", "start", "telemetry.timer"]),
+                call(["sudo", "systemctl", "enable", "telemetry.service"]),
+                call(["sudo", "systemctl", "start", "telemetry.service"]),
                 call(["sudo", "systemctl", "unmask", "sflow.service"]),
                 call(["sudo", "systemctl", "enable", "sflow.service"]),
                 call(["sudo", "systemctl", "start", "sflow.service"]),
@@ -257,7 +255,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] != 'ToRRouter') %}enabled{% else %}disabled{% endif %}"
@@ -266,7 +264,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "local",
                         "state": "{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %}enabled{% else %}always_disabled{% endif %}"
@@ -275,7 +273,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "True",
+                        "delayed": "True",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled",
@@ -289,7 +287,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "disabled"
@@ -298,7 +296,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "local",
                         "state": "always_disabled"
@@ -307,7 +305,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "True",
+                        "delayed": "True",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled",
@@ -320,9 +318,8 @@ HOSTCFGD_TEST_VECTOR = [
                 call(["sudo", "systemctl", "disable", "mux.service"]),
                 call(["sudo", "systemctl", "mask", "mux.service"]),
                 call(["sudo", "systemctl", "unmask", "telemetry.service"]),
-                call(["sudo", "systemctl", "unmask", "telemetry.timer"]),
-                call(["sudo", "systemctl", "enable", "telemetry.timer"]),
-                call(["sudo", "systemctl", "start", "telemetry.timer"]),
+                call(["sudo", "systemctl", "enable", "telemetry.service"]),
+                call(["sudo", "systemctl", "start", "telemetry.service"]),
             ],
             "daemon_reload_subprocess_call": [
                 call(["sudo", "systemctl", "daemon-reload"]),
@@ -358,7 +355,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"
@@ -367,7 +364,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "local",
                         "state": "{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %}enabled{% else %}always_disabled{% endif %}"
@@ -376,7 +373,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "True",
+                        "delayed": "True",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled",
@@ -390,7 +387,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"
@@ -399,7 +396,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "local",
                         "state": "always_disabled"
@@ -408,7 +405,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "True",
+                        "delayed": "True",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled",
@@ -424,9 +421,8 @@ HOSTCFGD_TEST_VECTOR = [
                 call(["sudo", "systemctl", "disable", "mux.service"]),
                 call(["sudo", "systemctl", "mask", "mux.service"]),
                 call(["sudo", "systemctl", "unmask", "telemetry.service"]),
-                call(["sudo", "systemctl", "unmask", "telemetry.timer"]),
-                call(["sudo", "systemctl", "enable", "telemetry.timer"]),
-                call(["sudo", "systemctl", "start", "telemetry.timer"]),
+                call(["sudo", "systemctl", "enable", "telemetry.service"]),
+                call(["sudo", "systemctl", "start", "telemetry.service"]),
             ],
             "daemon_reload_subprocess_call": [
                 call(["sudo", "systemctl", "daemon-reload"]),
@@ -463,7 +459,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] != 'ToRRouter') %}enabled{% else %}disabled{% endif %}"
@@ -472,7 +468,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "local",
                         "state": "{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %}enabled{% else %}always_disabled{% endif %}"
@@ -481,7 +477,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "True",
+                        "delayed": "True",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled",
@@ -495,7 +491,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled"
@@ -504,7 +500,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "set_owner": "local",
                         "state": "enabled"
@@ -513,7 +509,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "True",
+                        "delayed": "True",
                         "high_mem_alert": "disabled",
                         "set_owner": "kube",
                         "state": "enabled",
@@ -558,7 +554,7 @@ HOSTCFGD_TEST_VECTOR = [
                 "FEATURE": {
                     "bgp": {
                         "state": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
                         "auto_restart": "enabled",
@@ -566,7 +562,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                     "teamd": {
                         "state": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] %}disabled{% else %}enabled{% endif %}",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
                         "auto_restart": "enabled",
@@ -574,7 +570,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                     "lldp": {
                         "state": "enabled",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}False{% else %}True{% endif %}",
                         "auto_restart": "enabled",
@@ -590,7 +586,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "disabled"
                     },
@@ -598,7 +594,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
@@ -606,7 +602,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
@@ -653,7 +649,7 @@ HOSTCFGD_TEST_VECTOR = [
                 "FEATURE": {
                     "bgp": {
                         "state": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
                         "auto_restart": "enabled",
@@ -661,7 +657,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                     "teamd": {
                         "state": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] %}disabled{% else %}enabled{% endif %}",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
                         "auto_restart": "enabled",
@@ -669,7 +665,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                     "lldp": {
                         "state": "enabled",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}False{% else %}True{% endif %}",
                         "auto_restart": "enabled",
@@ -685,7 +681,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "disabled"
                     },
@@ -693,7 +689,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "disabled"
                     },
@@ -701,7 +697,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
@@ -748,7 +744,7 @@ HOSTCFGD_TEST_VECTOR = [
                 "FEATURE": {
                     "bgp": {
                         "state": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
                         "auto_restart": "enabled",
@@ -756,7 +752,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                     "teamd": {
                         "state": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] %}disabled{% else %}enabled{% endif %}",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
                         "auto_restart": "enabled",
@@ -764,7 +760,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                     "lldp": {
                         "state": "enabled",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}False{% else %}True{% endif %}",
                         "auto_restart": "enabled",
@@ -780,7 +776,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
@@ -788,7 +784,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
@@ -796,7 +792,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
@@ -847,7 +843,7 @@ HOSTCFGD_TEST_VECTOR = [
                 "FEATURE": {
                     "bgp": {
                         "state": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
                         "auto_restart": "enabled",
@@ -855,7 +851,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                     "teamd": {
                         "state": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] %}disabled{% else %}enabled{% endif %}",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
                         "auto_restart": "enabled",
@@ -863,7 +859,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                     "lldp": {
                         "state": "enabled",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}False{% else %}True{% endif %}",
                         "auto_restart": "enabled",
@@ -879,7 +875,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
@@ -887,7 +883,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
@@ -895,7 +891,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
@@ -947,7 +943,7 @@ HOSTCFGD_TEST_VECTOR = [
                 "FEATURE": {
                     "bgp": {
                         "state": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "False",
                         "has_per_asic_scope": "True",
                         "auto_restart": "enabled",
@@ -955,7 +951,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                     "teamd": {
                         "state": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] %}disabled{% else %}enabled{% endif %}",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "False",
                         "has_per_asic_scope": "True",
                         "auto_restart": "enabled",
@@ -963,7 +959,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                     "lldp": {
                         "state": "enabled",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}False{% else %}True{% endif %}",
                         "auto_restart": "enabled",
@@ -979,7 +975,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "False",
                         "has_per_asic_scope": "True",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "disabled"
                     },
@@ -987,7 +983,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "False",
                         "has_per_asic_scope": "True",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
@@ -995,7 +991,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
@@ -1060,7 +1056,7 @@ HOSTCFGD_TEST_VECTOR = [
                 "FEATURE": {
                     "bgp": {
                         "state": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "False",
                         "has_per_asic_scope": "True",
                         "auto_restart": "enabled",
@@ -1068,7 +1064,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                     "teamd": {
                         "state": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] %}disabled{% else %}enabled{% endif %}",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "False",
                         "has_per_asic_scope": "True",
                         "auto_restart": "enabled",
@@ -1076,7 +1072,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                     "lldp": {
                         "state": "enabled",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}False{% else %}True{% endif %}",
                         "auto_restart": "enabled",
@@ -1084,7 +1080,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                     "macsec": {
                         "state": "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and DEVICE_RUNTIME_METADATA['MACSEC_SUPPORTED'] %}enabled{% else %}disabled{% endif %}",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "has_global_scope": "False",
                         "has_per_asic_scope": "True",
                         "auto_restart": "enabled",
@@ -1098,7 +1094,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "False",
                         "has_per_asic_scope": "True",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
@@ -1106,7 +1102,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "False",
                         "has_per_asic_scope": "True",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
@@ -1114,7 +1110,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
@@ -1122,7 +1118,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "has_global_scope": "False",
                         "has_per_asic_scope": "True",
-                        "has_timer": "False",
+                        "delayed": "False",
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     }
@@ -1196,7 +1192,7 @@ HOSTCFG_DAEMON_CFG_DB = {
             "auto_restart": "enabled",
             "has_global_scope": "True",
             "has_per_asic_scope": "False",
-            "has_timer": "False",
+            "delayed": "False",
             "high_mem_alert": "disabled",
             "set_owner": "kube",
             "state": "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] != 'ToRRouter') %}enabled{% else %}disabled{% endif %}"
@@ -1205,7 +1201,7 @@ HOSTCFG_DAEMON_CFG_DB = {
             "auto_restart": "enabled",
             "has_global_scope": "True",
             "has_per_asic_scope": "False",
-            "has_timer": "False",
+            "delayed": "False",
             "high_mem_alert": "disabled",
             "set_owner": "local",
             "state": "{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %}enabled{% else %}always_disabled{% endif %}"
@@ -1214,7 +1210,7 @@ HOSTCFG_DAEMON_CFG_DB = {
             "auto_restart": "enabled",
             "has_global_scope": "True",
             "has_per_asic_scope": "False",
-            "has_timer": "True",
+            "delayed": "True",
             "high_mem_alert": "disabled",
             "set_owner": "kube",
             "state": "enabled",


### PR DESCRIPTION
Backporting https://github.com/sonic-net/sonic-host-services/pull/45
Code changes for config reload Enhancement https://github.com/sonic-net/SONiC/pull/1203.
Enhancing config reload to sequence the services and faster system initialization.

Immediately restart the critical services during config reload.
The non critical should be started only after all the ports are initialized.
Services can be configured to be started immediately or delayed. This can be using a field in FEATURE table.
The existing timers should be removed by this event driven approach.
This flow is applicable in case of all reboots (warm/fast/cold) as well as config reload.