### PR TITLE
Fix issue: hostcfgd unit test might be affected by other during parallel build

### DIFF
--- a/tests/hostcfgd/conftest.py
+++ b/tests/hostcfgd/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from sonic_py_common import device_info
+from unittest import mock
+
+@pytest.fixture(autouse=True, scope='session')
+def mock_get_device_runtime_metadata():
+    device_info.get_device_runtime_metadata = mock.MagicMock(return_value={})


### PR DESCRIPTION
**Why I did this?**

hostcfgd unit test failed sporadically:

```
15:18:56      def get_path_to_platform_dir():
15:18:56          """
15:18:56          Retreives the paths to the device's platform directory
15:18:56      
15:18:56          Returns:
15:18:56              A string containing the path to the platform directory of the device
15:18:56          """
15:18:56          # Get platform
15:18:56          platform = get_platform()
15:18:56      
15:18:56          # Determine whether we're running in a container or on the host
15:18:56          platform_path_host = os.path.join(HOST_DEVICE_PATH, platform)
15:18:56      
15:18:56          if os.path.isdir(CONTAINER_PLATFORM_PATH):
15:18:56              platform_path = CONTAINER_PLATFORM_PATH
15:18:56          elif os.path.isdir(platform_path_host):
15:18:56              platform_path = platform_path_host
15:18:56          else:
15:18:56  >           raise OSError("Failed to locate platform directory")
15:18:56  E           OSError: Failed to locate platform directory
```

After investigation, we found that this error is caused by parallel build which runs another test case test_j2files.py (https://github.com/sonic-net/sonic-buildimage/blob/96cac8e9184c3a81e8abf0f2b58c5a33afe25166/src/sonic-config-engine/tests/test_j2files.py#L507). In test_j2files.py, it creates a fake /host/machine.conf file which would cause hostcfgd unit test try to access platform folder, and platform folder does not exist on unit test environment.

**How I fix this?**

Mock the function device_info.get_device_runtime_metadata in hostcfgd.

**How I verify this?**

Running unit test and get passed.