### PR TITLE
Disable systemd auto-restart of dependent services for spineRouters

### DIFF
--- a/scripts/featured
+++ b/scripts/featured
@@ -319,7 +319,20 @@ class FeatureHandler(object):
         Returns:
             None.
         """
-        restart_field_str = "always" if "enabled" in feature_config.auto_restart else "no"
+        # As per the current code(due to various dependencies) SWSS service stop/start also stops/starts the dependent services(syncd, teamd, bgpd etc)
+        # There is an issue seen of syncd service getting stopped twice upon a critical process crash in syncd service due to above reason.
+        # Also early start of syncd service has traffic impact on VOQ chassis.
+        # to fix the above issue, we are disabling the auto restart of syncd service as it will be started by swss service.
+        # This change can be extended to other dependent services as well in future and also on pizza box platforms.
+
+        device_type = self._device_config.get('DEVICE_METADATA', {}).get('localhost', {}).get('type')
+        is_dependent_service = feature_config.name in ['syncd', 'gbsyncd']
+        if device_type == 'SpineRouter' and is_dependent_service:
+            syslog.syslog(syslog.LOG_INFO, "Skipped setting Restart field in systemd for {}".format(feature_config.name))
+            restart_field_str = "no"
+        else:
+            restart_field_str = "always" if "enabled" in feature_config.auto_restart else "no"
+
         feature_systemd_config = "[Service]\nRestart={}\n".format(restart_field_str)
         feature_names, feature_suffixes = self.get_multiasic_feature_instances(feature_config)
 

--- a/tests/featured/test_vectors.py
+++ b/tests/featured/test_vectors.py
@@ -532,8 +532,14 @@ FEATURED_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "high_mem_alert": "disabled"
                     },
-
-
+                    "syncd": {
+                        "state": "enabled",
+                        "delayed": "False",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "auto_restart": "enabled",
+                        "high_mem_alert": "disabled"
+                    },
                 },
             },
             "expected_config_db": {
@@ -562,12 +568,24 @@ FEATURED_TEST_VECTOR = [
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
+                    "syncd": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "delayed": "False",
+                        "high_mem_alert": "disabled",
+                        "state": "enabled"
+                    },
                 },
             },
             "enable_feature_subprocess_calls": [
                 call(["sudo", "systemctl", "stop", "bgp.service"]),
                 call(["sudo", "systemctl", "disable", "bgp.service"]),
                 call(["sudo", "systemctl", "mask", "bgp.service"]),
+                call(["sudo", "systemctl", "unmask", "syncd.service"]),
+                call(["sudo", "systemctl", "enable", "syncd.service"]),
+                call(["sudo", "systemctl", "start", "syncd.service"]),
+
             ],
             "daemon_reload_subprocess_call": [
                 call(["sudo", "systemctl", "daemon-reload"]),
@@ -620,8 +638,14 @@ FEATURED_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "high_mem_alert": "disabled"
                     },
-
-
+                    "syncd": {
+                        "state": "enabled",
+                        "delayed": "False",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "auto_restart": "enabled",
+                        "high_mem_alert": "disabled"
+                    },
                 },
             },
             "expected_config_db": {
@@ -650,12 +674,24 @@ FEATURED_TEST_VECTOR = [
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
+                    "syncd": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "delayed": "False",
+                        "high_mem_alert": "disabled",
+                        "state": "enabled"
+                    },
                 },
             },
             "enable_feature_subprocess_calls": [
                 call(["sudo", "systemctl", "stop", "bgp.service"]),
                 call(["sudo", "systemctl", "disable", "bgp.service"]),
                 call(["sudo", "systemctl", "mask", "bgp.service"]),
+                call(["sudo", "systemctl", "unmask", "syncd.service"]),
+                call(["sudo", "systemctl", "enable", "syncd.service"]),
+                call(["sudo", "systemctl", "start", "syncd.service"]),
+
             ],
             "daemon_reload_subprocess_call": [
                 call(["sudo", "systemctl", "daemon-reload"]),
@@ -708,8 +744,14 @@ FEATURED_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "high_mem_alert": "disabled"
                     },
-
-
+                    "syncd": {
+                        "state": "enabled",
+                        "delayed": "False",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "auto_restart": "enabled",
+                        "high_mem_alert": "disabled"
+                    },
                 },
             },
             "expected_config_db": {
@@ -738,6 +780,14 @@ FEATURED_TEST_VECTOR = [
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
+                    "syncd": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "delayed": "False",
+                        "high_mem_alert": "disabled",
+                        "state": "enabled"
+                    },
                 },
             },
             "enable_feature_subprocess_calls": [
@@ -747,7 +797,10 @@ FEATURED_TEST_VECTOR = [
                 call(["sudo", "systemctl", "start", "teamd.service"]),
                 call(["sudo", "systemctl", "enable", "teamd.service"]),
                 call(["sudo", "systemctl", "unmask", "teamd.service"]),
- 
+                call(["sudo", "systemctl", "unmask", "syncd.service"]),
+                call(["sudo", "systemctl", "enable", "syncd.service"]),
+                call(["sudo", "systemctl", "start", "syncd.service"]),
+
             ],
             "daemon_reload_subprocess_call": [
                 call(["sudo", "systemctl", "daemon-reload"]),
@@ -800,8 +853,14 @@ FEATURED_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "high_mem_alert": "disabled"
                     },
-
-
+                    "syncd": {
+                        "state": "enabled",
+                        "delayed": "False",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "auto_restart": "enabled",
+                        "high_mem_alert": "disabled"
+                    },
                 },
             },
             "expected_config_db": {
@@ -830,6 +889,14 @@ FEATURED_TEST_VECTOR = [
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
+                    "syncd": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "delayed": "False",
+                        "high_mem_alert": "disabled",
+                        "state": "enabled"
+                    },
                 },
             },
             "enable_feature_subprocess_calls": [
@@ -839,7 +906,10 @@ FEATURED_TEST_VECTOR = [
                 call(["sudo", "systemctl", "start", "teamd.service"]),
                 call(["sudo", "systemctl", "enable", "teamd.service"]),
                 call(["sudo", "systemctl", "unmask", "teamd.service"]),
- 
+                call(["sudo", "systemctl", "unmask", "syncd.service"]),
+                call(["sudo", "systemctl", "enable", "syncd.service"]),
+                call(["sudo", "systemctl", "start", "syncd.service"]),
+
             ],
             "daemon_reload_subprocess_call": [
                 call(["sudo", "systemctl", "daemon-reload"]),
@@ -893,8 +963,14 @@ FEATURED_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "high_mem_alert": "disabled"
                     },
-
-
+                    "syncd": {
+                        "state": "enabled",
+                        "delayed": "False",
+                        "has_global_scope": "False",
+                        "has_per_asic_scope": "True",
+                        "auto_restart": "enabled",
+                        "high_mem_alert": "disabled"
+                    },
                 },
             },
             "expected_config_db": {
@@ -923,6 +999,14 @@ FEATURED_TEST_VECTOR = [
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
+                    "syncd": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "False",
+                        "has_per_asic_scope": "True",
+                        "delayed": "False",
+                        "high_mem_alert": "disabled",
+                        "state": "enabled"
+                    },
                 },
             },
             "enable_feature_subprocess_calls": [
@@ -944,7 +1028,12 @@ FEATURED_TEST_VECTOR = [
                 call(["sudo", "systemctl", "stop", "lldp@1.service"]),
                 call(["sudo", "systemctl", "disable", "lldp@1.service"]),
                 call(["sudo", "systemctl", "mask", "lldp@1.service"]),
- 
+                call(["sudo", "systemctl", "start", "syncd@0.service"]),
+                call(["sudo", "systemctl", "enable", "syncd@0.service"]),
+                call(["sudo", "systemctl", "unmask", "syncd@0.service"]),
+                call(["sudo", "systemctl", "start", "syncd@1.service"]),
+                call(["sudo", "systemctl", "enable", "syncd@1.service"]),
+                call(["sudo", "systemctl", "unmask", "syncd@1.service"]),
             ],
             "daemon_reload_subprocess_call": [
                 call(["sudo", "systemctl", "daemon-reload"]),


### PR DESCRIPTION
Description:
Issue details and RCA here. https://github.com/sonic-net/sonic-buildimage/issues/16991

MSFT ADO:
25422412

How I did it:
Currently featured script overrides the systemd service files of the features depending upon auto_restart enable/disable.
I am skipping dependent features(syncd, gbsyncd for now) to have "RESTART=Always"
 for them to not start immidiately, and instead get started by SWSS through swss.sh script.
The issue of syncd double stop is also applicable to pizza box platforms, however no traffic impact is seen there, where as on VOQ chassis, we do see traffic impact due to early start of syncd service.
The change can be extended to pizza box platforms as well in future once it gets vetted on SpineRouters.

How to verify it
1.  extended Unit tests to cover this scenario.
2. followed same steps as mentioned in https://github.com/sonic-net/sonic-buildimage/issues/16991 and confirmed that
a. No traffic loss end to end
b. Dont see double stop/start of syncd service

Also Ran few more tests.

Tested on both single asic and multi-asic hw platforms.
Tested config-reload
sudo reboot
service restart
syncd process crash, orchagent process crash
Confirmed from logs, that in none of the scenario, syncd gets killed twice
