### PR TITLE
Add support to make determine/process reboot-cause services restartable

### DIFF
--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -29,6 +29,7 @@ REBOOT_CAUSE_FILE = os.path.join(REBOOT_CAUSE_DIR, "reboot-cause.txt")
 PREVIOUS_REBOOT_CAUSE_FILE = os.path.join(REBOOT_CAUSE_DIR,  "previous-reboot-cause.json")
 FIRST_BOOT_PLATFORM_FILE = "/tmp/notify_firstboot_to_platform"
 REBOOT_TYPE_KEXEC_FILE = "/proc/cmdline"
+REBOOT_PROCESSED_FILE = "/tmp/previous-reboot-cause-processed"
 # The following SONIC_BOOT_TYPEs come from the warm/fast reboot script which is in sonic-utilities
 # Because the system can be rebooted from some old versions, we have to take all possible BOOT options into consideration.
 # On 201803, 201807 we have
@@ -218,6 +219,10 @@ def main():
         sonic_logger.log_error("User {} does not have permission to execute".format(pwd.getpwuid(os.getuid()).pw_name))
         sys.exit("This utility must be run as root")
 
+    if os.path.exists(REBOOT_PROCESSED_FILE):
+        sonic_logger.log_info("User {} : reboot-cause already processed. Nothing to do. Exiting...".format(pwd.getpwuid(os.getuid()).pw_name))
+        sys.exit(0)
+
     # Create REBOOT_CAUSE_DIR if it doesn't exist
     if not os.path.exists(REBOOT_CAUSE_DIR):
         os.makedirs(REBOOT_CAUSE_DIR)
@@ -257,6 +262,10 @@ def main():
     with open(REBOOT_CAUSE_FILE, "w") as cause_file:
         cause_file.write(REBOOT_CAUSE_UNKNOWN)
 
+    # Create tmp reboot processed file to mark processing of last reboot cause during current boot.
+    # This is used to prevent reprocessing of reboot cause if this service restarts.
+    with open(REBOOT_PROCESSED_FILE, "w") as reboot_processed_file:
+        reboot_processed_file.write("processed last reboot cause")
 
 if __name__ == "__main__":
     main()

--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -29,7 +29,8 @@ REBOOT_CAUSE_FILE = os.path.join(REBOOT_CAUSE_DIR, "reboot-cause.txt")
 PREVIOUS_REBOOT_CAUSE_FILE = os.path.join(REBOOT_CAUSE_DIR,  "previous-reboot-cause.json")
 FIRST_BOOT_PLATFORM_FILE = "/tmp/notify_firstboot_to_platform"
 REBOOT_TYPE_KEXEC_FILE = "/proc/cmdline"
-REBOOT_PROCESSED_FILE = "/tmp/previous-reboot-cause-processed"
+TMP_DIR="/tmp"
+REBOOT_PROCESSED_FILE = os.path.join(TMP_DIR, "previous-reboot-cause-processed")
 # The following SONIC_BOOT_TYPEs come from the warm/fast reboot script which is in sonic-utilities
 # Because the system can be rebooted from some old versions, we have to take all possible BOOT options into consideration.
 # On 201803, 201807 we have
@@ -221,7 +222,7 @@ def main():
 
     if os.path.exists(REBOOT_PROCESSED_FILE):
         sonic_logger.log_info("User {} : reboot-cause already processed. Nothing to do. Exiting...".format(pwd.getpwuid(os.getuid()).pw_name))
-        sys.exit(0)
+        return
 
     # Create REBOOT_CAUSE_DIR if it doesn't exist
     if not os.path.exists(REBOOT_CAUSE_DIR):

--- a/tests/determine-reboot-cause_test.py
+++ b/tests/determine-reboot-cause_test.py
@@ -71,7 +71,8 @@ EXPECTED_USER_REBOOT_CAUSE_DICT = {'comment': '', 'gen_time': '2020_10_22_03_14_
 EXPECTED_KERNEL_PANIC_REBOOT_CAUSE_DICT = {'comment': '', 'gen_time': '2021_3_28_13_48_49', 'cause': 'Kernel Panic', 'user': 'N/A', 'time': 'Sun Mar 28 13:45:12 UTC 2021'}
 
 REBOOT_CAUSE_DIR="host/reboot-cause/"
-
+TMP_DIR="tmp/"
+REBOOT_PROCESSED_FILE="tmp/previous-reboot-cause-processed"
 class TestDetermineRebootCause(object):
     def test_parse_warmfast_reboot_from_proc_cmdline(self):
         with mock.patch("os.path.isfile") as mock_isfile:
@@ -179,23 +180,58 @@ class TestDetermineRebootCause(object):
                     assert additional_info == EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER
 
     @mock.patch('determine_reboot_cause.REBOOT_CAUSE_DIR', os.path.join(os.getcwd(), REBOOT_CAUSE_DIR))
+    @mock.patch('determine_reboot_cause.TMP_DIR', os.path.join(os.getcwd(), TMP_DIR))
     @mock.patch('determine_reboot_cause.REBOOT_CAUSE_HISTORY_DIR', os.path.join(os.getcwd(), 'host/reboot-cause/history/'))
     @mock.patch('determine_reboot_cause.PREVIOUS_REBOOT_CAUSE_FILE', os.path.join(os.getcwd(), 'host/reboot-cause/previous-reboot-cause.json'))
     @mock.patch('determine_reboot_cause.REBOOT_CAUSE_FILE', os.path.join(os.getcwd(),'host/reboot-cause/reboot-cause.txt'))
+    @mock.patch('determine_reboot_cause.REBOOT_PROCESSED_FILE', os.path.join(os.getcwd(),'tmp/previous-reboot-cause-processed'))
     def test_determine_reboot_cause_main_without_reboot_cause_dir(self):
         if os.path.exists(REBOOT_CAUSE_DIR):
             shutil.rmtree(REBOOT_CAUSE_DIR)
+        if not os.path.exists(TMP_DIR):
+            os.makedirs(TMP_DIR)
+        if os.path.exists(REBOOT_PROCESSED_FILE):
+            os.remove(REBOOT_PROCESSED_FILE)
         with mock.patch("os.geteuid", return_value=0):
             determine_reboot_cause.main()
             assert os.path.exists("host/reboot-cause/reboot-cause.txt") == True
             assert os.path.exists("host/reboot-cause/previous-reboot-cause.json") == True
+            assert os.path.exists(REBOOT_PROCESSED_FILE) == True
 
     @mock.patch('determine_reboot_cause.REBOOT_CAUSE_DIR', os.path.join(os.getcwd(), REBOOT_CAUSE_DIR))
+    @mock.patch('determine_reboot_cause.TMP_DIR', os.path.join(os.getcwd(), TMP_DIR))
     @mock.patch('determine_reboot_cause.REBOOT_CAUSE_HISTORY_DIR', os.path.join(os.getcwd(), 'host/reboot-cause/history/'))
     @mock.patch('determine_reboot_cause.PREVIOUS_REBOOT_CAUSE_FILE', os.path.join(os.getcwd(), 'host/reboot-cause/previous-reboot-cause.json'))
     @mock.patch('determine_reboot_cause.REBOOT_CAUSE_FILE', os.path.join(os.getcwd(),'host/reboot-cause/reboot-cause.txt'))
+    @mock.patch('determine_reboot_cause.REBOOT_PROCESSED_FILE', os.path.join(os.getcwd(),'tmp/previous-reboot-cause-processed'))
     def test_determine_reboot_cause_main_with_reboot_cause_dir(self):
+        if not os.path.exists(TMP_DIR):
+            os.makedirs(TMP_DIR)
+        if os.path.exists(REBOOT_PROCESSED_FILE):
+            os.remove(REBOOT_PROCESSED_FILE)
         with mock.patch("os.geteuid", return_value=0):
             determine_reboot_cause.main()
             assert os.path.exists("host/reboot-cause/reboot-cause.txt") == True
             assert os.path.exists("host/reboot-cause/previous-reboot-cause.json") == True   
+            assert os.path.exists(REBOOT_PROCESSED_FILE) == True
+
+    @mock.patch('determine_reboot_cause.REBOOT_CAUSE_DIR', os.path.join(os.getcwd(), REBOOT_CAUSE_DIR))
+    @mock.patch('determine_reboot_cause.TMP_DIR', os.path.join(os.getcwd(), TMP_DIR))
+    @mock.patch('determine_reboot_cause.REBOOT_CAUSE_HISTORY_DIR', os.path.join(os.getcwd(), 'host/reboot-cause/history/'))
+    @mock.patch('determine_reboot_cause.PREVIOUS_REBOOT_CAUSE_FILE', os.path.join(os.getcwd(), 'host/reboot-cause/previous-reboot-cause.json'))
+    @mock.patch('determine_reboot_cause.REBOOT_CAUSE_FILE', os.path.join(os.getcwd(),'host/reboot-cause/reboot-cause.txt'))
+    @mock.patch('determine_reboot_cause.REBOOT_PROCESSED_FILE', os.path.join(os.getcwd(),'tmp/previous-reboot-cause-processed'))
+    def test_determine_reboot_cause_test_restart(self):
+        if os.path.exists(REBOOT_CAUSE_DIR):
+            shutil.rmtree(REBOOT_CAUSE_DIR)
+        if not os.path.exists(TMP_DIR):
+            os.makedirs(TMP_DIR)
+        if not os.path.exists(REBOOT_PROCESSED_FILE):
+            os.mknod(REBOOT_PROCESSED_FILE)
+        with mock.patch("os.geteuid", return_value=0):
+            determine_reboot_cause.main()
+            assert os.path.exists("host/reboot-cause/reboot-cause.txt") == False
+            assert os.path.exists("host/reboot-cause/previous-reboot-cause.json") == False
+            assert os.path.exists(REBOOT_PROCESSED_FILE) == True
+        if os.path.exists(TMP_DIR):
+           shutil.rmtree(TMP_DIR)


### PR DESCRIPTION
Signed-off-by: anamehra <anamehra@cisco.com>

#### Why I did it
Fixes https://github.com/sonic-net/sonic-buildimage/issues/16990

This PR can be merged independently. The PR (https://github.com/sonic-net/sonic-buildimage/pull/17220) will need this host-services PR to be merged and released.

MSFT ADO: 25892864

1. determine-reboot-cause and process-reboot-cause service does not start If the database service fails to restart in the first attempt. Even if the Database service succeeds in next attempt, these reboot-cause services do not start.

2. The process-reboot-service does not restart if the docker or database service restarts, which leads to an empty reboot-cause history
3. deploy-mg from sonic-mgmt also triggers the docker service restart. The restart of the docker service caused the issue stated in 2 above. The docker restart also triggers determine-reboot-cause to restart which creates an additional reboot-cause file in history and modifies the last reboot-cause.

This PR along with sonic-buildimage PR (17220) fixes these issues by making both processes to start again when dependency meets after dependency failure, making both processes restart when the database service restarts, and preventing duplicate processing of the last reboot reason.

#### How I did it
1. Modified systemd unit files to make determine-reboot-cause and process-reboot-cause services restartable when the database service restarts.
2. On the restart, the determine-reboot-cause service should not recreate a new reboot-cause entry in the database. Added check for first start or restart to skip entry for restart case.

#### How to verify it
On single asic pizza box:
1.  Installed the image and check reboot-cause history
2. restart database service and verify that determine-reboot-cause and process-reboot-cause services also restart. Verify that reboot-cause shows correct data and no new entry is created for restart.

On Chassis:
1.  Installed the image and check reboot-cause history
2. restart the database service and verify that determine-reboot-cause and process-reboot-cause services also restart. Verify that reboot-cause shows correct data and no new entry is created for restart.
5. Reboot LC. On Supervicor, stop database-chassis service.
     Let database service on LC fail the first time. determine-reboot-cause and process-reboot-cause  would fail to start due to dependency failure
     start database-chassis on Supervisor. Database service on LC should now start successfully.
     Verify determine-reboot-cause and process-reboot-cause  also starts
     Verify show reboot-cause history output
