### PR TITLE
Fixed determine/process reboot-cause service dependency

### DIFF
--- a/data/debian/sonic-host-services-data.determine-reboot-cause.service
+++ b/data/debian/sonic-host-services-data.determine-reboot-cause.service
@@ -1,12 +1,13 @@
 [Unit]
 Description=Reboot cause determination service
-Requires=rc-local.service database.service
-After=rc-local.service database.service
+Requires=rc-local.service
+After=rc-local.service
+ConditionPathExists=!/tmp/determine-reboot-cause
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/local/bin/determine-reboot-cause
-
+ExecStartPost=/usr/bin/touch /tmp/determine-reboot-cause
 [Install]
 WantedBy=multi-user.target

--- a/data/debian/sonic-host-services-data.determine-reboot-cause.service
+++ b/data/debian/sonic-host-services-data.determine-reboot-cause.service
@@ -6,7 +6,6 @@ ConditionPathExists=!/tmp/determine-reboot-cause
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
 ExecStart=/usr/local/bin/determine-reboot-cause
 ExecStartPost=/usr/bin/touch /tmp/determine-reboot-cause
 [Install]

--- a/data/debian/sonic-host-services-data.process-reboot-cause.service
+++ b/data/debian/sonic-host-services-data.process-reboot-cause.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Retrieve the reboot cause from the history files and save them to StateDB
-Requires=database.service determine-reboot-cause.service
+Requires=database.service
 After=database.service determine-reboot-cause.service
 
 [Service]
 Type=simple
+RemainAfterExit=yes
 ExecStart=/usr/local/bin/process-reboot-cause

--- a/data/debian/sonic-host-services-data.process-reboot-cause.timer
+++ b/data/debian/sonic-host-services-data.process-reboot-cause.timer
@@ -1,7 +1,9 @@
 [Unit]
 Description=Delays process-reboot-cause until network is stably connected
+PartOf=process-reboot-cause.service
 
 [Timer]
+OnUnitActiveSec=0 sec
 OnBootSec=1min 30 sec
 Unit=process-reboot-cause.service
 


### PR DESCRIPTION
Signed-off-by: anamehra [anamehra@cisco.com](mailto:anamehra@cisco.com)

**Why I did it**
Fixes https://github.com/sonic-net/sonic-buildimage/issues/16990

MSFT ADO: **25892864**

1. determine-reboot-cause and process-reboot-cause service does not start If the database service fails to restart in the first attempt. Even if the Database service succeeds in the next attempt, these reboot-cause services do not start.

2. The process-reboot-service does not restart if the docker or database service restarts, which leads to an empty reboot-cause history

3. deploy-mg from sonic-mgmt also triggers the docker service restart. The restart of the docker service caused the issue stated in 2 above. The docker restart also triggers determine-reboot-cause to restart which creates an additional reboot-cause file in history and modifies the last reboot-cause.

**How I did it**
This PR  fixes these issues by 
1. Removing the determine-reboot-cause service's dependency on the database service. This service script does not have any dependency on database service and should be independent and run once during the boot.
The service expects the platform service publishing the hardware reboot cause to be finished before determine-reboot-cause starts. The platform service may set "Before=determine-reboot-cause" dependency in Unit file.

2.  Remove process-reboot-cause 'Require' dependency on determine-reboot-cause. This hard dependency is not required, moreover, it makes determine-reboot-cause restart if process-reboot-cause restarts which is not required as determine-reboot-cause is a one-shot service to be executed during boot.

3. Fixed timer Unit for process-reboot-cause to make it restartable once the dependency condition is met after the service has entered a dependency failed state.

**How to verify it**
On a pizza box:

1. Installed the image and check reboot-cause history
2. restart the database service and verify that determine-reboot-cause is not restarted and process-reboot-cause service is restarted. Verify that 'show reboot-cause' and 'show reboot-cause history' show correct data and no new entry is created for restart.

On Chassis:

1. Installed the image and check reboot-cause history
restart database service and verify that determine-reboot-cause is not restarted and process-reboot-cause service is restarted. Verify that 'show reboot-cause' and 'show reboot-cause history'  show correct data and no new entry is created for restart.
3. Reboot LC. On Supervicor, stop database-chassis service.
4. Let database service on LC fail the first time. determine-reboot-cause should succeed and process-reboot-cause should fail to start due to dependency failure
5. start database-chassis service on Supervisor. Database service on LC should now start successfully.
6. Verify process-reboot-cause also starts
7. Verify 'show reboot-cause history' and 'show reboot-cause' output