### PR TITLE
[cisco|express-boot]: Add support for cisco express boot in sonic-host-services

### DIFF
--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -38,6 +38,7 @@ REBOOT_TYPE_KEXEC_FILE = "/proc/cmdline"
 # To extract the commom part of them, we should have the following PATTERN
 REBOOT_TYPE_KEXEC_PATTERN_WARM = ".*SONIC_BOOT_TYPE=(warm|fastfast).*"
 REBOOT_TYPE_KEXEC_PATTERN_FAST = ".*SONIC_BOOT_TYPE=(fast|fast-reboot).*"
+REBOOT_TYPE_KEXEC_PATTERN_EXPRESS = ".*SONIC_BOOT_TYPE=(express).*"
 
 REBOOT_CAUSE_UNKNOWN = "Unknown"
 REBOOT_CAUSE_NON_HARDWARE = "Non-Hardware"
@@ -58,6 +59,9 @@ def parse_warmfast_reboot_from_proc_cmdline():
         m = re.search(REBOOT_TYPE_KEXEC_PATTERN_FAST, cause_file_kexec)
         if m and m.group(1):
             return 'fast-reboot'
+        m = re.search(REBOOT_TYPE_KEXEC_PATTERN_EXPRESS, cause_file_kexec)
+        if m and m.group(1):
+            return 'express-reboot'
     return None
 
 

--- a/tests/determine-reboot-cause_test.py
+++ b/tests/determine-reboot-cause_test.py
@@ -39,8 +39,10 @@ BOOT_IMAGE=/image-20191130.52/boot/vmlinuz-4.9.0-11-2-amd64 root=/dev/sda4 rw co
 
 EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE = "warm"
 
-PROC_CMDLINE_CONTENTS = """\
-BOOT_IMAGE=/image-20191130.52/boot/vmlinuz-4.9.0-11-2-amd64 root=/dev/sda4 rw console=tty0 console=ttyS1,9600n8 quiet net.ifnames=0 biosdevname=0 loop=image-20191130.52/fs.squashfs loopfstype=squashfs apparmor=1 security=apparmor varlog_size=4096 usbcore.autosuspend=-1 module_blacklist=gpio_ich SONIC_BOOT_TYPE=warm"""
+PROC_CMDLINE_EXPRESS_BOOT_CONTENTS = """\
+BOOT_IMAGE=/image-20191130.52/boot/vmlinuz-4.9.0-11-2-amd64 root=/dev/sda4 rw console=tty0 console=ttyS1,9600n8 quiet net.ifnames=0 biosdevname=0 loop=image-20191130.52/fs.squashfs loopfstype=squashfs apparmor=1 security=apparmor varlog_size=4096 usbcore.autosuspend=-1 module_blacklist=gpio_ich SONIC_BOOT_TYPE=express"""
+
+EXPECTED_PARSE_EXPRESS_REBOOT_FROM_PROC_CMDLINE = "express-reboot"
 
 REBOOT_CAUSE_CONTENTS = """\
 User issued 'warm-reboot' command [User: admin, Time: Mon Nov  2 22:37:45 UTC 2020]"""
@@ -81,6 +83,11 @@ class TestDetermineRebootCause(object):
                 result = determine_reboot_cause.parse_warmfast_reboot_from_proc_cmdline()
                 assert result == EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE
                 open_mocked.assert_called_once_with("/proc/cmdline")
+            express_mocked = mock.mock_open(read_data=PROC_CMDLINE_EXPRESS_BOOT_CONTENTS)
+            with mock.patch("{}.open".format(BUILTINS), express_mocked):
+                result = determine_reboot_cause.parse_warmfast_reboot_from_proc_cmdline()
+                assert result == EXPECTED_PARSE_EXPRESS_REBOOT_FROM_PROC_CMDLINE
+                express_mocked.assert_called_once_with("/proc/cmdline")
 
     def test_find_software_reboot_cause_user(self):
         with mock.patch("os.path.isfile") as mock_isfile:


### PR DESCRIPTION
Why I did it
Add support of express boot for cisco 8000 platform

How I did it
Add support of express boot for cisco 8000 platform. There are 4 PRs for this feature:
https://github.com/sonic-net/sonic-buildimage/pull/17369
https://github.com/sonic-net/sonic-sairedis/pull/1329
https://github.com/sonic-net/sonic-utilities/pull/3056
https://github.com/sonic-net/sonic-host-services/pull/90

How to verify it
execute express-reboot script