### PR TITLE
Disable systemd auto-restart of dependent services for spineRouters

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -454,7 +454,20 @@ class FeatureHandler(object):
         Returns:
             None.
         """
-        restart_field_str = "always" if "enabled" in feature_config.auto_restart else "no"
+        # As per the current code(due to various dependencies) SWSS service stop/start also stops/starts the dependent services(syncd, teamd, bgpd etc)
+        # There is an issue seen of syncd service getting stopped twice upon a critical process crash in syncd service due to above reason.
+        # Also early start of syncd service has traffic impact on VOQ chassis.
+        # to fix the above issue, we are disabling the auto restart of syncd service as it will be started by swss service.
+        # This change can be extended to other dependent services as well in future and also on pizza box platforms.
+
+        device_type = self._device_config.get('DEVICE_METADATA', {}).get('localhost', {}).get('type')
+        is_dependent_service = feature_config.name in ['syncd', 'gbsyncd']
+        if device_type == 'SpineRouter' and is_dependent_service:
+            syslog.syslog(syslog.LOG_INFO, "Skipped setting Restart field in systemd for {}".format(feature_config.name))
+            restart_field_str = "no"
+        else:
+            restart_field_str = "always" if "enabled" in feature_config.auto_restart else "no"
+
         feature_systemd_config = "[Service]\nRestart={}\n".format(restart_field_str)
         feature_names, feature_suffixes = self.get_multiasic_feature_instances(feature_config)
 

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -51,7 +51,7 @@ class TestFeatureHandler(TestCase):
 
         return True if not ddiff else False
 
-    def checks_systemd_config_file(self, feature_table, feature_systemd_name_map=None):
+    def checks_systemd_config_file(self, device_type, feature_table, feature_systemd_name_map=None):
         """Checks whether the systemd configuration file of each feature was created or not
         and whether the `Restart=` field in the file is set correctly or not.
 
@@ -68,6 +68,7 @@ class TestFeatureHandler(TestCase):
                                                 'auto_restart.conf')
 
         for feature_name in feature_table:
+            is_dependent_feature = True if feature_name in ['syncd', 'gbsyncd'] else False
             auto_restart_status = feature_table[feature_name].get('auto_restart', 'disabled')
             if "enabled" in auto_restart_status:
                 auto_restart_status = "enabled"
@@ -83,7 +84,10 @@ class TestFeatureHandler(TestCase):
 
                 with open(feature_systemd_config_file_path) as systemd_config_file:
                     status = systemd_config_file.read().strip()
-                assert status == '[Service]\nRestart={}'.format(truth_table[auto_restart_status])
+                    if device_type == 'SpineRouter' and is_dependent_feature:
+                        assert status == '[Service]\nRestart=no'
+                    else:
+                        assert status == '[Service]\nRestart={}'.format(truth_table[auto_restart_status])
 
     def get_state_db_set_calls(self, feature_table):
         """Returns a Mock call objects which recorded the `set` calls to `FEATURE` table in `STATE_DB`.
@@ -140,6 +144,7 @@ class TestFeatureHandler(TestCase):
                             device_config = {}
                             device_config['DEVICE_METADATA'] = MockConfigDb.CONFIG_DB['DEVICE_METADATA']
                             device_config.update(config_data['device_runtime_metadata'])
+                            device_type = MockConfigDb.CONFIG_DB['DEVICE_METADATA']['localhost']['type']
 
                             feature_handler = hostcfgd.FeatureHandler(MockConfigDb(), feature_state_table_mock,
                                                                       device_config, False)
@@ -166,13 +171,13 @@ class TestFeatureHandler(TestCase):
 
                             feature_table_state_db_calls = self.get_state_db_set_calls(feature_table)
 
-                            self.checks_systemd_config_file(config_data['config_db']['FEATURE'], feature_systemd_name_map)
+                            self.checks_systemd_config_file(device_type, config_data['config_db']['FEATURE'], feature_systemd_name_map)
                             mocked_subprocess.check_call.assert_has_calls(config_data['enable_feature_subprocess_calls'],
                                                                           any_order=True)
                             mocked_subprocess.check_call.assert_has_calls(config_data['daemon_reload_subprocess_call'],
                                                                           any_order=True)
                             feature_state_table_mock.set.assert_has_calls(feature_table_state_db_calls)
-                            self.checks_systemd_config_file(config_data['config_db']['FEATURE'], feature_systemd_name_map)
+                            self.checks_systemd_config_file(device_type, config_data['config_db']['FEATURE'], feature_systemd_name_map)
 
     @parameterized.expand(HOSTCFGD_TEST_VECTOR)
     @patchfs
@@ -204,6 +209,7 @@ class TestFeatureHandler(TestCase):
                         device_config = {}
                         device_config['DEVICE_METADATA'] = MockConfigDb.CONFIG_DB['DEVICE_METADATA']
                         device_config.update(config_data['device_runtime_metadata'])
+                        device_type = MockConfigDb.CONFIG_DB['DEVICE_METADATA']['localhost']['type']
                         feature_handler = hostcfgd.FeatureHandler(MockConfigDb(), feature_state_table_mock,
                                                                   device_config, False)
                         feature_handler.enable_delayed_service = True
@@ -217,7 +223,7 @@ class TestFeatureHandler(TestCase):
                             feature_names, _ = feature_handler.get_multiasic_feature_instances(feature)
                             feature_systemd_name_map[feature_name] = feature_names
 
-                        self.checks_systemd_config_file(config_data['config_db']['FEATURE'], feature_systemd_name_map)
+                        self.checks_systemd_config_file(device_type, config_data['config_db']['FEATURE'], feature_systemd_name_map)
                         mocked_subprocess.check_call.assert_has_calls(config_data['enable_feature_subprocess_calls'],
                                                                       any_order=True)
                         mocked_subprocess.check_call.assert_has_calls(config_data['daemon_reload_subprocess_call'],

--- a/tests/hostcfgd/test_vectors.py
+++ b/tests/hostcfgd/test_vectors.py
@@ -576,8 +576,14 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "high_mem_alert": "disabled"
                     },
-
-
+                    "syncd": {
+                        "state": "enabled",
+                        "delayed": "False",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "auto_restart": "enabled",
+                        "high_mem_alert": "disabled"
+                    },
                 },
             },
             "expected_config_db": {
@@ -606,12 +612,23 @@ HOSTCFGD_TEST_VECTOR = [
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
+                    "syncd": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "delayed": "False",
+                        "high_mem_alert": "disabled",
+                        "state": "enabled"
+                    },
                 },
             },
             "enable_feature_subprocess_calls": [
                 call(["sudo", "systemctl", "stop", "bgp.service"]),
                 call(["sudo", "systemctl", "disable", "bgp.service"]),
                 call(["sudo", "systemctl", "mask", "bgp.service"]),
+                call(["sudo", "systemctl", "start", "syncd.service"]),
+                call(["sudo", "systemctl", "enable", "syncd.service"]),
+                call(["sudo", "systemctl", "unmask", "syncd.service"]),
             ],
             "daemon_reload_subprocess_call": [
                 call(["sudo", "systemctl", "daemon-reload"]),
@@ -671,8 +688,14 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "high_mem_alert": "disabled"
                     },
-
-
+                    "syncd": {
+                        "state": "enabled",
+                        "delayed": "False",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "auto_restart": "enabled",
+                        "high_mem_alert": "disabled"
+                    },
                 },
             },
             "expected_config_db": {
@@ -701,12 +724,23 @@ HOSTCFGD_TEST_VECTOR = [
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
+                    "syncd": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "delayed": "False",
+                        "high_mem_alert": "disabled",
+                        "state": "enabled"
+                    },
                 },
             },
             "enable_feature_subprocess_calls": [
                 call(["sudo", "systemctl", "stop", "bgp.service"]),
                 call(["sudo", "systemctl", "disable", "bgp.service"]),
                 call(["sudo", "systemctl", "mask", "bgp.service"]),
+                call(["sudo", "systemctl", "start", "syncd.service"]),
+                call(["sudo", "systemctl", "enable", "syncd.service"]),
+                call(["sudo", "systemctl", "unmask", "syncd.service"]),
             ],
             "daemon_reload_subprocess_call": [
                 call(["sudo", "systemctl", "daemon-reload"]),
@@ -766,8 +800,14 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "high_mem_alert": "disabled"
                     },
-
-
+                    "syncd": {
+                        "state": "enabled",
+                        "delayed": "False",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "auto_restart": "enabled",
+                        "high_mem_alert": "disabled"
+                    },
                 },
             },
             "expected_config_db": {
@@ -796,6 +836,14 @@ HOSTCFGD_TEST_VECTOR = [
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
+                    "syncd": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "delayed": "False",
+                        "high_mem_alert": "disabled",
+                        "state": "enabled"
+                    },
                 },
             },
             "enable_feature_subprocess_calls": [
@@ -805,6 +853,9 @@ HOSTCFGD_TEST_VECTOR = [
                 call(["sudo", "systemctl", "start", "teamd.service"]),
                 call(["sudo", "systemctl", "enable", "teamd.service"]),
                 call(["sudo", "systemctl", "unmask", "teamd.service"]),
+                call(["sudo", "systemctl", "start", "syncd.service"]),
+                call(["sudo", "systemctl", "enable", "syncd.service"]),
+                call(["sudo", "systemctl", "unmask", "syncd.service"]),
  
             ],
             "daemon_reload_subprocess_call": [
@@ -865,8 +916,14 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "high_mem_alert": "disabled"
                     },
-
-
+                    "syncd": {
+                        "state": "enabled",
+                        "delayed": "False",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "auto_restart": "enabled",
+                        "high_mem_alert": "disabled"
+                    },
                 },
             },
             "expected_config_db": {
@@ -895,6 +952,14 @@ HOSTCFGD_TEST_VECTOR = [
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
+                    "syncd": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "True",
+                        "delayed": "False",
+                        "high_mem_alert": "disabled",
+                        "state": "enabled"
+                    },
                 },
             },
             "enable_feature_subprocess_calls": [
@@ -904,6 +969,9 @@ HOSTCFGD_TEST_VECTOR = [
                 call(["sudo", "systemctl", "start", "teamd.service"]),
                 call(["sudo", "systemctl", "enable", "teamd.service"]),
                 call(["sudo", "systemctl", "unmask", "teamd.service"]),
+                call(["sudo", "systemctl", "start", "syncd.service"]),
+                call(["sudo", "systemctl", "enable", "syncd.service"]),
+                call(["sudo", "systemctl", "unmask", "syncd.service"]),
  
             ],
             "daemon_reload_subprocess_call": [
@@ -965,8 +1033,14 @@ HOSTCFGD_TEST_VECTOR = [
                         "auto_restart": "enabled",
                         "high_mem_alert": "disabled"
                     },
-
-
+                    "syncd": {
+                        "state": "enabled",
+                        "delayed": "False",
+                        "has_global_scope": "False",
+                        "has_per_asic_scope": "True",
+                        "auto_restart": "enabled",
+                        "high_mem_alert": "disabled"
+                    },
                 },
             },
             "expected_config_db": {
@@ -995,6 +1069,14 @@ HOSTCFGD_TEST_VECTOR = [
                         "high_mem_alert": "disabled",
                         "state": "enabled"
                     },
+                    "syncd": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "False",
+                        "has_per_asic_scope": "True",
+                        "delayed": "False",
+                        "high_mem_alert": "disabled",
+                        "state": "enabled"
+                    },
                 },
             },
             "enable_feature_subprocess_calls": [
@@ -1016,6 +1098,12 @@ HOSTCFGD_TEST_VECTOR = [
                 call(["sudo", "systemctl", "stop", "lldp@1.service"]),
                 call(["sudo", "systemctl", "disable", "lldp@1.service"]),
                 call(["sudo", "systemctl", "mask", "lldp@1.service"]),
+                call(["sudo", "systemctl", "start", "syncd@0.service"]),
+                call(["sudo", "systemctl", "enable", "syncd@0.service"]),
+                call(["sudo", "systemctl", "unmask", "syncd@0.service"]),
+                call(["sudo", "systemctl", "start", "syncd@1.service"]),
+                call(["sudo", "systemctl", "enable", "syncd@1.service"]),
+                call(["sudo", "systemctl", "unmask", "syncd@1.service"]),
  
             ],
             "daemon_reload_subprocess_call": [


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is cherry-pick PR.. Master branch PR. https://github.com/sonic-net/sonic-host-services/pull/83
Issue details and RCA here. https://github.com/sonic-net/sonic-buildimage/issues/16991

##### Work item tracking
- Microsoft ADO **25422412**:

#### How I did it
Currently hostcfgd script overrides the systemd service files of the features depending upon auto_restart enable/disable.
I am skipping dependent features(syncd, gbsyncd for now) to have "RESTART=Always"
for them to not start immediately, and instead get started by SWSS through swss.sh script.
The issue of syncd double stop is also applicable to pizza box platforms, however no traffic impact is seen there, whereas on VOQ chassis, we do see traffic impact due to early start of syncd service.
The change can be extended to pizza box platforms as well in future once it gets vetted on SpineRouters.

#### How to verify it
extended Unit tests to cover this scenario.
followed same steps as mentioned in https://github.com/sonic-net/sonic-buildimage/issues/16991 and confirmed that
a. No traffic loss end to end
b. Don't see double stop/start of syncd service
Also Ran few more tests.

Tested on both single asic and multi-asic hw platforms.
Tested config-reload
sudo reboot
service restart
syncd process crash, orchagent process crash
Confirmed from logs, that in none of the scenario, syncd gets killed twice
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)
SONiC.20220532.45
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

