### PR TITLE
Password Hardening: Add support to disable expiration date

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -45,8 +45,8 @@ SSH_MAX_VALUES={"authentication_retries": 100, "login_timeout": 600, "ports": 65
 SSH_CONFIG_NAMES={"authentication_retries": "MaxAuthTries" , "login_timeout": "LoginGraceTime"}
 
 ACCOUNT_NAME = 0 # index of account name
-AGE_DICT = { 'MAX_DAYS': {'REGEX_DAYS': r'^PASS_MAX_DAYS[ \t]*(?P<max_days>\d*)', 'DAYS': 'max_days', 'CHAGE_FLAG': '-M '},
-            'WARN_DAYS': {'REGEX_DAYS': r'^PASS_WARN_AGE[ \t]*(?P<warn_days>\d*)', 'DAYS': 'warn_days', 'CHAGE_FLAG': '-W '}
+AGE_DICT = { 'MAX_DAYS': {'REGEX_DAYS': r'^PASS_MAX_DAYS[ \t]*(?P<max_days>-?\d*)', 'DAYS': 'max_days', 'CHAGE_FLAG': '-M '},
+            'WARN_DAYS': {'REGEX_DAYS': r'^PASS_WARN_AGE[ \t]*(?P<warn_days>-?\d*)', 'DAYS': 'warn_days', 'CHAGE_FLAG': '-W '}
             }
 PAM_LIMITS_CONF_TEMPLATE = "/usr/share/sonic/templates/pam_limits.j2"
 LIMITS_CONF_TEMPLATE = "/usr/share/sonic/templates/limits.conf.j2"
@@ -722,15 +722,11 @@ class PasswHardening(object):
         if passw_policies:
             if 'state' in passw_policies:
                 if passw_policies['state'] == 'enabled':
-                    if 'expiration' in passw_policies:
-                        if int(self.passw_policies['expiration']) != 0: # value '0' meaning age policy is disabled
-                            #  the logic is to modify the expiration time according the last updated modificatiion
-                            #
-                            curr_expiration = int(passw_policies['expiration'])
-
-                    if 'expiration_warning' in passw_policies:
-                        if int(self.passw_policies['expiration_warning']) != 0: # value '0' meaning age policy is disabled
-                            curr_expiration_warning = int(passw_policies['expiration_warning'])
+                    # Special values of expiration/expiration warning
+                    # 0: meaning password will be expired/warning immediately.
+                    # -1: meaning password expired/warning never.
+                    curr_expiration = int(passw_policies.get('expiration'))
+                    curr_expiration_warning = int(passw_policies.get('expiration_warning'))
 
         if self.is_passwd_aging_expire_update(curr_expiration, 'MAX_DAYS'):
             # Set aging policy for existing users

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -725,8 +725,8 @@ class PasswHardening(object):
                     # Special values of expiration/expiration warning
                     # 0: meaning password will be expired/warning immediately.
                     # -1: meaning password expired/warning never.
-                    curr_expiration = int(passw_policies.get('expiration'))
-                    curr_expiration_warning = int(passw_policies.get('expiration_warning'))
+                    curr_expiration = int(passw_policies.get('expiration', -1))
+                    curr_expiration_warning = int(passw_policies.get('expiration_warning', -1))
 
         if self.is_passwd_aging_expire_update(curr_expiration, 'MAX_DAYS'):
             # Set aging policy for existing users

--- a/tests/hostcfgd/sample_output/PASSWORD_HARDENING_enable_digits_class/login.defs
+++ b/tests/hostcfgd/sample_output/PASSWORD_HARDENING_enable_digits_class/login.defs
@@ -157,9 +157,9 @@ UMASK		022
 #	PASS_MIN_DAYS	Minimum number of days allowed between password changes.
 #	PASS_WARN_AGE	Number of days warning given before a password expires.
 #
-PASS_MAX_DAYS	99999
+PASS_MAX_DAYS	0
 PASS_MIN_DAYS	0
-PASS_WARN_AGE	7
+PASS_WARN_AGE	0
 
 #
 # Min/max values for automatic uid selection in useradd


### PR DESCRIPTION
[password-hardening]Add support to disable expiration date like in Linux.-1: expiration will never occur, 0: expiration will expire immediately

This commit is part of the fix to the following bug:
https://github.com/sonic-net/sonic-buildimage/issues/17427