### PR TITLE
Fixed ip6table internal_docker_ip_traffic rule command for multi-asic

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -334,7 +334,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
             allow_internal_docker_ip_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-A', 'INPUT', '-s', self.namespace_docker_mgmt_ipv6[namespace], '-d', self.namespace_docker_mgmt_ipv6[namespace], '-j', 'ACCEPT'])
             allow_internal_docker_ip_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['iptables', '-A', 'INPUT', '-s', self.namespace_mgmt_ip, '-d', self.namespace_docker_mgmt_ip[namespace], '-j', 'ACCEPT'])
 
-            allow_internal_docker_ip_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-A', 'INPUT', '-s', self.namespace_mgmt_ipv6, '-d', 'self.namespace_docker_mgmt_ipv6[namespace]', '-j', 'ACCEPT'])
+            allow_internal_docker_ip_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-A', 'INPUT', '-s', self.namespace_mgmt_ipv6, '-d', self.namespace_docker_mgmt_ipv6[namespace], '-j', 'ACCEPT'])
 
         else:
 

--- a/tests/caclmgrd/caclmgrd_generate_allow_internal_docker_ip_traffic_test.py
+++ b/tests/caclmgrd/caclmgrd_generate_allow_internal_docker_ip_traffic_test.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+from parameterized import parameterized
+from sonic_py_common.general import load_module_from_source
+from unittest import TestCase, mock
+from pyfakefs.fake_filesystem_unittest import patchfs
+
+from .test_internal_docker_ip_traffic_vectors import CACLMGRD_INTERNAL_DOCKER_IP_TEST_VECTOR
+
+
+class TestCaclmgrdGenerateInternalDockerIp(TestCase):
+    """
+        Test caclmgrd multi-asic generate internal docker ip allow rule
+    """
+    def setUp(self):
+        test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        modules_path = os.path.dirname(test_path)
+        scripts_path = os.path.join(modules_path, "scripts")
+        sys.path.insert(0, modules_path)
+        caclmgrd_path = os.path.join(scripts_path, 'caclmgrd')
+        self.caclmgrd = load_module_from_source('caclmgrd', caclmgrd_path)
+        self.maxDiff = None
+
+    @parameterized.expand(CACLMGRD_INTERNAL_DOCKER_IP_TEST_VECTOR)
+    @patchfs
+    def test_caclmgrd_internal_docker_ip_traffic(self, test_name, test_data, fs):
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ip = mock.MagicMock()
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ipv6 = mock.MagicMock()
+        caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
+        caclmgrd_daemon.iptables_cmd_ns_prefix['asic0'] = ['ip', 'netns', 'exec', 'asic0']
+        caclmgrd_daemon.namespace_docker_mgmt_ip['asic0'] = '1.1.1.1/32'
+        caclmgrd_daemon.namespace_mgmt_ip = '2.2.2.2/32'
+        caclmgrd_daemon.namespace_docker_mgmt_ipv6['asic0'] = 'fd::01/128'
+        caclmgrd_daemon.namespace_mgmt_ipv6 = 'fd::02/128'
+
+        ret = caclmgrd_daemon.generate_allow_internal_docker_ip_traffic_commands('asic0')
+        self.assertListEqual(test_data["return"], ret)

--- a/tests/caclmgrd/test_internal_docker_ip_traffic_vectors.py
+++ b/tests/caclmgrd/test_internal_docker_ip_traffic_vectors.py
@@ -1,0 +1,18 @@
+from unittest.mock import call
+
+"""
+    caclmgrd internal docker ip traffic test vector
+"""
+CACLMGRD_INTERNAL_DOCKER_IP_TEST_VECTOR = [
+    [
+        "Allow internal docker traffic",
+        {
+            "return": [
+                ['ip', 'netns', 'exec', 'asic0', 'iptables', '-A', 'INPUT', '-s', '1.1.1.1/32', '-d', '1.1.1.1/32', '-j', 'ACCEPT'],
+                ['ip', 'netns', 'exec', 'asic0', 'ip6tables', '-A', 'INPUT', '-s', 'fd::01/128', '-d', 'fd::01/128', '-j', 'ACCEPT'],
+                ['ip', 'netns', 'exec', 'asic0', 'iptables', '-A', 'INPUT', '-s', '2.2.2.2/32', '-d', '1.1.1.1/32', '-j', 'ACCEPT'],
+                ['ip', 'netns', 'exec', 'asic0', 'ip6tables', '-A', 'INPUT', '-s', 'fd::02/128', '-d', 'fd::01/128', '-j', 'ACCEPT']
+            ]
+        }
+    ]
+]


### PR DESCRIPTION
Signed-off-by: anamehra <anamehra@cisco.com>

Fixes: https://github.com/sonic-net/sonic-buildimage/issues/17431

The self.namespace_docker_mgmt_ipv6[namespace] variable was being used as a string causing the cmd to fail.
Fixed the command.

#### Which release branch to backport (provide reason below if selected)

- [x] 202305