### PR TITLE
[caclmgrd][DualToR] Fix a case where vlan address is not network address for DualToR Active-active configuration

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -44,7 +44,7 @@ def _ip_prefix_in_key(key):
 
 def get_ipv4_networks_from_interface_table(table, intf_name):
     
-    addresses = []
+    addresses = {}
     if table:
         for key, _ in table.items():
             if not _ip_prefix_in_key(key):
@@ -54,8 +54,10 @@ def get_ipv4_networks_from_interface_table(table, intf_name):
             iface_name, iface_cidr = key
             if iface_name.startswith(intf_name):
                 ip_ntwrk = ipaddress.ip_network(iface_cidr, strict=False)
-                if isinstance(ip_ntwrk, ipaddress.IPv4Network):
-                    addresses.append(ip_ntwrk)
+                ip_str = iface_cidr.split("/")[0]
+                ip_addr = ipaddress.ip_address(ip_str)
+                if isinstance(ip_ntwrk, ipaddress.IPv4Network) and isinstance(ip_addr, ipaddress.IPv4Address):
+                    addresses[ip_ntwrk] = ip_addr
 
     return addresses
 
@@ -365,11 +367,14 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                 self.log_warning("Loopback 3 IP not available from DualToR active-active config")
                 return fwd_dualtor_grpc_traffic_from_host_to_soc_cmds
 
-            if not isinstance(loopback_networks[0], ipaddress.IPv4Network):
+
+            loopback_address_keys = list(loopback_networks.keys())
+
+            if not isinstance(loopback_address_keys[0], ipaddress.IPv4Network):
                 self.log_warning("Loopback 3 IP Network not available from DualToR active-active config")
                 return fwd_dualtor_grpc_traffic_from_host_to_soc_cmds
 
-            loopback_address = loopback_networks[0].network_address
+            loopback_address = loopback_address_keys[0].network_address
             vlan_name = 'Vlan'
             vlan_table = config_db_connector.get_table(self.VLAN_INTF_TABLE)
             vlan_networks = get_ipv4_networks_from_interface_table(vlan_table, vlan_name)
@@ -389,10 +394,9 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                     if 'cable_type' in kvp and kvp['cable_type'] == 'active-active':
                         soc_ipv4_str = kvp['soc_ipv4'].split("/")[0]
                         soc_ipv4_addr = ipaddress.ip_address(soc_ipv4_str)
-                        for ip_network in vlan_networks:
+                        for ip_network, vlan_address in vlan_networks.items():
                             # Only add the vlan source IP specific soc IP address to IPtables
                             if soc_ipv4_addr in ip_network:
-                                vlan_address = ip_network.network_address
                                 fwd_dualtor_grpc_traffic_from_host_to_soc_cmds.append(self.iptables_cmd_ns_prefix[namespace] + 
                                          ['iptables', '-t', 'nat', '-A', 'POSTROUTING', '--destination', str(soc_ipv4_addr), '--source', str(vlan_address), '-j', 'SNAT', '--to-source', str(loopback_address)])
 

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -368,13 +368,13 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                 return fwd_dualtor_grpc_traffic_from_host_to_soc_cmds
 
 
-            loopback_address_keys = list(loopback_networks.keys())
+            loopback_address_keys = list(loopback_networks.values())
 
             if not isinstance(loopback_address_keys[0], ipaddress.IPv4Network):
                 self.log_warning("Loopback 3 IP Network not available from DualToR active-active config")
                 return fwd_dualtor_grpc_traffic_from_host_to_soc_cmds
 
-            loopback_address = loopback_address_keys[0].network_address
+            loopback_address = loopback_address_keys[0]
             vlan_name = 'Vlan'
             vlan_table = config_db_connector.get_table(self.VLAN_INTF_TABLE)
             vlan_networks = get_ipv4_networks_from_interface_table(vlan_table, vlan_name)

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -368,7 +368,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                 return fwd_dualtor_grpc_traffic_from_host_to_soc_cmds
 
 
-            loopback_address_keys = list(loopback_networks.values())
+            loopback_address_keys = list(loopback_networks.keys())
 
             if not isinstance(loopback_address_keys[0], ipaddress.IPv4Network):
                 self.log_warning("Loopback 3 IP Network not available from DualToR active-active config")

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -368,13 +368,13 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                 return fwd_dualtor_grpc_traffic_from_host_to_soc_cmds
 
 
-            loopback_address_keys = list(loopback_networks.keys())
+            loopback_address_vals = list(loopback_networks.values())
 
             if not isinstance(loopback_address_keys[0], ipaddress.IPv4Network):
                 self.log_warning("Loopback 3 IP Network not available from DualToR active-active config")
                 return fwd_dualtor_grpc_traffic_from_host_to_soc_cmds
 
-            loopback_address = loopback_address_keys[0]
+            loopback_address = loopback_address_vals[0]
             vlan_name = 'Vlan'
             vlan_table = config_db_connector.get_table(self.VLAN_INTF_TABLE)
             vlan_networks = get_ipv4_networks_from_interface_table(vlan_table, vlan_name)

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -370,7 +370,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
 
             loopback_address_vals = list(loopback_networks.values())
 
-            if not isinstance(loopback_address_keys[0], ipaddress.IPv4Network):
+            if not isinstance(loopback_address_vals[0], ipaddress.IPv4Address):
                 self.log_warning("Loopback 3 IP Network not available from DualToR active-active config")
                 return fwd_dualtor_grpc_traffic_from_host_to_soc_cmds
 

--- a/tests/caclmgrd/caclmgrd_soc_rules_test.py
+++ b/tests/caclmgrd/caclmgrd_soc_rules_test.py
@@ -29,7 +29,7 @@ class TestCaclmgrdSoc(TestCase):
         
     @parameterized.expand(CACLMGRD_SOC_TEST_VECTOR)
     @patchfs
-    @patch('caclmgrd.get_ipv4_networks_from_interface_table', MagicMock(return_value={IPv4Network('10.10.10.18/24', strict=False): IPv4Address('10.10.10.18') , IPv4Network('10.10.11.18/24', strict=False) : IPv4Address('10.10.11.18')  }))
+    #@patch('caclmgrd.get_ipv4_networks_from_interface_table', MagicMock(return_value={IPv4Network('10.10.10.18/24', strict=False): IPv4Address('10.10.10.18') , IPv4Network('10.10.11.18/24', strict=False) : IPv4Address('10.10.11.18')  }))
     def test_caclmgrd_soc(self, test_name, test_data, fs):
         if not os.path.exists(DBCONFIG_PATH):
             fs.create_file(DBCONFIG_PATH) # fake database_config.json

--- a/tests/caclmgrd/caclmgrd_soc_rules_test.py
+++ b/tests/caclmgrd/caclmgrd_soc_rules_test.py
@@ -29,7 +29,7 @@ class TestCaclmgrdSoc(TestCase):
         
     @parameterized.expand(CACLMGRD_SOC_TEST_VECTOR)
     @patchfs
-    #@patch('caclmgrd.get_ipv4_networks_from_interface_table', MagicMock(return_value={IPv4Network('10.10.10.18/24', strict=False): IPv4Address('10.10.10.18') , IPv4Network('10.10.11.18/24', strict=False) : IPv4Address('10.10.11.18')  }))
+    @patch('caclmgrd.get_ipv4_networks_from_interface_table', MagicMock(return_value={IPv4Network('10.10.11.18/24', strict=False): IPv4Address('10.10.11.18') , IPv4Network('10.10.10.18/24', strict=False) : IPv4Address('10.10.10.18')  }))
     def test_caclmgrd_soc(self, test_name, test_data, fs):
         if not os.path.exists(DBCONFIG_PATH):
             fs.create_file(DBCONFIG_PATH) # fake database_config.json

--- a/tests/caclmgrd/caclmgrd_soc_rules_test.py
+++ b/tests/caclmgrd/caclmgrd_soc_rules_test.py
@@ -29,7 +29,7 @@ class TestCaclmgrdSoc(TestCase):
         
     @parameterized.expand(CACLMGRD_SOC_TEST_VECTOR)
     @patchfs
-    @patch('caclmgrd.get_ipv4_networks_from_interface_table', MagicMock(return_value={IPv4Network('10.10.10.18/24', strict=False): IPv4Address('10.10.10.18', strict=False) , IPv4Network('10.10.11.18/24', strict=False) : IPv4Address('10.10.11.18', strict=False)  }))
+    @patch('caclmgrd.get_ipv4_networks_from_interface_table', MagicMock(return_value={IPv4Network('10.10.10.18/24', strict=False): IPv4Address('10.10.10.18') , IPv4Network('10.10.11.18/24', strict=False) : IPv4Address('10.10.11.18')  }))
     def test_caclmgrd_soc(self, test_name, test_data, fs):
         if not os.path.exists(DBCONFIG_PATH):
             fs.create_file(DBCONFIG_PATH) # fake database_config.json

--- a/tests/caclmgrd/caclmgrd_soc_rules_test.py
+++ b/tests/caclmgrd/caclmgrd_soc_rules_test.py
@@ -29,7 +29,7 @@ class TestCaclmgrdSoc(TestCase):
         
     @parameterized.expand(CACLMGRD_SOC_TEST_VECTOR)
     @patchfs
-    @patch('caclmgrd.get_ipv4_networks_from_interface_table', MagicMock(return_value=[IPv4Network('10.10.10.18/24', strict=False), IPv4Network('10.10.11.18/24', strict=False)]))
+    @patch('caclmgrd.get_ipv4_networks_from_interface_table', MagicMock(return_value={IPv4Network('10.10.10.18/24', strict=False): IPv4Address('10.10.10.18', strict=False) , IPv4Network('10.10.11.18/24', strict=False) : IPv4Address('10.10.11.18', strict=False)  }))
     def test_caclmgrd_soc(self, test_name, test_data, fs):
         if not os.path.exists(DBCONFIG_PATH):
             fs.create_file(DBCONFIG_PATH) # fake database_config.json
@@ -79,7 +79,7 @@ class TestCaclmgrdSoc(TestCase):
 
     @parameterized.expand(CACLMGRD_SOC_TEST_VECTOR_EMPTY)
     @patchfs
-    @patch('caclmgrd.get_ipv4_networks_from_interface_table', MagicMock(return_value=['10.10.10.10']))
+    @patch('caclmgrd.get_ipv4_networks_from_interface_table', MagicMock(return_value={'10.10.10.10': '10.10.10.1'}))
     def test_caclmgrd_soc_ip_string(self, test_name, test_data, fs):
         if not os.path.exists(DBCONFIG_PATH):
             fs.create_file(DBCONFIG_PATH) # fake database_config.json
@@ -109,4 +109,4 @@ class TestCaclmgrdSoc(TestCase):
         table = {("Vlan1000","10.10.10.1/32"): "val"}
         ip_addr = self.caclmgrd.get_ipv4_networks_from_interface_table(table, "Vlan")
 
-        assert (ip_addr == [IPv4Network('10.10.10.1/32')])
+        assert (ip_addr == {IPv4Network('10.10.10.1/32'): IPv4Address('10.10.10.1')})

--- a/tests/caclmgrd/test_soc_rules_vectors.py
+++ b/tests/caclmgrd/test_soc_rules_vectors.py
@@ -18,7 +18,7 @@ CACLMGRD_SOC_TEST_VECTOR = [
                 "MUX_CABLE": {
                     "Ethernet4": {
                         "cable_type": "active-active",
-                        "soc_ipv4": "10.10.11.7/32",
+                        "soc_ipv4": "10.10.10.7/32",
                     }
                 },
                 "VLAN_INTERFACE": {
@@ -35,7 +35,7 @@ CACLMGRD_SOC_TEST_VECTOR = [
                 },
             },
             "expected_subprocess_calls": [
-                call(['iptables', '-t', 'nat', '-A', 'POSTROUTING', '--destination', '10.10.11.7', '--source', '10.10.11.18', '-j', 'SNAT', '--to-source', '10.10.10.18'], universal_newlines=True, stdout=-1)
+                call(['iptables', '-t', 'nat', '-A', 'POSTROUTING', '--destination', '10.10.10.7', '--source', '10.10.10.18', '-j', 'SNAT', '--to-source', '10.10.11.18'], universal_newlines=True, stdout=-1)
             ],
             "popen_attributes": {
                 'communicate.return_value': ('output', 'error'),

--- a/tests/caclmgrd/test_soc_rules_vectors.py
+++ b/tests/caclmgrd/test_soc_rules_vectors.py
@@ -35,7 +35,7 @@ CACLMGRD_SOC_TEST_VECTOR = [
                 },
             },
             "expected_subprocess_calls": [
-                call(['iptables', '-t', 'nat', '-A', 'POSTROUTING', '--destination', '10.10.11.7', '--source', '10.10.11.18', '-j', 'SNAT', '--to-source', '10.10.10.10'], universal_newlines=True, stdout=-1)
+                call(['iptables', '-t', 'nat', '-A', 'POSTROUTING', '--destination', '10.10.11.7', '--source', '10.10.11.18', '-j', 'SNAT', '--to-source', '10.10.10.18'], universal_newlines=True, stdout=-1)
             ],
             "popen_attributes": {
                 'communicate.return_value': ('output', 'error'),

--- a/tests/caclmgrd/test_soc_rules_vectors.py
+++ b/tests/caclmgrd/test_soc_rules_vectors.py
@@ -35,7 +35,7 @@ CACLMGRD_SOC_TEST_VECTOR = [
                 },
             },
             "expected_subprocess_calls": [
-                call(['iptables', '-t', 'nat', '-A', 'POSTROUTING', '--destination', '10.10.11.7', '--source', '10.10.11.0', '-j', 'SNAT', '--to-source', '10.10.10.0'], universal_newlines=True, stdout=-1)
+                call(['iptables', '-t', 'nat', '-A', 'POSTROUTING', '--destination', '10.10.11.7', '--source', '10.10.11.18', '-j', 'SNAT', '--to-source', '10.10.10.10'], universal_newlines=True, stdout=-1)
             ],
             "popen_attributes": {
                 'communicate.return_value': ('output', 'error'),


### PR DESCRIPTION
This PR fixes #82 where a corner case is not covered, if vlan address of DUT is not network address. 
Basically a src IP is added to the SNAT rule so that only packets originating from ToR with src IP as vlan IP get natted by the rule and change the src IP to LoopBack IP

For multiple vlan IP's only the vlan address coming from configuration is picked as the vlan address and not the network address. 

We consider a case where there are multiple vlan IP's are example in such format :

```
Vlan705                 10.131.113.17/28     up/up         N/A                   N/A
Vlan805                 10.131.111.129/26    up/up         N/A                   N/A

  "VLAN_INTERFACE": {
        "Vlan705|10.131.113.17/28": {},
        "Vlan805|10.131.111.129/26": {},
```
In such a case we expect iptables rules should be :

```
target     prot opt source               destination         
SNAT       all  --  10.131.113.17        10.131.113.19        to:10.212.64.1
SNAT       all  --  10.131.111.129       10.131.111.131       to:10.212.64.1
```

where soc_ip's are such :
```
10.131.111.131, 10.131.113.19
```

Before this change the souce IP of the vlan is not correctly picked in the iptables rule
