### PR TITLE
Use upholds to ensure determine service startes after process service.

### DIFF
--- a/data/debian/sonic-host-services-data.determine-reboot-cause.service
+++ b/data/debian/sonic-host-services-data.determine-reboot-cause.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Reboot cause determination service
-Requires=rc-local.service database.service
-After=rc-local.service database.service
+After=rc-local.service
+Upholds=rc-local.service
 
 [Service]
 Type=oneshot

--- a/data/debian/sonic-host-services-data.process-reboot-cause.service
+++ b/data/debian/sonic-host-services-data.process-reboot-cause.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Retrieve the reboot cause from the history files and save them to StateDB
-Requires=database.service determine-reboot-cause.service
 After=database.service determine-reboot-cause.service
+Upholds=database.service determine-reboot-cause.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
Signed-off-by: Xincun Li [xincun.li@microsoft.com](mailto:xincun.li@microsoft.com)

**Why I did it**

To enhance system stability and optimize inter-service dependencies, I removed the determine-reboot-cause's dependency on database.service and improved process-reboot-cause's dependency on database.service. This was achieved using the upholds feature in Debian 12#249, ensuring a more reliable and efficient operational environment.

MSFT ADO: **26209780**

**How I did it**

1. Remove determine-reboot-cause's dependency with database.service.
1. Improves process-reboot-cause dependency with database.service by upholds feature in Debian 12#249
> https://manpages.debian.org/experimental/systemd/systemd.unit.5.en.html

```
Upholds=
Configures dependencies similar to Wants=, but as long as this unit is up, all units listed in Upholds= are started whenever found to be inactive or failed, and no job is queued for them. While a Wants= dependency on another unit has a one-time effect when this units started, a Upholds= dependency on it has a continuous effect, constantly restarting the unit if necessary. This is an alternative to the Restart= setting of service units, to ensure they are kept running whatever happens. The restart happens without delay, and usual per-unit rate-limit applies.

When Upholds=b.service is used on a.service, this dependency will show as UpheldBy=a.service in the property listing of b.service.

Added in version 249.
```

**How to verify it**
Steps:

1. Without changes: Show reboot-cause history, check output.
2. Apply the change
3. Restart db docker, restart process reboot cause.
4. Verify the Show reboot-cause history, check output.
5. list dependency output.


admin@str3-msn4600c-acs-05:/etc/systemd/system$ sudo systemctl list-dependencies process-reboot-cause
process-reboot-cause.service
● ├─database.service
● ├─determine-reboot-cause.service
● ├─system.slice
● └─sysinit.target
●   ├─apparmor.service
●   ├─dev-hugepages.mount
●   ├─dev-mqueue.mount
●   ├─haveged.service
●   ├─kmod-static-nodes.service
●   ├─proc-sys-fs-binfmt_misc.automount
●   ├─sys-fs-fuse-connections.mount
●   ├─sys-kernel-config.mount
●   ├─sys-kernel-debug.mount
●   ├─sys-kernel-tracing.mount
●   ├─systemd-ask-password-console.path
●   ├─systemd-binfmt.service
○   ├─systemd-firstboot.service
●   ├─systemd-journal-flush.service
●   ├─systemd-journald.service
○   ├─systemd-machine-id-commit.service
●   ├─systemd-modules-load.service
○   ├─systemd-pcrphase-sysinit.service
○   ├─systemd-pcrphase.service
○   ├─systemd-pstore.service
●   ├─systemd-random-seed.service
○   ├─systemd-repart.service
●   ├─systemd-sysctl.service
●   ├─systemd-sysusers.service
●   ├─systemd-tmpfiles-setup-dev.service
●   ├─systemd-tmpfiles-setup.service
●   ├─systemd-udev-trigger.service
●   ├─systemd-udevd.service
●   ├─systemd-update-utmp.service
●   ├─cryptsetup.target
●   ├─integritysetup.target
●   ├─local-fs.target
●   │ └─systemd-remount-fs.service
●   ├─swap.target
●   └─veritysetup.target
