### PR TITLE
Fix sonic host service

### DIFF
--- a/data/debian/sonic-host-services-data.sonic-hostservice.service
+++ b/data/debian/sonic-host-services-data.sonic-hostservice.service
@@ -12,5 +12,5 @@ RestartSec=10
 TimeoutStopSec=3
 
 [Install]
-WantedBy=mgmt-framework.service telemetry.service
+WantedBy=mgmt-framework.service telemetry.service gnmi.service
 


### PR DESCRIPTION
What I did
When we disable telemetry.service, sonic-hostservice will not start. And root cause is sonic-hostservice is only wanted by telemetry.service.

How I did it
Add dependency for gnmi.service.

How to verify it
Disable telemetry.service and build new image, and then check sonic-hostservice with new image.