### PR TITLE
Fix hostcfgd crash when delete entire config table.

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1728,6 +1728,7 @@ class HostConfigDaemon:
             def callback(table, key, data):
                 if data is None:
                     op = "DEL"
+                    data = {}
                 else:
                     op = "SET"
                 return func(key, op, data)

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1797,7 +1797,6 @@ def main():
     daemon.start()
 
 if __name__ == "__main__":
-    main()
     try:
         main()
     except Exception as e:

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1797,9 +1797,5 @@ def main():
     daemon.start()
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as e:
-        syslog.syslog(syslog.LOG_ERR, "hostcfgd crashed with exception: {}".format(e))
-        raise e
+    main()
 

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1798,4 +1798,9 @@ def main():
 
 if __name__ == "__main__":
     main()
+    try:
+        main()
+    except Exception as e:
+        syslog.syslog(syslog.LOG_ERR, "hostcfgd crashed with exception: {}".format(e))
+        raise e
 

--- a/tests/common/mock_configdb.py
+++ b/tests/common/mock_configdb.py
@@ -58,6 +58,9 @@ class MockConfigDb(object):
     def subscribe(self, table_name, callback):
         self.handlers[table_name] = callback
 
+    def publish(self, table_name, key, op, data):
+        self.handlers[table_name](key, op, data)
+
     def listen(self, init_data_handler=None):
         for e in MockConfigDb.event_queue:
             self.handlers[e[0]](e[0], e[1], self.get_entry(e[0], e[1]))

--- a/tests/hostcfgd/hostcfgd_tacacs_test.py
+++ b/tests/hostcfgd/hostcfgd_tacacs_test.py
@@ -214,15 +214,21 @@ class TestHostcfgdTACACS(TestCase):
         original_syslog = hostcfgd.syslog
         with mock.patch('hostcfgd.syslog.syslog') as mocked_syslog:
             mocked_syslog.LOG_INFO = original_syslog.LOG_INFO
+            mocked_syslog.LOG_ERR = original_syslog.LOG_ERR
 
             # simulate subscribe callback
             try:
-                hostcfgd.ConfigDBConnector.publish('AAA', 'authorization', 'DEL', None)
+                host_config_daemon.__dict__['config_db'].publish('AAA', 'authorization', 'DEL', None)
             except TypeError as e:
                 assert False
 
             # check sys log
             expected = [
-                mock.call(mocked_syslog.LOG_INFO, "AAA Update: key: authorization, op: DEL, data: {}")
+                mock.call(mocked_syslog.LOG_INFO, "file size check pass: /sonic/src/sonic-host-services/tests/hostcfgd/output/TACACS_config_db_local/sshd size is (2139) bytes"),
+                mock.call(mocked_syslog.LOG_INFO, "file size check pass: /sonic/src/sonic-host-services/tests/hostcfgd/output/TACACS_config_db_local/login size is (4951) bytes"),
+                mock.call(mocked_syslog.LOG_INFO, "Found audisp-tacplus PID: "),
+                mock.call(mocked_syslog.LOG_INFO, "cmd - ['service', 'aaastatsd', 'stop']"),
+                mock.call(mocked_syslog.LOG_ERR, "['service', 'aaastatsd', 'stop'] - failed: return code - 1, output:\nNone"),
+                mock.call(mocked_syslog.LOG_INFO, "AAA Update: key: DEL, op: DEL, data: {}")
             ]
             mocked_syslog.assert_has_calls(expected)

--- a/tests/hostcfgd/hostcfgd_tacacs_test.py
+++ b/tests/hostcfgd/hostcfgd_tacacs_test.py
@@ -217,7 +217,7 @@ class TestHostcfgdTACACS(TestCase):
 
             # simulate subscribe callback
             try:
-                hostcfgd.ConfigDBConnector.handlers['AAA']('AAA', 'DEL', None)
+                hostcfgd.ConfigDBConnector.publish('AAA', 'authorization', 'DEL', None)
             except TypeError as e:
                 assert False
 

--- a/tests/hostcfgd/hostcfgd_tacacs_test.py
+++ b/tests/hostcfgd/hostcfgd_tacacs_test.py
@@ -224,8 +224,8 @@ class TestHostcfgdTACACS(TestCase):
 
             # check sys log
             expected = [
-                mock.call(mocked_syslog.LOG_INFO, "file size check pass: /sonic/src/sonic-host-services/tests/hostcfgd/output/TACACS_config_db_local/sshd size is (2139) bytes"),
-                mock.call(mocked_syslog.LOG_INFO, "file size check pass: /sonic/src/sonic-host-services/tests/hostcfgd/output/TACACS_config_db_local/login size is (4951) bytes"),
+                mock.call(mocked_syslog.LOG_INFO, "file size check pass: {} size is (2139) bytes".format(hostcfgd.ETC_PAMD_SSHD)),
+                mock.call(mocked_syslog.LOG_INFO, "file size check pass: {} size is (4951) bytes".format(hostcfgd.ETC_PAMD_LOGIN)),
                 mock.call(mocked_syslog.LOG_INFO, "Found audisp-tacplus PID: "),
                 mock.call(mocked_syslog.LOG_INFO, "cmd - ['service', 'aaastatsd', 'stop']"),
                 mock.call(mocked_syslog.LOG_ERR, "['service', 'aaastatsd', 'stop'] - failed: return code - 1, output:\nNone"),


### PR DESCRIPTION
**What I did**
Fix hostcfgd crash when delete entire config table.

**Why I did it**
hostcfgd subscribe table change in register_callbacks() method. When a config table been deleted, the 'data' parameter of callback method will be 'None', however most callback doesn't handle the 'None' case, they only handle empty dictionary case. when this happen hostcfgd will crash.

**How I verified it**
Pass all UT.
Add new UT for code coverage.

##### Work item tracking
- Microsoft ADO: 27166522

**Details if related**
