### PR TITLE
Fix issue: delayed service will not be restarted if swss crashes

### DIFF
--- a/scripts/featured
+++ b/scripts/featured
@@ -166,7 +166,7 @@ class FeatureHandler(object):
     def port_listener(self, key, op, data):
         if not key:
             return 
-        if op == 'SET' and key == 'PortInitDone' and not self.is_delayed_enabled:
+        if op == 'SET' and key == 'PortInitDone':
             syslog.syslog(syslog.LOG_INFO, "Updating delayed features after port initialization")
             self.enable_delayed_services()
 

--- a/tests/featured/featured_test.py
+++ b/tests/featured/featured_test.py
@@ -320,6 +320,24 @@ class TestFeatureHandler(TestCase):
         }
         feature_handler.sync_state_field(feature_table)
         mock_db.mod_entry.assert_called_with('FEATURE', 'sflow', {'state': 'enabled'})
+    
+    def test_port_init_done_twice(self):
+        """There could be multiple "PortInitDone" event in case of swss
+        restart(either due to crash or due to manual operation). swss
+        restarting would cause all services that depend on it to be stopped.
+        Those stopped services which have delayed=True will not be auto
+        restarted by systemd, featured is responsible for enabling those services
+        when swss is ready. This test case covers it.
+        """
+        feature_handler = featured.FeatureHandler(None, None, {}, False)
+        assert not feature_handler.is_delayed_enabled
+        feature_handler.port_listener(key='PortInitDone', op='SET', data=None)
+        assert feature_handler.is_delayed_enabled
+        
+        feature_handler.enable_delayed_services = mock.MagicMock()
+        feature_handler.port_listener(key='PortInitDone', op='SET', data=None)
+        feature_handler.enable_delayed_services.assert_called_once()
+
 
 @mock.patch("syslog.syslog", side_effect=syslog_side_effect)
 @mock.patch('sonic_py_common.device_info.get_device_runtime_metadata')


### PR DESCRIPTION
**What I did**

Delayed services are counting on featured to start them when system reaches PORT INIT DONE. However, there is an extra flag check "self.is_delayed_enabled" in `port_listener`. It means that the delayed service will not be restarted if swss crashes. The PR is a fix of the issue.

**How I did**

Remove the extra flag check "self.is_delayed_enabled" in `port_listener`

**How I verified**

Manual test done, passed.