### PR TITLE
Change to use pip3 since py2 is deprecated on buildimage branch.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ stages:
     - script: |
         set -xe
         sudo pip3 install enum34
-        sudo pip install psutil
+        sudo pip3 install psutil
         sudo pip3 install swsssdk-2.0.1-py3-none-any.whl
         sudo pip3 install sonic_py_common-1.0-py3-none-any.whl
         sudo pip3 install sonic_yang_mgmt-1.0-py3-none-any.whl


### PR DESCRIPTION
Change to use pip3 since py2 is deprecated on buildimage branch.