### PR TITLE
Add dbus service to support restart and kill process

### DIFF
--- a/host_modules/systemd_service.py
+++ b/host_modules/systemd_service.py
@@ -1,0 +1,44 @@
+"""Systemd service handler"""
+
+from host_modules import host_service
+import subprocess
+
+MOD_NAME = 'systemd'
+ALLOWED_SERVICES = ['snmp', 'swss']
+EXIT_FAILURE = 1
+
+
+class SystemdService(host_service.HostModule):
+    """
+    DBus endpoint that executes the service command
+    """
+    @host_service.method(host_service.bus_name(MOD_NAME), in_signature='s', out_signature='is')
+    def restart_service(self, service):
+        if service not in ALLOWED_SERVICES:
+            return EXIT_FAILURE, "Dbus does not support {} service management".format(service)
+
+        cmd = ['/usr/bin/systemctl', 'reset-failed', service]
+        result = subprocess.run(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        msg = ''
+        if result.returncode:
+            msg = result.stderr.decode()
+            return result.returncode, msg
+
+        cmd = ['/usr/bin/systemctl', 'restart', service]
+        result = subprocess.run(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if result.returncode:
+            msg = result.stderr.decode()
+        
+        return result.returncode, msg
+    
+    @host_service.method(host_service.bus_name(MOD_NAME), in_signature='s', out_signature='is')
+    def stop_service(self, service):
+        if service not in ALLOWED_SERVICES:
+            return EXIT_FAILURE, "Dbus does not support {} service management".format(service)
+
+        cmd = ['/usr/bin/systemctl', 'stop', service]
+        result = subprocess.run(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        msg = ''
+        if result.returncode:
+            msg = result.stderr.decode()
+        return result.returncode, msg

--- a/host_modules/systemd_service.py
+++ b/host_modules/systemd_service.py
@@ -4,7 +4,7 @@ from host_modules import host_service
 import subprocess
 
 MOD_NAME = 'systemd'
-ALLOWED_SERVICES = ['snmp', 'swss']
+ALLOWED_SERVICES = ['snmp', 'swss', 'dhcp_relay', 'radv', 'restapi', 'lldp', 'sshd']
 EXIT_FAILURE = 1
 
 

--- a/host_modules/systemd_service.py
+++ b/host_modules/systemd_service.py
@@ -14,8 +14,10 @@ class SystemdService(host_service.HostModule):
     """
     @host_service.method(host_service.bus_name(MOD_NAME), in_signature='s', out_signature='is')
     def restart_service(self, service):
+        if not service:
+            return EXIT_FAILURE, "Dbus restart_service called with no service specified"
         if service not in ALLOWED_SERVICES:
-            return EXIT_FAILURE, "Dbus does not support {} service management".format(service)
+            return EXIT_FAILURE, "Dbus does not support {} service restart".format(service)
 
         cmd = ['/usr/bin/systemctl', 'reset-failed', service]
         result = subprocess.run(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -33,6 +35,8 @@ class SystemdService(host_service.HostModule):
     
     @host_service.method(host_service.bus_name(MOD_NAME), in_signature='s', out_signature='is')
     def stop_service(self, service):
+        if not service:
+            return EXIT_FAILURE, "Dbus stop_service called with no service specified"
         if service not in ALLOWED_SERVICES:
             return EXIT_FAILURE, "Dbus does not support {} service management".format(service)
 

--- a/host_modules/systemd_service.py
+++ b/host_modules/systemd_service.py
@@ -20,12 +20,9 @@ class SystemdService(host_service.HostModule):
             return EXIT_FAILURE, "Dbus does not support {} service restart".format(service)
 
         cmd = ['/usr/bin/systemctl', 'reset-failed', service]
-        result = subprocess.run(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        result = subprocess.run(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+        
         msg = ''
-        if result.returncode:
-            msg = result.stderr.decode()
-            return result.returncode, msg
-
         cmd = ['/usr/bin/systemctl', 'restart', service]
         result = subprocess.run(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if result.returncode:

--- a/host_modules/systemd_service.py
+++ b/host_modules/systemd_service.py
@@ -4,7 +4,7 @@ from host_modules import host_service
 import subprocess
 
 MOD_NAME = 'systemd'
-ALLOWED_SERVICES = ['snmp', 'swss', 'dhcp_relay', 'radv', 'restapi', 'lldp', 'sshd']
+ALLOWED_SERVICES = ['snmp', 'swss', 'dhcp_relay', 'radv', 'restapi', 'lldp', 'sshd', 'pmon', 'rsyslog']
 EXIT_FAILURE = 1
 
 

--- a/scripts/sonic-host-server
+++ b/scripts/sonic-host-server
@@ -12,7 +12,7 @@ import dbus.service
 import dbus.mainloop.glib
 
 from gi.repository import GObject
-from host_modules import config_engine, gcu, host_service, showtech
+from host_modules import config_engine, gcu, host_service, showtech, systemd_service
 
 
 def register_dbus():
@@ -21,7 +21,8 @@ def register_dbus():
             'config': config_engine.Config('config'),
             'gcu': gcu.GCU('gcu'),
             'host_service': host_service.HostService('host_service'),
-            'showtech': showtech.Showtech('showtech')
+            'showtech': showtech.Showtech('showtech'),
+            'systemd': systemd_service.SystemdService('systemd')
             }
     for mod_name, handler_class in mod_dict.items():
         handlers[mod_name] = handler_class

--- a/tests/host_modules/systemd_service_test.py
+++ b/tests/host_modules/systemd_service_test.py
@@ -38,6 +38,16 @@ class TestSystemdService(object):
     @mock.patch("dbus.SystemBus")
     @mock.patch("dbus.service.BusName")
     @mock.patch("dbus.service.Object.__init__")
+    def test_service_restart_empty(self, MockInit, MockBusName, MockSystemBus):
+        service = ""
+        systemd_service_stub = systemd_service.SystemdService(systemd_service.MOD_NAME)
+        ret, msg = systemd_service_stub.restart_service(service)
+        assert ret == 1
+        assert "restart_service called with no service specified" in msg
+    
+    @mock.patch("dbus.SystemBus")
+    @mock.patch("dbus.service.BusName")
+    @mock.patch("dbus.service.Object.__init__")
     def test_service_stop_valid(self, MockInit, MockBusName, MockSystemBus):
         with mock.patch("subprocess.run") as mock_run:
             res_mock = mock.Mock()
@@ -65,3 +75,12 @@ class TestSystemdService(object):
         assert ret == 1
         assert "Dbus does not support" in msg
 
+    @mock.patch("dbus.SystemBus")
+    @mock.patch("dbus.service.BusName")
+    @mock.patch("dbus.service.Object.__init__")
+    def test_service_stop_empty(self, MockInit, MockBusName, MockSystemBus):
+        service = ""
+        systemd_service_stub = systemd_service.SystemdService(systemd_service.MOD_NAME)
+        ret, msg = systemd_service_stub.stop_service(service)
+        assert ret == 1
+        assert "stop_service called with no service specified" in msg

--- a/tests/host_modules/systemd_service_test.py
+++ b/tests/host_modules/systemd_service_test.py
@@ -1,0 +1,76 @@
+import sys
+import os
+import pytest
+from unittest import mock
+from host_modules import systemd_service
+
+class TestSystemdService(object):
+    @mock.patch("dbus.SystemBus")
+    @mock.patch("dbus.service.BusName")
+    @mock.patch("dbus.service.Object.__init__")
+    def test_service_restart(self, MockInit, MockBusName, MockSystemBus):
+        with mock.patch("subprocess.run") as mock_run:
+            res_mock = mock.Mock()
+            test_ret = 0
+            attrs = {"returncode": test_ret, "stderr": test_msg}
+            res_mock.configure_mock(**attrs)
+            mock_run.return_value = res_mock
+            service = "snmp"
+            systemd_service_stub = systemd_service.SystemdService(systemd_service.MOD_NAME)
+            ret, msg = systemd_service_stub.restart_service(service)
+            call_args = mock_run.call_args[0][0]
+            assert service in call_args
+            assert "/usr/bin/systemctl" in call_args
+            assert ret == test_ret, "Return value is wrong"
+            assert msg == "", "Return message is wrong"
+
+        with mock.patch("subprocess.run") as mock_run:
+            res_mock = mock.Mock()
+            test_ret = 1
+            test_msg = b"Dbus does not support"
+            attrs = {"returncode": test_ret, "stderr": test_msg}
+            res_mock.configure_mock(**attrs)
+            mock_run.return_value = res_mock
+            service = "unsupported"
+            systemd_service_stub = systemd_service.SystemdService(systemd_service.MOD_NAME)
+            ret, msg = systemd_service_stub.restart_service(service)
+            call_args = mock_run.call_args[0][0]
+            assert "/usr/bin/systemctl" in call_args
+            assert service in call_args
+            assert "stop" in call_args
+            assert ret == test_ret, "Return value is wrong"
+            assert "Dbus does not support" in msg, "Return message is wrong"
+    
+        
+    def test_service_stop(self, MockInit, MockBusName, MockSystemBus):
+        with mock.patch("subprocess.run") as mock_run:
+            res_mock = mock.Mock()
+            test_ret = 0
+            attrs = {"returncode": test_ret, "stderr": test_msg}
+            res_mock.configure_mock(**attrs)
+            mock_run.return_value = res_mock
+            service = "snmp"
+            systemd_service_stub = systemd_service.SystemdService(systemd_service.MOD_NAME)
+            ret, msg = systemd_service_stub.stop_service(service)
+            call_args = mock_run.call_args[0][0]
+            assert service in call_args
+            assert "/usr/bin/systemctl" in call_args
+            assert ret == test_ret, "Return value is wrong"
+            assert msg == "", "Return message is wrong"
+
+        with mock.patch("subprocess.run") as mock_run:
+            res_mock = mock.Mock()
+            test_ret = 1
+            test_msg = b"Dbus does not support"
+            attrs = {"returncode": test_ret, "stderr": test_msg}
+            res_mock.configure_mock(**attrs)
+            mock_run.return_value = res_mock
+            service = "unsupported"
+            systemd_service_stub = systemd_service.SystemdService(systemd_service.MOD_NAME)
+            ret, msg = systemd_service_stub.stop_service(service)
+            call_args = mock_run.call_args[0][0]
+            assert "/usr/bin/systemctl" in call_args
+            assert service in call_args
+            assert "stop" in call_args
+            assert ret == test_ret, "Return value is wrong"
+            assert "Dbus does not support" in msg, "Return message is wrong"

--- a/tests/host_modules/systemd_service_test.py
+++ b/tests/host_modules/systemd_service_test.py
@@ -8,10 +8,11 @@ class TestSystemdService(object):
     @mock.patch("dbus.SystemBus")
     @mock.patch("dbus.service.BusName")
     @mock.patch("dbus.service.Object.__init__")
-    def test_service_restart(self, MockInit, MockBusName, MockSystemBus):
+    def test_service_restart_valid(self, MockInit, MockBusName, MockSystemBus):
         with mock.patch("subprocess.run") as mock_run:
             res_mock = mock.Mock()
             test_ret = 0
+            test_msg = b"Succeeded"
             attrs = {"returncode": test_ret, "stderr": test_msg}
             res_mock.configure_mock(**attrs)
             mock_run.return_value = res_mock
@@ -23,29 +24,25 @@ class TestSystemdService(object):
             assert "/usr/bin/systemctl" in call_args
             assert ret == test_ret, "Return value is wrong"
             assert msg == "", "Return message is wrong"
-
-        with mock.patch("subprocess.run") as mock_run:
-            res_mock = mock.Mock()
-            test_ret = 1
-            test_msg = b"Dbus does not support"
-            attrs = {"returncode": test_ret, "stderr": test_msg}
-            res_mock.configure_mock(**attrs)
-            mock_run.return_value = res_mock
-            service = "unsupported"
-            systemd_service_stub = systemd_service.SystemdService(systemd_service.MOD_NAME)
-            ret, msg = systemd_service_stub.restart_service(service)
-            call_args = mock_run.call_args[0][0]
-            assert "/usr/bin/systemctl" in call_args
-            assert service in call_args
-            assert "stop" in call_args
-            assert ret == test_ret, "Return value is wrong"
-            assert "Dbus does not support" in msg, "Return message is wrong"
-    
+   
+    @mock.patch("dbus.SystemBus")
+    @mock.patch("dbus.service.BusName")
+    @mock.patch("dbus.service.Object.__init__")
+    def test_service_restart_invalid(self, MockInit, MockBusName, MockSystemBus):
+        systemd_service_stub = systemd_service.SystemdService(systemd_service.MOD_NAME)
+        service = "unsupported_service"
+        ret, msg = systemd_service_stub.restart_service(service)
+        assert ret == 1
+        assert "Dbus does not support" in msg
         
-    def test_service_stop(self, MockInit, MockBusName, MockSystemBus):
+    @mock.patch("dbus.SystemBus")
+    @mock.patch("dbus.service.BusName")
+    @mock.patch("dbus.service.Object.__init__")
+    def test_service_stop_valid(self, MockInit, MockBusName, MockSystemBus):
         with mock.patch("subprocess.run") as mock_run:
             res_mock = mock.Mock()
             test_ret = 0
+            test_msg = b"Succeeded"
             attrs = {"returncode": test_ret, "stderr": test_msg}
             res_mock.configure_mock(**attrs)
             mock_run.return_value = res_mock
@@ -58,19 +55,13 @@ class TestSystemdService(object):
             assert ret == test_ret, "Return value is wrong"
             assert msg == "", "Return message is wrong"
 
-        with mock.patch("subprocess.run") as mock_run:
-            res_mock = mock.Mock()
-            test_ret = 1
-            test_msg = b"Dbus does not support"
-            attrs = {"returncode": test_ret, "stderr": test_msg}
-            res_mock.configure_mock(**attrs)
-            mock_run.return_value = res_mock
-            service = "unsupported"
-            systemd_service_stub = systemd_service.SystemdService(systemd_service.MOD_NAME)
-            ret, msg = systemd_service_stub.stop_service(service)
-            call_args = mock_run.call_args[0][0]
-            assert "/usr/bin/systemctl" in call_args
-            assert service in call_args
-            assert "stop" in call_args
-            assert ret == test_ret, "Return value is wrong"
-            assert "Dbus does not support" in msg, "Return message is wrong"
+    @mock.patch("dbus.SystemBus")
+    @mock.patch("dbus.service.BusName")
+    @mock.patch("dbus.service.Object.__init__")
+    def test_service_stop_invalid(self, MockInit, MockBusName, MockSystemBus):
+        service = "unsupported service"
+        systemd_service_stub = systemd_service.SystemdService(systemd_service.MOD_NAME)
+        ret, msg = systemd_service_stub.stop_service(service)
+        assert ret == 1
+        assert "Dbus does not support" in msg
+


### PR DESCRIPTION
As part of the GNOI project (HLD: https://github.com/sonic-net/SONiC/pull/1644), we require dbus support for service kill and restart.

This PR adds dbus support for service kill and restart, restricted to services snmp and swss to protect SONiC system in initial phases of this project. 