### PR TITLE
[caclmgrd]Fix bfd and vxlan acl rules programming in acl table update scenario

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -806,6 +806,12 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
             self.log_info("  " + ' '.join(cmd))
 
         self.run_commands(iptables_cmds)
+        if self.bfdAllowed:
+            self.allow_bfd_protocol(namespace)
+        if self.VxlanAllowed:
+            fvs = swsscommon.FieldValuePairs([("src_ip", self.VxlanSrcIP)])
+            self.allow_vxlan_port(namespace, fvs)
+
 
         self.update_control_plane_nat_acls(namespace, service_to_source_ip_map, config_db_connector)
 

--- a/tests/caclmgrd/caclmgrd_bfd_test.py
+++ b/tests/caclmgrd/caclmgrd_bfd_test.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import swsscommon
+from swsscommon import swsscommon
 
 from parameterized import parameterized
 from sonic_py_common.general import load_module_from_source
@@ -18,7 +18,7 @@ class TestCaclmgrdBfd(TestCase):
         Test caclmgrd bfd
     """
     def setUp(self):
-        swsscommon.swsscommon.ConfigDBConnector = MockConfigDb
+        swsscommon.ConfigDBConnector = MockConfigDb
         test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         modules_path = os.path.dirname(test_path)
         scripts_path = os.path.join(modules_path, "scripts")
@@ -47,5 +47,10 @@ class TestCaclmgrdBfd(TestCase):
 
                 caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
                 caclmgrd_daemon.allow_bfd_protocol('')
+                mocked_subprocess.Popen.assert_has_calls(test_data["expected_subprocess_calls"], any_order=True)
+                caclmgrd_daemon.bfdAllowed = True
+                mocked_subprocess.Popen.reset_mock()
+                caclmgrd_daemon.num_changes[''] = 1
+                caclmgrd_daemon.check_and_update_control_plane_acls('', 1)
                 mocked_subprocess.Popen.assert_has_calls(test_data["expected_subprocess_calls"], any_order=True)
 

--- a/tests/caclmgrd/caclmgrd_vxlan_test.py
+++ b/tests/caclmgrd/caclmgrd_vxlan_test.py
@@ -55,4 +55,9 @@ class TestCaclmgrdVxlan(TestCase):
                 mocked_subprocess.Popen.assert_has_calls(test_data["expected_add_subprocess_calls"], any_order=True)
                 caclmgrd_daemon.block_vxlan_port('')
                 mocked_subprocess.Popen.assert_has_calls(test_data["expected_del_subprocess_calls"], any_order=True)
+                caclmgrd_daemon.allow_vxlan_port('', data)
+                mocked_subprocess.Popen.reset_mock()
+                caclmgrd_daemon.num_changes[''] = 1
+                caclmgrd_daemon.check_and_update_control_plane_acls('', 1)
+                mocked_subprocess.Popen.assert_has_calls(test_data["expected_add_subprocess_calls"], any_order=True)
 

--- a/tests/common/mock_configdb.py
+++ b/tests/common/mock_configdb.py
@@ -51,8 +51,9 @@ class MockConfigDb(object):
 
     def get_table(self, table_name):
         data = {}
-        for k, v in MockConfigDb.CONFIG_DB[table_name].items():
-            data[self.deserialize_key(k)] = v
+        if table_name in MockConfigDb.CONFIG_DB:
+            for k, v in MockConfigDb.CONFIG_DB[table_name].items():
+                data[self.deserialize_key(k)] = v
         return data
 
     def subscribe(self, table_name, callback):


### PR DESCRIPTION
When there is an ACL table update, caclmgrd flushes all the existing rules and recreates the rules based on configuration. This flow misses bfd and vxlan rules and thus if an ACL table is dynamically loaded, BFD and VxLAN rules would miss in the final set of rules.

Fixed the flow by checking and adding VxLAN and BFD rules

Added UT to verify the flow