### PR TITLE
Update sonic-host-services-data.determine-reboot-cause.service

### DIFF
--- a/data/debian/sonic-host-services-data.determine-reboot-cause.service
+++ b/data/debian/sonic-host-services-data.determine-reboot-cause.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Reboot cause determination service
-Requires=rc-local.service database.service
-After=rc-local.service database.service
+Requires=rc-local.service
+After=rc-local.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Signed-off-by: Xincun Li [xincun.li@microsoft.com](mailto:xincun.li@microsoft.com)

**Why I did it**

To enhance system stability and optimize inter-service dependencies, I removed the determine-reboot-cause's dependency on database.service.

MSFT ADO: **26209780**

**How I did it**

1. Remove determine-reboot-cause's dependency with database.service.

**How to verify it**
Steps:

1. Without changes: Show reboot-cause history, check output.
2. Apply the change
3. Restart db docker, check determine process reboot cause.
4. Verify the Show reboot-cause history, check output.
5. list dependency output.

```shell
admin@str3-msn4600c-acs-05:~$ show reboot-cause history 
Name                 Cause                                              Time                             User    Comment
-------------------  -------------------------------------------------  -------------------------------  ------  ---------
2024_04_23_19_09_23  reboot                                             Tue 23 Apr 2024 07:07:23 PM UTC  admin   N/A
2024_04_23_07_02_00  Unknown (First boot of SONiC version 20231110.09)  N/A                              N/A     N/A
2024_04_23_06_48_50  reboot                                             Tue 23 Apr 2024 06:48:02 AM UTC  admin   N/A
2024_04_23_06_43_13  reboot                                             Tue 23 Apr 2024 06:42:25 AM UTC  admin   N/A
2024_04_23_06_08_24  Unknown                                            N/A                              N/A     N/A
2024_04_22_21_29_03  reboot                                             Mon 22 Apr 2024 09:28:16 PM UTC  admin   N/A
2024_04_22_21_22_52  reboot                                             Mon 22 Apr 2024 09:22:05 PM UTC  admin   N/A
2024_04_22_21_16_52  reboot                                             Mon 22 Apr 2024 09:16:05 PM UTC  admin   N/A
2024_04_22_21_10_47  Watchdog                                           N/A                              N/A     Unknown
2024_04_22_21_04_44  soft-reboot                                        Mon 22 Apr 2024 09:04:24 PM UTC  admin   N/A

admin@str3-msn4600c-acs-05:~$ docker stop database 
database

admin@str3-msn4600c-acs-05:~$ docker ps -a
CONTAINER ID   IMAGE                                COMMAND                  CREATED       STATUS                     PORTS     NAMES
1de2b92d4c59   docker-snmp:latest                   "/usr/local/bin/supe…"   2 hours ago   Up 2 hours                           snmp
ba6a737312f9   docker-sonic-mgmt-framework:latest   "/usr/local/bin/supe…"   2 hours ago   Up 2 hours                           mgmt-framework
8a4389c45bdf   docker-lldp:latest                   "/usr/bin/docker-lld…"   2 hours ago   Up 2 hours                           lldp
90a875824801   docker-sonic-gnmi:latest             "/usr/local/bin/supe…"   2 hours ago   Up 2 hours                           gnmi
ce19ec771ac5   docker-platform-monitor:latest       "/usr/bin/docker_ini…"   2 hours ago   Up 2 hours                           pmon
c456c8548ee6   docker-router-advertiser:latest      "/usr/bin/docker-ini…"   2 hours ago   Up 2 hours                           radv
c521123a450c   docker-syncd-mlnx:latest             "/usr/local/bin/supe…"   2 hours ago   Up 2 hours                           syncd
03b4d87822fa   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   2 hours ago   Up 2 hours                           bgp
226ae26a0614   docker-teamd:latest                  "/usr/local/bin/supe…"   2 hours ago   Up 2 hours                           teamd
bc689d1e75c5   docker-orchagent:latest              "/usr/bin/docker-ini…"   2 hours ago   Up 2 hours                           swss
5cdc86b679f8   docker-eventd:latest                 "/usr/local/bin/supe…"   2 hours ago   Up 2 hours                           eventd
34fe36f3428f   docker-database:latest               "/usr/local/bin/dock…"   2 hours ago   Exited (0) 6 seconds ago             database

admin@str3-msn4600c-acs-05:~$ systemctl status determine-reboot-cause.service 
● determine-reboot-cause.service - Reboot cause determination service
     Loaded: loaded (/lib/systemd/system/determine-reboot-cause.service; enabled; preset: enabled)
     Active: active (exited) since Tue 2024-04-23 19:09:23 UTC; 2h 47min ago
   Main PID: 6841 (code=exited, status=0/SUCCESS)

admin@str3-msn4600c-acs-05:~$ docker start database 
database
admin@str3-msn4600c-acs-05:~$ docker ps
CONTAINER ID   IMAGE                                COMMAND                  CREATED       STATUS          PORTS     NAMES
1de2b92d4c59   docker-snmp:latest                   "/usr/local/bin/supe…"   2 hours ago   Up 2 hours                snmp
ba6a737312f9   docker-sonic-mgmt-framework:latest   "/usr/local/bin/supe…"   2 hours ago   Up 2 hours                mgmt-framework
8a4389c45bdf   docker-lldp:latest                   "/usr/bin/docker-lld…"   2 hours ago   Up 2 hours                lldp
90a875824801   docker-sonic-gnmi:latest             "/usr/local/bin/supe…"   2 hours ago   Up 2 hours                gnmi
ce19ec771ac5   docker-platform-monitor:latest       "/usr/bin/docker_ini…"   2 hours ago   Up 2 hours                pmon
c456c8548ee6   docker-router-advertiser:latest      "/usr/bin/docker-ini…"   2 hours ago   Up 2 hours                radv
03b4d87822fa   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   2 hours ago   Up 2 hours                bgp
226ae26a0614   docker-teamd:latest                  "/usr/local/bin/supe…"   2 hours ago   Up 2 hours                teamd
bc689d1e75c5   docker-orchagent:latest              "/usr/bin/docker-ini…"   2 hours ago   Up 2 hours                swss
34fe36f3428f   docker-database:latest               "/usr/local/bin/dock…"   2 hours ago   Up 22 seconds             database
admin@str3-msn4600c-acs-05:~$ show reboot-cause history
Name                 Cause                                              Time                             User    Comment
-------------------  -------------------------------------------------  -------------------------------  ------  ---------
2024_04_23_19_09_23  reboot                                             Tue 23 Apr 2024 07:07:23 PM UTC  admin   N/A
2024_04_23_07_02_00  Unknown (First boot of SONiC version 20231110.09)  N/A                              N/A     N/A
2024_04_23_06_48_50  reboot                                             Tue 23 Apr 2024 06:48:02 AM UTC  admin   N/A
2024_04_23_06_43_13  reboot                                             Tue 23 Apr 2024 06:42:25 AM UTC  admin   N/A
2024_04_23_06_08_24  Unknown                                            N/A                              N/A     N/A
2024_04_22_21_29_03  reboot                                             Mon 22 Apr 2024 09:28:16 PM UTC  admin   N/A
2024_04_22_21_22_52  reboot                                             Mon 22 Apr 2024 09:22:05 PM UTC  admin   N/A
2024_04_22_21_16_52  reboot                                             Mon 22 Apr 2024 09:16:05 PM UTC  admin   N/A
2024_04_22_21_10_47  Watchdog                                           N/A                              N/A     Unknown
2024_04_22_21_04_44  soft-reboot                                        Mon 22 Apr 2024 09:04:24 PM UTC  admin   N/A

admin@str3-msn4600c-acs-05:~$ sudo systemctl list-dependencies determine-reboot-cause.service 
determine-reboot-cause.service
● ├─system.slice
● └─sysinit.target
●   ├─apparmor.service
●   ├─dev-hugepages.mount
●   ├─dev-mqueue.mount
●   ├─haveged.service
●   ├─kmod-static-nodes.service
●   ├─proc-sys-fs-binfmt_misc.automount
●   ├─sys-fs-fuse-connections.mount
●   ├─sys-kernel-config.mount
●   ├─sys-kernel-debug.mount
●   ├─sys-kernel-tracing.mount
●   ├─systemd-ask-password-console.path
●   ├─systemd-binfmt.service
○   ├─systemd-firstboot.service
●   ├─systemd-journal-flush.service
●   ├─systemd-journald.service
○   ├─systemd-machine-id-commit.service
●   ├─systemd-modules-load.service
●   ├─systemd-network-generator.service
○   ├─systemd-pcrphase-sysinit.service
○   ├─systemd-pcrphase.service
○   ├─systemd-pstore.service
●   ├─systemd-random-seed.service
○   ├─systemd-repart.service
●   ├─systemd-sysctl.service
●   ├─systemd-sysusers.service
●   ├─systemd-tmpfiles-setup-dev.service
●   ├─systemd-tmpfiles-setup.service
●   ├─systemd-udev-trigger.service
●   ├─systemd-udevd.service
●   ├─systemd-update-utmp.service
●   ├─cryptsetup.target
●   ├─integritysetup.target
●   ├─local-fs.target
●   │ └─systemd-remount-fs.service
●   ├─swap.target
●   └─veritysetup.target
