### PR TITLE
Added code to process-reboot-check that mitigates JSON decoder errors

### DIFF
--- a/scripts/process-reboot-cause
+++ b/scripts/process-reboot-cause
@@ -52,12 +52,16 @@ def read_reboot_cause_files_and_save_state_db():
         x = TIME_SORTED_FULL_REBOOT_FILE_LIST[i]
         if os.path.isfile(x):
             with open(x, "r") as cause_file:
-                data = json.load(cause_file)
-                _hash = '{}|{}'.format(REBOOT_CAUSE_TABLE_NAME, data['gen_time'])
-                state_db.set(state_db.STATE_DB, _hash, 'cause', data['cause'])
-                state_db.set(state_db.STATE_DB, _hash, 'time', data['time'])
-                state_db.set(state_db.STATE_DB, _hash, 'user', data['user'])
-                state_db.set(state_db.STATE_DB, _hash, 'comment', data['comment'])
+                try:
+                    data = json.load(cause_file)
+                    _hash = '{}|{}'.format(REBOOT_CAUSE_TABLE_NAME, data['gen_time'])
+                    state_db.set(state_db.STATE_DB, _hash, 'cause', data['cause'])
+                    state_db.set(state_db.STATE_DB, _hash, 'time', data['time'])
+                    state_db.set(state_db.STATE_DB, _hash, 'user', data['user'])
+                    state_db.set(state_db.STATE_DB, _hash, 'comment', data['comment'])
+                except json.decoder.JSONDecodeError as je:
+                    sonic_logger.log_info("Unable to process reload cause file {}: {}".format(x, je))
+                    pass
 
     if len(TIME_SORTED_FULL_REBOOT_FILE_LIST) > 10:
         for i in range(len(TIME_SORTED_FULL_REBOOT_FILE_LIST)):


### PR DESCRIPTION
**Why I did it**

The current process-reboot-cause script is susceptible to JSONDecodeErrors if the reboot-cause file is not a properly formatted JSON file.

**How I did it**

Added a try-except block around the actual JSON parsing bit of the code

**Microsoft ADO**: 28062468

**How I verified it**

First I verified that the issue is seen when the reboot-cause file is either an empty file or an improperly formatted JSON file:

<img width="319" alt="image" src="https://github.com/sonic-net/sonic-host-services/assets/93744978/e24c53f5-096d-4e2a-9a6f-a696ebac0eb9">

<img width="544" alt="image" src="https://github.com/sonic-net/sonic-host-services/assets/93744978/7f6b9ed2-5231-4739-938d-a67bc283fdb8">

I then replaced the existing script with the script from this PR and restarted the service:

<img width="832" alt="image" src="https://github.com/sonic-net/sonic-host-services/assets/93744978/cb5eba6c-5deb-4a7d-9f76-4c7011ad5628">

As is seen, the service exited with `SUCCESS` exit code and journalctl shows the JSON Decoder exception raised when trying to parse an improper JSON file.
