### PR TITLE
Made Global and ASIC Scope Handling only for multi-asic only.

### DIFF
--- a/scripts/featured
+++ b/scripts/featured
@@ -287,7 +287,9 @@ class FeatureHandler(object):
             unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
             if not unit_file_state:
                 continue
-            if unit_file_state != "disabled" and \
+            if self.is_multi_npu:
+                continue
+            if unit_file_state != "masked" and \
               ((not feature_config.has_per_asic_scope and '@' in feature_name) or (not feature_config.has_global_scope and '@' not in feature_name)):
                 cmds = []
                 for suffix in reversed(feature_suffixes):

--- a/scripts/featured
+++ b/scripts/featured
@@ -287,7 +287,7 @@ class FeatureHandler(object):
             unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
             if not unit_file_state:
                 continue
-            if self.is_multi_npu:
+            if not self.is_multi_npu:
                 continue
             if unit_file_state != "masked" and \
               ((not feature_config.has_per_asic_scope and '@' in feature_name) or (not feature_config.has_global_scope and '@' not in feature_name)):


### PR DESCRIPTION
Why I did:

To fix: https://github.com/sonic-net/sonic-buildimage/pull/19039 KVM Test failure.

How I did:
Global and ASIC Scope handling make sense only for Multi-asic platforms. For Single ASIC platforms they don't apply, and feature can be controlled by Feature `state` field.

 Also one the feature is masked it final state is masked and not disabled. So updated the check to see if service is not in masked state then try to disable/mask it.

```
admin@vlab-01:/var/log$ sudo systemctl show lldp.service --property UnitFileState
UnitFileState=masked
```

