### PR TITLE
Fixed determine/process reboot-cause service dependency (#17406)

### DIFF
--- a/data/debian/sonic-host-services-data.determine-reboot-cause.service
+++ b/data/debian/sonic-host-services-data.determine-reboot-cause.service
@@ -2,6 +2,7 @@
 Description=Reboot cause determination service
 Requires=rc-local.service
 After=rc-local.service
+Wants=process-reboot-cause.service
 
 [Service]
 Type=oneshot

--- a/data/debian/sonic-host-services-data.process-reboot-cause.service
+++ b/data/debian/sonic-host-services-data.process-reboot-cause.service
@@ -1,8 +1,16 @@
 [Unit]
 Description=Retrieve the reboot cause from the history files and save them to StateDB
-Requires=database.service determine-reboot-cause.service
+PartOf=database.service
 After=database.service determine-reboot-cause.service
 
 [Service]
 Type=simple
+ExecStartPre=/usr/bin/systemctl is-active database
+ExecStartPre=/usr/bin/systemctl is-active determine-reboot-cause
+Restart=on-failure
+RestartSec=30
+RemainAfterExit=yes
 ExecStart=/usr/local/bin/process-reboot-cause
+
+[Install]
+WantedBy=multi-user.target

--- a/data/debian/sonic-host-services-data.process-reboot-cause.timer
+++ b/data/debian/sonic-host-services-data.process-reboot-cause.timer
@@ -1,9 +1,0 @@
-[Unit]
-Description=Delays process-reboot-cause until network is stably connected
-
-[Timer]
-OnBootSec=1min 30 sec
-Unit=process-reboot-cause.service
-
-[Install]
-WantedBy=timers.target


### PR DESCRIPTION
Signed-off-by: anamehra <anamehra@cisco.com>
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes https://github.com/sonic-net/sonic-buildimage/issues/16990  for 202405 branch

Cherry-picked PR https://github.com/sonic-net/sonic-buildimage/pull/17406 due to conflict.

1. determine-reboot-cause  and process-reboot-cause service does not start If the database service fails to restart in the first attempt. Even if the Database service succeeds in the next attempt, these reboot-cause services do not start.

2. The process-reboot-cause service also does not restart if the docker or database service restarts, which leads to an empty reboot-cause history

3. deploy-mg from sonic-mgmt also triggers the docker service restart. The restart of the docker service caused the issue stated in 2 above. The docker restart also triggers determine-reboot-cause to restart which creates an additional reboot-cause file in history and modifies the last reboot-cause.

This PR fixes these issues by making both processes start again when dependency meets after dependency failure, making both processes restart when the database service restarts, and preventing duplicate processing of the last reboot reason.

##### Work item tracking
- Microsoft ADO **25892856**

#### How I did it
1. Modified systemd unit files to make determine-reboot-cause and process-reboot-cause services restartable when the database service restarts.
2. On the restart, the determine-reboot-cause service should not recreate a new reboot-cause entry in the database. Added check for first start or restart to skip entry for restart case.

#### How to verify it
On single asic pizza box:
1.  Installed the image and check reboot-cause history
2. restart database service and verify that determine-reboot-cause and process-reboot-cause services also restart. Verify that reboot-cause shows correct data and no new entry is created for restart.

On Chassis:
1.  Installed the image and check reboot-cause history
2. restart the database service and verify that determine-reboot-cause and process-reboot-cause services also restart. Verify that reboot-cause shows correct data and no new entry is created for restart.
5. Reboot LC. On Supervicor, stop database-chassis service.
     Let database service on LC fail the first time. determine-reboot-cause and process-reboot-cause  would fail to start due to dependency failure
     start database-chassis on Supervisor. Database service on LC should now start successfully.
     Verify determine-reboot-cause and process-reboot-cause  also starts
     Verify show reboot-cause history output
