### PR TITLE
Ignore sonic_platform package fileNotFoundError on non-chassis vs platforms

### DIFF
--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -108,7 +108,7 @@ def get_reboot_cause_from_platform():
         chassis  = platform.get_chassis()
         hardware_reboot_cause_major, hardware_reboot_cause_minor = chassis.get_reboot_cause()
         sonic_logger.log_info("Platform api returns reboot cause {}, {}".format(hardware_reboot_cause_major, hardware_reboot_cause_minor))
-    except ImportError:
+    except (ImportError, FileNotFoundError):
         sonic_logger.log_warning("sonic_platform package not installed. Unable to detect hardware reboot causes.")
         hardware_reboot_cause_major, hardware_reboot_cause_minor = REBOOT_CAUSE_NON_HARDWARE, "N/A"
 


### PR DESCRIPTION

Issue:
For T2 vs chassis support, sonic_platform package was introduced as part of PR https://github.com/sonic-net/sonic-buildimage/pull/18512

Even though this package will be present on all VS platforms, its a no-op on non-chassis VS platforms. On VS Chassis platforms, this requires a metadata file, which will not be available on pizza box VS platforms. 

As part of determine-reboot-cause script, this sonic_platform package is imported, which is throwing FIleNotFoundError on vs platforms, where this metadata file is not present.

Fix: Added this FileNotFoundError in exception, as this is under a determine_reboot_cause_from_platform check, which is NA on VS platforms.
