### PR TITLE
Modified scripts: replaced deprecated 'logger' with 'syslogger'

### DIFF
--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -14,7 +14,7 @@ try:
     import re
     import sys
 
-    from sonic_py_common import device_info, logger
+    from sonic_py_common import device_info, syslogger
 
 except ImportError as err:
     raise ImportError("%s - required module not found" % str(err))
@@ -44,7 +44,7 @@ REBOOT_CAUSE_NON_HARDWARE = "Non-Hardware"
 REBOOT_CAUSE_HARDWARE_OTHER = "Hardware - Other"
 
 # Global logger class instance
-sonic_logger = logger.Logger(SYSLOG_IDENTIFIER)
+sonic_logger = syslogger.SysLogger(SYSLOG_IDENTIFIER)
 
 
 # ============================= Functions =============================
@@ -210,7 +210,7 @@ def determine_reboot_cause():
 
 def main():
     # Configure logger to log all messages INFO level and higher
-    sonic_logger.set_min_log_priority_info()
+    sonic_logger.set_min_log_priority(sonic_logger.DEFAULT_LOG_LEVEL)
 
     sonic_logger.log_info("Starting up...")
 

--- a/scripts/process-reboot-cause
+++ b/scripts/process-reboot-cause
@@ -13,7 +13,7 @@ try:
     import sys
 
     from swsscommon import swsscommon
-    from sonic_py_common import logger
+    from sonic_py_common import syslogger
 except ImportError as err:
     raise ImportError("%s - required module not found" % str(err))
 
@@ -33,7 +33,7 @@ REDIS_HOSTIP = "127.0.0.1"
 state_db = None
 
 # Global logger class instance
-sonic_logger = logger.Logger(SYSLOG_IDENTIFIER)
+sonic_logger = syslogger.SysLogger(SYSLOG_IDENTIFIER)
 
 
 # ============================= Functions =============================

--- a/scripts/process-reboot-cause
+++ b/scripts/process-reboot-cause
@@ -72,7 +72,7 @@ def read_reboot_cause_files_and_save_state_db():
 
 def main():
     # Configure logger to log all messages INFO level and higher
-    sonic_logger.set_min_log_priority_info()
+    sonic_logger.set_min_log_priority(sonic_logger.DEFAULT_LOG_LEVEL)
 
     sonic_logger.log_info("Starting up...")
 


### PR DESCRIPTION
**Why I did it**




Modified `determine-reboot-cause` and `process-reboot-cause` scripts to use `syslogger` so as to address an issue where the original Logger.py could override the SYSLOG_IDENTIFIER if a new Logger instance is created.

**How I did it**


Modified the respective scripts to use `SysLogger` instead of `Logger`

**Microsoft ADO: 28449266**

**How I verified it**

1. Ran all the Unit Tests and ensured that they all passed
2. Verified the change on SONiC devices by copying the updated scripts to the host and starting the respective services:

**process-reboot-cause**
```
root@sonic# systemctl start process-reboot-cause.service
root@sonic# systemctl status process-reboot-cause.service
○ process-reboot-cause.service - Retrieve the reboot cause from the history files and save them to StateDB
     Loaded: loaded (/lib/systemd/system/process-reboot-cause.service; static)
     Active: inactive (dead) since Mon 2024-07-08 23:20:38 UTC; 11s ago
   Duration: 210ms
TriggeredBy: ● process-reboot-cause.timer
    Process: 2705155 ExecStart=/usr/local/bin/process-reboot-cause (code=exited, status=0/SUCCESS)
   Main PID: 2705155 (code=exited, status=0/SUCCESS)

Jul 08 23:20:37 sonic-device systemd[1]: Started process-reboot-cause.service - Retrieve the reboot cause from the history files and save them to StateDB.
Jul 08 23:20:37 sonic-device process-reboot-cause[2705155]: Starting up...
Jul 08 23:20:37 sonic-device process-reboot-cause[2705155]: Previous reboot cause: User issued 'reboot' command [User: admin, Time: Wed 03 Jul 2024 11:07:33 PM UTC]
Jul 08 23:20:38 sonic-device systemd[1]: process-reboot-cause.service: Deactivated successfully.
root@sonic#

```

**determine-reboot-cause**
```
root@sonic# systemctl start determine-reboot-cause.service
root@sonic# systemctl status determine-reboot-cause.service
● determine-reboot-cause.service - Reboot cause determination service
     Loaded: loaded (/lib/systemd/system/determine-reboot-cause.service; enabled; preset: enabled)
     Active: active (exited) since Wed 2024-07-03 23:08:52 UTC; 5 days ago
   Main PID: 1017 (code=exited, status=0/SUCCESS)

Notice: journal has been rotated since unit was started, output may be incomplete.
root@sonic#
```