### PR TITLE
Fix security vulnerability in caclmgrd

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -783,8 +783,15 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
 
         # Add iptables/ip6tables commands to allow all incoming packets with TTL of 0 or 1
         # This allows the device to respond to tools like tcptraceroute
-        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['iptables', '-A', 'INPUT', '-m', 'ttl', '--ttl-lt', '2', '-j', 'ACCEPT'])
-        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-m', 'hl', '--hl-lt', '2', '-j', 'ACCEPT'])
+        # Allow ICMP with TTL < 2
+        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['iptables', '-A', 'INPUT', '-p', 'icmp', '-m', 'ttl', '--ttl-lt', '2', '-j', 'ACCEPT'])
+        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-A', 'INPUT', '-p', 'ipv6-icmp', '-m', 'hl', '--hl-lt', '2', '-j', 'ACCEPT'])
+
+        # Allow UDP and TCP with TTL < 2 and dst-port > 1024, in case traceroute based on UDP or TCP
+        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['iptables', '-A', 'INPUT', '-p', 'udp', '-m', 'ttl', '--ttl-lt', '2', '--dport', '1025:65535', '-j', 'ACCEPT'])
+        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['iptables', '-A', 'INPUT', '-p', 'tcp', '-m', 'ttl', '--ttl-lt', '2', '--dport', '1025:65535', '-j', 'ACCEPT'])
+        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-A', 'INPUT', '-p', 'udp', '-m', 'hl', '--hl-lt', '2', '--dport', '1025:65535', '-j', 'ACCEPT'])
+        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-m', 'hl', '--hl-lt', '2', '--dport', '1025:65535', '-j', 'ACCEPT'])
 
         # Finally, if the device has control plane ACLs configured,
         # add iptables/ip6tables commands to drop all other incoming packets


### PR DESCRIPTION
- description:

After installation, a default iptables rule allows an attacker to bypass all others rules protecting the switch management & control-plane.

- Mitigation:

Accept only ttl-lt 2 for ICMP packets, or possibly dst-port > 1024.
Traceroute may be based on ICMP or UDP or TCP.
For ICMP: accept all icmp protocol TTL < 2 packets
For UDP: accept UDP protocol TTL < 2 and UDP dest port > 1024 packets
For TCP: accept TCP protocol TTL < 2 and TCP dest port > 1024 packets
For other mismatched packets, default action is drop

- work item:

28662516
