### PR TITLE
Fix hostcfgd modify_single_file method generates empty file issue

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -612,8 +612,8 @@ class AaaCfg(object):
             e_operations = [item for sublist in zip(e_list, operations) for item in sublist]
             with open(filename+'.new', 'w') as f:
                 subprocess.call(["sed"] + e_operations + [filename], stdout=f)
-            subprocess.call(["mv", '-f', filename, filename+'.old'])
-            subprocess.call(['mv', '-f', filename+'.new', filename])
+            subprocess.call(["cp", '-f', filename, filename+'.old'])
+            subprocess.call(['cp', '-f', filename+'.new', filename])
 
         self.check_file_not_empty(filename)
 


### PR DESCRIPTION
Fix hostcfgd modify_single_file method generates empty file issue

#### Why I did it
Fix hostcfgd modify_single_file method generates empty file issue: https://github.com/sonic-net/sonic-buildimage/issues/19748

In the original code, there are 2 'mv' commands to backup and copy new file, if hostcfgd crash between those 2 commands, the original file will be removed, then when hostcfgd restart later, it will generate a empty file.

The issue can be fix by use cp command.

##### Work item tracking
- Microsoft ADO: 29064569

#### How I did it
Replace 'mv' command to 'cp' command

#### How to verify it
Manually verified.
Pass all test case.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

will updated with this PR image later.
- [] SONiC.master-16482.360728-2c8b4066f

#### Description for the changelog
Fix hostcfgd modify_single_file method generates empty file issue

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

