### PR TITLE
Disable connection tracking for icmpv6 traffic

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -581,6 +581,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-P', 'OUTPUT', 'ACCEPT'])
         iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-F'])
         iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-X'])
+        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-t', 'raw', '-F'])
 
         # Add iptables/ip6tables commands to allow all traffic from localhost
         iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['iptables', '-A', 'INPUT', '-s', '127.0.0.1', '-i', 'lo', '-j', 'ACCEPT'])
@@ -642,6 +643,10 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         # TODO: Determine BGP ACLs based on configured device sessions, and remove this blanket acceptance
         iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['iptables', '-A', 'INPUT', '-p', 'tcp', '--dport', '179', '-j', 'ACCEPT'])
         iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-A', 'INPUT', '-p', 'tcp', '--dport', '179', '-j', 'ACCEPT'])
+
+        # Add ip6tables commands to disable connection tracking for icmpv6 traffic
+        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-t', 'raw', '-A', 'PREROUTING', '-p', 'ipv6-icmp', '-j', 'NOTRACK'])
+        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-t', 'raw', '-A', 'OUTPUT', '-p', 'ipv6-icmp', '-j', 'NOTRACK'])
 
         # Get current ACL tables and rules from Config DB
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'systemd-python',
         'Jinja2>=2.10',
         'PyGObject',
+        'pycairo==1.26.1',
         'psutil'
     ] + sonic_dependencies,
     setup_requires = [

--- a/tests/caclmgrd/caclmgrd_conntrack_test.py
+++ b/tests/caclmgrd/caclmgrd_conntrack_test.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+from swsscommon import swsscommon
+from parameterized import parameterized
+from unittest import TestCase, mock
+from pyfakefs.fake_filesystem_unittest import patchfs
+from sonic_py_common.general import load_module_from_source
+
+from .test_icmpv6_ct_rule_vectors import CACLMGRD_ICMPV6_CT_RULE_TEST_VECTOR
+from tests.common.mock_configdb import MockConfigDb
+
+DBCONFIG_PATH = '/var/run/redis/sonic-db/database_config.json'
+
+
+class TestCaclmgrdConntrack(TestCase):
+    """
+    Test to verify that ip6tables rules to not track icmpv6 packets exist
+    """
+    def setUp(self):
+        swsscommon.ConfigDBConnector = MockConfigDb
+        test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        modules_path = os.path.dirname(test_path)
+        scripts_path = os.path.join(modules_path, "scripts")
+        sys.path.insert(0, modules_path)
+        caclmgrd_path = os.path.join(scripts_path, 'caclmgrd')
+        self.caclmgrd = load_module_from_source('caclmgrd', caclmgrd_path)
+        self.icmpv6_ct_prerouting_rule = ('ip6tables', '-t', 'raw', '-A', 'PREROUTING', '-p', 'ipv6-icmp', '-j', 'NOTRACK')
+        self.icmpv6_ct_output_rule = ('ip6tables', '-t', 'raw', '-A', 'OUTPUT', '-p', 'ipv6-icmp', '-j', 'NOTRACK')
+
+    @parameterized.expand(CACLMGRD_ICMPV6_CT_RULE_TEST_VECTOR)
+    @patchfs
+    def test_caclmgrd_icmpv6_ct_rules(self, test_name, test_data, fs):
+        if not os.path.exists(DBCONFIG_PATH):
+            fs.create_file(DBCONFIG_PATH)  # fake database_config.json
+
+        MockConfigDb.set_config_db(test_data["config_db"])
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ip = mock.MagicMock()
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ipv6 = mock.MagicMock()
+        self.caclmgrd.ControlPlaneAclManager.generate_block_ip2me_traffic_iptables_commands = mock.MagicMock(return_value=[])
+        self.caclmgrd.ControlPlaneAclManager.get_chain_list = mock.MagicMock(return_value=["INPUT", "FORWARD", "OUTPUT"])
+        self.caclmgrd.ControlPlaneAclManager.get_chassis_midplane_interface_ip = mock.MagicMock(return_value='')
+        caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
+
+        ip6tables_rules_ret, _ = caclmgrd_daemon.get_acl_rules_and_translate_to_iptables_commands('', MockConfigDb())
+        ip6tables_rules_ret = [tuple(i) for i in ip6tables_rules_ret]
+        self.assertIn(self.icmpv6_ct_prerouting_rule, ip6tables_rules_ret)
+        self.assertIn(self.icmpv6_ct_output_rule, ip6tables_rules_ret)

--- a/tests/caclmgrd/test_icmpv6_ct_rule_vectors.py
+++ b/tests/caclmgrd/test_icmpv6_ct_rule_vectors.py
@@ -1,0 +1,24 @@
+from unittest.mock import call
+import subprocess
+
+"""
+    caclmgrd icmpv6 conntrack rules test vector
+"""
+CACLMGRD_ICMPV6_CT_RULE_TEST_VECTOR = [
+    [
+        "ICMPv6 conntrack rules test",
+        {
+            "config_db": {
+                "DEVICE_METADATA": {
+                    "localhost": {
+                        "subtype": "DualToR",
+                        "type": "ToRRouter",
+                    }
+                },
+                "FEATURE": {},
+            },
+            "return": [
+            ],
+        }
+    ]
+]


### PR DESCRIPTION
 icmpv6 connection tracking can cause conntrack table in kernel to grow rapidly
 and lead to packets being dropped, making the device unresponsive to connection
 requests. The signature seen when this happens is the following:

 "kernel: nf_conntrack: nf_conntrack: table full, dropping packet”

 An investigation on this identified that most of the entries in conntrack table
 were due to unreplied icmpv6 requests which ended up in the dying list.

 Snippet of "conntrack -f ipv6 -L dying " on a device with the issue:

icmpv6   58 0 src=2603:10b0:105:1065::1 dst=2603:10b0:105:1065:0:3de0:f090:e3e0 type=128 code=0 id=56516 [UNREPLIED] src=2603:10b0:105:1065:0:3de0:f090:e3e0 dst=2603:10b0:105:1065::1 type=129 code=0 id=56516 mark=0 use=1
icmpv6   58 0 src=2603:10b0:105:1065::1 dst=2603:10b0:105:1065:8:9e9a:fa90:e3d0 type=128 code=0 id=49585 [UNREPLIED] src=2603:10b0:105:1065:8:9e9a:fa90:e3d0 dst=2603:10b0:105:1065::1 type=129 code=0 id=49585 mark=0 use=1
icmpv6   58 0 src=2603:10b0:105:1065::1 dst=2603:10b0:105:1065:1:6af9:fd90:e3cc type=128 code=0 id=50650 [UNREPLIED] src=2603:10b0:105:1065:1:6af9:fd90:e3cc dst=2603:10b0:105:1065::1 type=129 code=0 id=50650 mark=0 use=2
icmpv6   58 0 src=2603:10b0:105:1065::1 dst=2603:10b0:105:1065:1:21fb:f090:e3c4 type=128 code=0 id=37425 [UNREPLIED] src=2603:10b0:105:1065:1:21fb:f090:e3c4 dst=2603:10b0:105:1065::1 type=129 code=0 id=37425 mark=0 use=1
icmpv6   58 0 src=2603:10b0:105:1065::1 dst=2603:10b0:105:1065:0:8715:f690:e3cc type=128 code=0 id=49153 [UNREPLIED] src=2603:10b0:105:1065:0:8715:f690:e3cc dst=2603:10b0:105:1065::1 type=129 code=0 id=49153 mark=0 use=1
icmpv6   58 0 src=2603:10b0:105:1065::1 dst=2603:10b0:105:1065:0:4b95:f790:e3c4 type=128 code=0 id=12475 [UNREPLIED] src=2603:10b0:105:1065:0:4b95:f790:e3c4 dst=2603:10b0:105:1065::1 type=129 code=0 id=12475 mark=0 use=1
icmpv6   58 0 src=2603:10b0:105:1065::1 dst=2603:10b0:105:1065:0:453e:f090:e3d4 type=128 code=0 id=57081 [UNREPLIED] src=2603:10b0:105:1065:0:453e:f090:e3d4 dst=2603:10b0:105:1065::1 type=129 code=0 id=57081 mark=0 use=1

 The fix here is to use the raw table PREROUTING and OUTPUT chains in
 ip6tables to disable CT for icmpv6 packets as these really don't need to be
 tracked. SONiC has other iptables rules below to accept icmpv6 traffic even
 without explicit tracking

 -A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type 128 -j ACCEPT
 -A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type 129 -j ACCEPT
 -A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type 1 -j ACCEPT
 -A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type 3 -j ACCEPT
 -A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type 135 -j ACCEPT
 -A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type 136 -j ACCEPT
 -A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type 133 -j ACCEPT
 -A INPUT -p ipv6-icmp -m icmp6 --icmpv6-type 134 -j ACCEPT

 The change has been tested manually using ipv6 neighbors in INCOMPLETE/FAILED
 states and verifying that the icmpv6 connection requests do not get added to
 the kernel conntrack table. The change has also been validated against arp/ndp/
 cacl/nat sonic-mgmt test cases as well. A sonic-mgmt test gap is also opened to
 automate tests for this scenario.
 https://github.com/sonic-net/sonic-mgmt/issues/14350