### PR TITLE
Modify procdockerstatsd to update the redis STATE_DB with system disk…

### DIFF
--- a/scripts/procdockerstatsd
+++ b/scripts/procdockerstatsd
@@ -67,6 +67,17 @@ class ProcDockerStats(daemon_base.DaemonBase):
             process_data_list.append(process_data)
         return process_data_list
 
+   def format_mount_cmd_output(self, cmdout):
+       lines = cmdout.splitlines()
+       keys = re.split(" +", lines[0])
+       mount_data = dict()
+       mount_data_list = []
+       for line in lines[1:]:
+           values = line.split()
+           mount_data_list.append(values)
+       formatted_dict = self.create_mount_dict(mount_data_list)
+       return formatted_dict
+
     def convert_to_bytes(self, value):
         UNITS_B = 'B'
         UNITS_KB = 'KB'
@@ -118,6 +129,20 @@ class ProcDockerStats(daemon_base.DaemonBase):
 
                 dockerdict[key]['PIDS'] = row.get('PIDS')
         return dockerdict
+
+    def create_mount_dict(self, dict_list):
+        mountdict = {}
+        for row in dict_list[0:]:
+            if row[1] == "tmpfs" or row[1] == "devtmpfs" or row[1] == "overlay":
+                continue
+            key = 'MOUNT_POINTS|{}'.format(row[6])
+            mountdict[key] = {}
+            mountdict[key]['Filesystem'] = row[0]
+            mountdict[key]['Type'] = row[1]
+            mountdict[key]['1K-blocks'] = row[2]
+            mountdict[key]['Used'] = row[3]
+            mountdict[key]['Available'] = row[4]
+        return mountdict
 
     def update_dockerstats_command(self):
         cmd = ["docker", "stats", "--no-stream", "-a"]
@@ -197,6 +222,23 @@ class ProcDockerStats(daemon_base.DaemonBase):
         self.update_state_db(fips_db_key, 'enforced', str(enforced))
         self.update_state_db(fips_db_key, 'enabled', str(enabled))
 
+    def update_mountpointstats_command(self):
+        cmd = ["df", "-T"]
+        data = self.run_command(cmd)
+        if not data:
+            self.log_error("'{}' returned null output for filesystem".format(cmd))
+            return False
+        mountdata = self.format_mount_cmd_output(data)
+        if not mountdata:
+            self.log_error("formatting for filesystem output failed")
+            return False
+        self.state_db.delete_all_by_pattern('STATE_DB', 'MOUNT_POINTS|*')
+        for k1, v1 in mountdata.items():
+            for k2, v2 in v1.items():
+                self.update_state_db(k1, k2, v2)
+        return True
+
+
     def update_state_db(self, key1, key2, value2):
         self.state_db.set('STATE_DB', key1, key2, value2)
 
@@ -208,6 +250,7 @@ class ProcDockerStats(daemon_base.DaemonBase):
             print("Must be root to run this daemon")
             sys.exit(1)
 
+        counter = 1
         while True:
             self.update_dockerstats_command()
             datetimeobj = datetime.now()
@@ -218,8 +261,16 @@ class ProcDockerStats(daemon_base.DaemonBase):
             self.update_fipsstats_command()
             self.update_state_db('FIPS_STATS|LastUpdateTime', 'lastupdate', str(datetimeobj))
 
+            if counter == 5:
+                self.update_mountpointstats_command()
+                self.update_state_db('MOUNT_POINTS|LastUpdateTime', 'lastupdate', str(datetimeobj))
+                counter = 1
+
             # Data need to be updated every 2 mins. hence adding delay of 120 seconds
             time.sleep(120)
+
+        # Adding a counter to ensure mount points only updates every 10 mins, instead of 2 mins
+        counter += 1
 
         self.log_info("Exiting ...")
 

--- a/scripts/procdockerstatsd
+++ b/scripts/procdockerstatsd
@@ -298,8 +298,8 @@ class ProcDockerStats(daemon_base.DaemonBase):
             # Data need to be updated every 2 mins. hence adding delay of 120 seconds
             time.sleep(120)
 
-        # Adding a counter to ensure mount points only updates every 10 mins, instead of 2 mins
-        counter += 1
+            # Adding a counter to ensure mount points only updates every 10 mins, instead of 2 mins
+            counter += 1
 
         self.log_info("Exiting ...")
 

--- a/scripts/procdockerstatsd
+++ b/scripts/procdockerstatsd
@@ -68,16 +68,16 @@ class ProcDockerStats(daemon_base.DaemonBase):
             process_data_list.append(process_data)
         return process_data_list
 
-   def format_mount_cmd_output(self, cmdout):
-       lines = cmdout.splitlines()
-       keys = re.split(" +", lines[0])
-       mount_data = dict()
-       mount_data_list = []
-       for line in lines[1:]:
-           values = line.split()
-           mount_data_list.append(values)
-       formatted_dict = self.create_mount_dict(mount_data_list)
-       return formatted_dict
+    def format_mount_cmd_output(self, cmdout):
+        lines = cmdout.splitlines()
+        keys = re.split(" +", lines[0])
+        mount_data = dict()
+        mount_data_list = []
+        for line in lines[1:]:
+            values = line.split()
+            mount_data_list.append(values)
+        formatted_dict = self.create_mount_dict(mount_data_list)
+        return formatted_dict
 
     def convert_to_bytes(self, value):
         UNITS_B = 'B'

--- a/tests/procdockerstatsd_test.py
+++ b/tests/procdockerstatsd_test.py
@@ -137,3 +137,15 @@ class TestProcDockerStatsDaemon(object):
         pdstatsd.update_fipsstats_command()
         assert pdstatsd.state_db.get('STATE_DB', 'FIPS_STATS|state', 'enforced') == "False"
         assert pdstatsd.state_db.get('STATE_DB', 'FIPS_STATS|state', 'enabled') == "True"
+
+    def test_create_mount_dict(self):
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        mountpoint_dict = ["/host", "ext-4", "10000", "1000", "9000", "", "/dev"]
+        mountpoint_dict_return = pdstatsd.create_mount_dict(mountpoint_dict)
+        key = 'MOUNT_POINTS|{}.'.format(mountpoint_dict[6])
+
+        assert mountpoint_dict_return[key]['Filesystem'] == "ext-4"
+        assert mountpoint_dict_return[key]['Type'] == "10000"
+        assert mountpoint_dict_return[key]['1K-blocks'] == "1000"
+        assert mountpoint_dict_return[key]['Used'] == "9000"
+        assert mountpoint_dict_return[key]['Available'] == "/dev"

--- a/tests/procdockerstatsd_test.py
+++ b/tests/procdockerstatsd_test.py
@@ -164,6 +164,22 @@ class TestProcDockerStatsDaemon(object):
         mock_create_mount_dict.assert_called_once()
         assert ret == True 
 
+    @patch.object(procdockerstatsd.ProcDockerStats, "create_mount_dict", return_value={})
+    def test_update_mountpointstats_command_empty(self, mock_create_mount_dict):
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        ret = pdstatsd.update_mountpointstats_command()
+        mock_create_mount_dict.assert_called_once()
+        assert not ret
+
+    @patch.object(procdockerstatsd.ProcDockerStats, "create_mount_dict", return_value={})
+    @patch.object(procdockerstatsd.ProcDockerStats, "run_command", return_value={})
+    def test_update_mountpointstats_command_fail(self, mock_create_mount_dict, mock_run_command):
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        ret = pdstatsd.update_mountpointstats_command()
+
+        mock_create_mount_dict.assert_called_once()
+        assert ret == False
+
     @patch.object(procdockerstatsd.ProcDockerStats, "create_mount_dict", return_value={"MOUNT_POINTS|/dev": {"Filesystem": "udev", "Type": "ext-4", "1K-blocks": "10000", "Used": "1000", "Available": "9000"}}) 
     def test_format_mount_cmd_output(self, mock_create_mount_dict):
         pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)

--- a/tests/procdockerstatsd_test.py
+++ b/tests/procdockerstatsd_test.py
@@ -142,7 +142,7 @@ class TestProcDockerStatsDaemon(object):
         pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
         mountpoint_dict = [["udev", "ext-4", "10000", "1000", "9000", "", "/dev"]]
         mountpoint_dict_return = pdstatsd.create_mount_dict(mountpoint_dict)
-        key = 'MOUNT_POINTS|{}.'.format(mountpoint_dict[6])
+        key = 'MOUNT_POINTS|{}.'.format(mountpoint_dict[0][6])
 
         assert mountpoint_dict_return[key]['Filesystem'] == "/host"
         assert mountpoint_dict_return[key]['Type'] == "ext-4"

--- a/tests/procdockerstatsd_test.py
+++ b/tests/procdockerstatsd_test.py
@@ -144,7 +144,7 @@ class TestProcDockerStatsDaemon(object):
         mountpoint_dict_return = pdstatsd.create_mount_dict(mountpoint_dict)
         key = 'MOUNT_POINTS|{}.'.format(mountpoint_dict[0][6])
 
-        assert mountpoint_dict_return[key]['Filesystem'] == "/host"
+        assert mountpoint_dict_return[key]['Filesystem'] == "udev"
         assert mountpoint_dict_return[key]['Type'] == "ext-4"
         assert mountpoint_dict_return[key]['1K-blocks'] == "10000"
         assert mountpoint_dict_return[key]['Used'] == "1000"

--- a/tests/procdockerstatsd_test.py
+++ b/tests/procdockerstatsd_test.py
@@ -140,12 +140,12 @@ class TestProcDockerStatsDaemon(object):
 
     def test_create_mount_dict(self):
         pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
-        mountpoint_dict = ["/host", "ext-4", "10000", "1000", "9000", "", "/dev"]
+        mountpoint_dict = [["udev", "ext-4", "10000", "1000", "9000", "", "/dev"]]
         mountpoint_dict_return = pdstatsd.create_mount_dict(mountpoint_dict)
         key = 'MOUNT_POINTS|{}.'.format(mountpoint_dict[6])
 
-        assert mountpoint_dict_return[key]['Filesystem'] == "ext-4"
-        assert mountpoint_dict_return[key]['Type'] == "10000"
-        assert mountpoint_dict_return[key]['1K-blocks'] == "1000"
-        assert mountpoint_dict_return[key]['Used'] == "9000"
-        assert mountpoint_dict_return[key]['Available'] == "/dev"
+        assert mountpoint_dict_return[key]['Filesystem'] == "/host"
+        assert mountpoint_dict_return[key]['Type'] == "ext-4"
+        assert mountpoint_dict_return[key]['1K-blocks'] == "10000"
+        assert mountpoint_dict_return[key]['Used'] == "1000"
+        assert mountpoint_dict_return[key]['Available'] == "9000"


### PR DESCRIPTION
What changes:
Write the disk and partition usage information to the STATE_DB in redis

How:
Modify procdockerstatsd to routinely update the redis table

How to verify:
STATE_DB will contain updated "MOUNT_POINTS" entries
Unit tests to be added to verify correctness

Description for changelog:
Update the redis STATE_DB of the system disk and partition info

Sample entries added to STATE_DB:
```
127.0.0.1:6379[6]> keys *MOUNT*
1) "MOUNT_POINTS|LastUpdateTime"
2) "MOUNT_POINTS|/host"
3) "MOUNT_POINTS|/var/log"

127.0.0.1:6379[6]> hgetall "MOUNT_POINTS|/host"
1) "Filesystem"
2) "/dev/vda3"
3) "Type"
4) "ext4"
5) "1K-blocks"
6) "32847824"
7) "Used"
8) "5704672"
9) "Available"
10) "27126768"
```

Signed-off-by: Rakshintha Prasad [[rakprasa@cisco.com](mailto:rakprasa@cisco.com)]