### PR TITLE
Adding support for filtering by destination IP and/or incoming interface to caclmgrd.

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -768,6 +768,14 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                                 if rule_props["PACKET_ACTION"] == "ACCEPT":
                                     ipv4_src_ip_set.add(rule_props["SRC_IP"])
 
+                            if "DST_IPV6" in rule_props and rule_props["DST_IPV6"]:
+                                rule_cmd += ["-d", str(rule_props["DST_IPV6"])]
+                            elif "DST_IP" in rule_props and rule_props["DST_IP"]:
+                                rule_cmd += ["-d", str(rule_props["DST_IP"])]
+
+                            if "INC_INTF" in rule_props and rule_props["INC_INTF"]:
+                                rule_cmd += ["-i", str(rule_props["INC_INTF"])]
+
                             # Destination port 0 is reserved/unused port, so, using it to apply the rule to all ports.
                             if dst_port != "0":
                                 rule_cmd += ["--dport", str(dst_port)]

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -773,8 +773,8 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                             elif "DST_IP" in rule_props and rule_props["DST_IP"]:
                                 rule_cmd += ["-d", str(rule_props["DST_IP"])]
 
-                            if "INC_INTF" in rule_props and rule_props["INC_INTF"]:
-                                rule_cmd += ["-i", str(rule_props["INC_INTF"])]
+                            if "IN_PORTS" in rule_props and rule_props["IN_PORTS"]:
+                                rule_cmd += ["-i", str(rule_props["IN_PORTS"])]
 
                             # Destination port 0 is reserved/unused port, so, using it to apply the rule to all ports.
                             if dst_port != "0":

--- a/tests/caclmgrd/test_external_client_acl_vectors.py
+++ b/tests/caclmgrd/test_external_client_acl_vectors.py
@@ -139,7 +139,7 @@ EXTERNAL_CLIENT_ACL_TEST_VECTOR = [
                         "PACKET_ACTION": "ACCEPT",
                         "PRIORITY": "9998",
                         "DST_IP": "0.0.0.0/0",
-                        "INC_INTF": "mgmt"
+                        "IN_PORTS": "mgmt"
                     },
                 },
                 "DEVICE_METADATA": {

--- a/tests/caclmgrd/test_external_client_acl_vectors.py
+++ b/tests/caclmgrd/test_external_client_acl_vectors.py
@@ -78,6 +78,83 @@ EXTERNAL_CLIENT_ACL_TEST_VECTOR = [
         }
     ],
     [
+        "Test single IPv4 dst port + dst ip for EXTERNAL_CLIENT_ACL",
+        {
+            "config_db": {
+                "ACL_TABLE": {
+                    "EXTERNAL_CLIENT_ACL": {
+                        "stage": "INGRESS",
+                        "type": "CTRLPLANE",
+                        "services": [
+                            "EXTERNAL_CLIENT"
+                        ]
+                    }
+                },
+                "ACL_RULE": {
+                    "EXTERNAL_CLIENT_ACL|DEFAULT_RULE": {
+                        "ETHER_TYPE": "2048",
+                        "PACKET_ACTION": "DROP",
+                        "PRIORITY": "1"
+                    },
+                    "EXTERNAL_CLIENT_ACL|RULE_1": {
+                        "L4_DST_PORT": "8081",
+                        "PACKET_ACTION": "ACCEPT",
+                        "PRIORITY": "9998",
+                        "DST_IP": "20.0.0.66/32"
+                    },
+                },
+                "DEVICE_METADATA": {
+                    "localhost": {
+                    }
+                },
+                "FEATURE": {},
+            },
+            "return": [
+                ['iptables', '-A', 'INPUT', '-p', 'tcp', '-d', '20.0.0.66/32', '--dport', '8081', '-j', 'ACCEPT'],
+                ['iptables', '-A', 'INPUT', '-p', 'tcp', '--dport', '8081', '-j', 'DROP']
+            ],
+        }
+    ],
+    [
+        "Test single IPv4 dst port + incoming interface for EXTERNAL_CLIENT_ACL",
+        {
+            "config_db": {
+                "ACL_TABLE": {
+                    "EXTERNAL_CLIENT_ACL": {
+                        "stage": "INGRESS",
+                        "type": "CTRLPLANE",
+                        "services": [
+                            "EXTERNAL_CLIENT"
+                        ]
+                    }
+                },
+                "ACL_RULE": {
+                    "EXTERNAL_CLIENT_ACL|DEFAULT_RULE": {
+                        "ETHER_TYPE": "2048",
+                        "PACKET_ACTION": "DROP",
+                        "PRIORITY": "1"
+                    },
+                    "EXTERNAL_CLIENT_ACL|RULE_1": {
+                        "L4_DST_PORT": "8081",
+                        "PACKET_ACTION": "ACCEPT",
+                        "PRIORITY": "9998",
+                        "DST_IP": "0.0.0.0/0",
+                        "INC_INTF": "mgmt"
+                    },
+                },
+                "DEVICE_METADATA": {
+                    "localhost": {
+                    }
+                },
+                "FEATURE": {},
+            },
+            "return": [
+                ['iptables', '-A', 'INPUT', '-p', 'tcp', '-d', '0.0.0.0/0', '-i', 'mgmt', '--dport', '8081', '-j', 'ACCEPT'],
+                ['iptables', '-A', 'INPUT', '-p', 'tcp', '--dport', '8081', '-j', 'DROP']
+            ],
+        }
+    ],
+    [
         "Test IPv4 dst port range + src ip forEXTERNAL_CLIENT_ACL",
         {
             "config_db": {
@@ -153,6 +230,44 @@ EXTERNAL_CLIENT_ACL_TEST_VECTOR = [
             },
             "return": [
                 ['iptables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001::2/128', '--dport', '8081', '-j', 'ACCEPT'],
+                ['iptables', '-A', 'INPUT', '-p', 'tcp', '--dport', '8081', '-j', 'DROP']
+            ],
+        }
+    ],
+    [
+        "Test IPv6 single dst port range + dst ip forEXTERNAL_CLIENT_ACL",
+        {
+            "config_db": {
+                "ACL_TABLE": {
+                    "EXTERNAL_CLIENT_ACL": {
+                        "stage": "INGRESS",
+                        "type": "CTRLPLANE",
+                        "services": [
+                            "EXTERNAL_CLIENT"
+                        ]
+                    }
+                },
+                "ACL_RULE": {
+                    "EXTERNAL_CLIENT_ACL|DEFAULT_RULE": {
+                        "ETHER_TYPE": "2048",
+                        "PACKET_ACTION": "DROP",
+                        "PRIORITY": "1"
+                    },
+                    "EXTERNAL_CLIENT_ACL|RULE_1": {
+                        "L4_DST_PORT": "8081",
+                        "PACKET_ACTION": "ACCEPT",
+                        "PRIORITY": "9998",
+                        "DST_IP": "2001::6/128"
+                    },
+                },
+                "DEVICE_METADATA": {
+                    "localhost": {
+                    }
+                },
+                "FEATURE": {},
+            },
+            "return": [
+                ['iptables', '-A', 'INPUT', '-p', 'tcp', '-d', '2001::6/128', '--dport', '8081', '-j', 'ACCEPT'],
                 ['iptables', '-A', 'INPUT', '-p', 'tcp', '--dport', '8081', '-j', 'DROP']
             ],
         }


### PR DESCRIPTION
This feature - filtering by destination IP and/or incoming interface - can be useful to limit certain traffic from reaching the control plane via unwanted interfaces, such as VLAN interfaces or P2Ps.