### PR TITLE
Add a method DockerService.Load to sonic host service.

### DIFF
--- a/host_modules/docker_service.py
+++ b/host_modules/docker_service.py
@@ -251,3 +251,26 @@ class DockerService(host_service.HostModule):
             return errno.ENOENT, "Image {} not found.".format(image)
         except Exception as e:
             return 1, "Failed to run image {}: {}".format(image, str(e))
+
+    @host_service.method(
+        host_service.bus_name(MOD_NAME), in_signature="s", out_signature="is"
+    )
+    def load(self, image):
+        """
+        Load a Docker image from a tar archive.
+
+        Args:
+            image (str): The path to the tar archive containing the Docker image.
+
+        Returns:
+            tuple: A tuple containing the exit code (int) and a message indicating the result of the operation.
+        """
+        try:
+            client = docker.from_env()
+            with open(image, 'rb') as image_tar:
+                client.images.load(image_tar)
+            return 0, "Image {} has been loaded.".format(image)
+        except FileNotFoundError:
+            return errno.ENOENT, "File {} not found.".format(image)
+        except Exception as e:
+            return 1, "Failed to load image {}: {}".format(image, str(e))


### PR DESCRIPTION
The method will load a tar image to docker engine (equivalent to the CLI `docker load`)

The API is needed for implementing gnoi.containerz.deploy, where we deploy a docker image to the network device.
