### PR TITLE
Fix the issue of no info log in syslog for caclmgrd

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -18,7 +18,7 @@ try:
     import threading
     import time
     from sonic_py_common.general import getstatusoutput_noshell_pipe
-    from sonic_py_common import daemon_base, device_info, multi_asic
+    from sonic_py_common import logger, device_info, multi_asic
     from swsscommon import swsscommon
 except ImportError as err:
     raise ImportError("%s - required module not found" % str(err))
@@ -64,7 +64,7 @@ def get_ipv4_networks_from_interface_table(table, intf_name):
 # ============================== Classes ==============================
 
 
-class ControlPlaneAclManager(daemon_base.DaemonBase):
+class ControlPlaneAclManager(logger.Logger):
     """
     Class which reads control plane ACL tables and rules from Config DB,
     translates them into equivalent iptables commands and runs those


### PR DESCRIPTION
### **Issue**
Fix the issue https://github.com/sonic-net/sonic-buildimage/issues/21290
No info log found in syslog on 202405 image for caclmgrd 

### **Work item tracking**
- Microsoft ADO **(number only)**:
30611546

### Why did it happen
RP https://github.com/sonic-net/sonic-buildimage/pull/17171, introduced a new Class SysLogger, DaemonBase will choose SysLogger by default
PR https://github.com/sonic-net/sonic-buildimage/pull/19232/, it added noticed level and make it to be default level which suppresses INFO logs.

`caclmgr.set_min_log_priority_info()` it sets min log priority to info, this function is in Logger class, SysLogger doesn't have this function. But DaemonBase still inherits Logger which implements set_min_log_priority_info, that's why even caclmgrd called this function, it didn't throw exception. But it didn't make INFO level effect in SysLogger which is actually used in caclmgrd

Even change to use Logger by setting `use_syslogger=False`, it still doesn't work.
The root cause is that it added a new instance for logger, `self.logger_instance`, any instance inherited from DaemonBase class can't change the debug level, the level they changed is their own instance, not the self.logger_instance's level.

### **How to fix**
The solution here for caclmgrd is to choose logger.Logger class instead of DaemonBase.

### **How to verify it**
Test it on 202405