### PR TITLE
Enabled configuration of the default number of kdumps 

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1150,6 +1150,10 @@ class KdumpCfg(object):
             value = self.kdump_defaults.get(row)
             if not kdump_conf.get(row):
                 self.config_db.mod_entry("KDUMP", "config", {row : value})
+        
+        # Configure num_dumps
+        num_dumps = kdump_conf.get("num_dumps") or self.kdump_defaults["num_dumps"]
+        run_cmd(["sonic-kdump-config", "--num_dumps", num_dumps])
 
     def kdump_update(self, key, data):
         syslog.syslog(syslog.LOG_INFO, "Kdump global configuration update")


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Hostcfgd is not configuring the num_kdumps in linux based on default/init configuration. This PR is fixing that. 

The PR is opened as result of suggestion made in https://github.com/sonic-net/sonic-buildimage/pull/20647

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Enabled num_kdumps config in hostcfgd during boot.

#### How to verify it
UT Log:
root@sonic:/home/cisco# show reboot h
Name                 Cause                                                                   Time                             User    Comment
-------------------  ----------------------------------------------------------------------  -------------------------------  ------  ---------
2024_08_26_19_35_54  Kernel Panic                                                            Mon Aug 26 07:32:18 PM UTC 2024  N/A     N/A
2024_08_26_19_29_47  Kernel Panic                                                            Mon Aug 26 07:26:16 PM UTC 2024  N/A     N/A
2024_08_26_19_04_03  Kernel Panic                                                            Mon Aug 26 07:00:36 PM UTC 2024  N/A     N/A
2024_08_26_18_54_39  Kernel Panic                                                            Mon Aug 26 06:51:35 PM UTC 2024  N/A     N/A
2024_08_26_18_43_13  reboot                                                                  Mon Aug 26 06:36:53 PM UTC 2024  cisco   N/A
...
root@sonic:/home/cisco# show kdump files
          Kernel core dump files                        Kernel dmesg files
------------------------------------------  ------------------------------------------
/var/crash/202408261932/kdump.202408261932  /var/crash/202408261932/dmesg.202408261932
/var/crash/202408261926/kdump.202408261926  /var/crash/202408261926/dmesg.202408261926
/var/crash/202408261900/kdump.202408261900  /var/crash/202408261900/dmesg.202408261900
root@sonic:/home/cisco# ls /var/crash/
202408261900  202408261926  202408261932  kdump_lock  kexec_cmd


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->
- [x] 202405

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Configured the num_kdumps parameter during process startup. 
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
N/A
#### A picture of a cute animal (not mandatory but encouraged)

