### PR TITLE
Updated Key and Path

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -417,7 +417,7 @@ class AaaCfg(object):
             self.accounting = data
         if modify_conf:
             self.modify_conf_file()
-        
+
         if key == 'authentication':
             # Enable/Disable LDAP service (nslcd) according LDAP configuration.
             handle_nslcd_service(self.is_ldap_config_complete())
@@ -716,7 +716,7 @@ class AaaCfg(object):
         os.chmod(PAM_AUTH_CONF + ".tmp", 0o644)
         os.rename(PAM_AUTH_CONF + ".tmp", PAM_AUTH_CONF)
 
-        if os.path.isfile(PAM_SESSION_CONF): 
+        if os.path.isfile(PAM_SESSION_CONF):
             # Support to add home directory to LDAP AAA users
             if 'ldap' in authentication['login']:
                 if not is_match(MKHOME_DIR_LIB_REG, PAM_SESSION_CONF):
@@ -1141,8 +1141,8 @@ class KdumpCfg(object):
             "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
             "num_dumps": "3",
             "remote": "false",            # New feature: remote, default is "false"
-            "SSH_KEY": "<user@server>",   # New feature: SSH key, default value
-            "SSH_PATH": "<path>"          # New feature: SSH path, default value
+            "ssh_key": "<user@server>",   # New feature: SSH key, default value
+            "ssh_path": "<path>"          # New feature: SSH path, default value
         }
 
     def load(self, kdump_table):
@@ -1155,7 +1155,7 @@ class KdumpCfg(object):
             value = self.kdump_defaults.get(row)
             if not kdump_conf.get(row):
                 self.config_db.mod_entry("KDUMP", "config", {row: value})
-        
+
         # Configure num_dumps
         num_dumps = kdump_conf.get("num_dumps") or self.kdump_defaults["num_dumps"]
         run_cmd(["sonic-kdump-config", "--num_dumps", num_dumps])
@@ -1195,11 +1195,11 @@ class KdumpCfg(object):
             run_cmd(["sonic-kdump-config", "--remote", remote])
 
             # SSH key
-            if data.get("SSH_KEY") is not None and (data.get("SSH_KEY") != self.kdump_defaults["SSH_KEY"]): 
-                    run_cmd(["sonic-kdump-config", "--ssh_key", data.get("SSH_KEY")])
-            # SSH_PATH
-            if data.get("SSH_PATH") is not None and (data.get("SSH_PATH") != self.kdump_defaults["SSH_PATH"]): 
-                    run_cmd(["sonic-kdump-config", "--ssh_path", data.get("SSH_PATH")])
+            if data.get("ssh_key") is not None and (data.get("ssh_key") != self.kdump_defaults["ssh_key"]):
+                    run_cmd(["sonic-kdump-config", "--ssh_key", data.get("ssh_key")])
+            # ssh_path
+            if data.get("ssh_path") is not None and (data.get("ssh_path") != self.kdump_defaults["ssh_path"]):
+                    run_cmd(["sonic-kdump-config", "--ssh_path", data.get("ssh_path")])
 
 class NtpCfg(object):
     """
@@ -1304,7 +1304,7 @@ class NtpCfg(object):
     def ntp_srv_key_update(self, ntp_servers: dict, ntp_keys: dict):
         """Update NTP server/key configuration
 
-        The tables holds only NTP servers config and/or NTP authentication keys 
+        The tables holds only NTP servers config and/or NTP authentication keys
         config, so any change to those tables should cause NTP config reload.
         It does not make sense to handle each of the separately. NTP config
         reload takes whole configuration, so once got to this handler - cache
@@ -1359,12 +1359,12 @@ class PamLimitsCfg(object):
     def update_config_file(self):
         device_metadata = self.config_db.get_table('DEVICE_METADATA')
         ssh_server_policies = {}
-        try: 
+        try:
             ssh_server_policies = self.config_db.get_table('SSH_SERVER')
         except KeyError:
             """Dont throw except in case we don`t have SSH_SERVER config."""
             pass
-	
+
         if "localhost" not in device_metadata and "POLICIES" not in ssh_server_policies:
             return
 
@@ -1738,11 +1738,11 @@ class FipsCfg(object):
             return
         syslog.syslog(syslog.LOG_INFO, f'FipsCfg: update the FIPS enforce option {self.enforce}.')
         loader.set_fips(image, self.enforce)
-        
+
 class MemoryStatisticsCfg:
     """
     The MemoryStatisticsCfg class manages the configuration updates for the MemoryStatisticsDaemon, a daemon
-    responsible for collecting memory usage statistics. It monitors configuration changes in ConfigDB and, based 
+    responsible for collecting memory usage statistics. It monitors configuration changes in ConfigDB and, based
     on those updates, performs actions such as restarting, shutting down, or reloading the daemon.
     Attributes:
         VALID_KEYS (list): List of valid configuration keys ("enabled", "sampling_interval", "retention_period").
@@ -1797,7 +1797,7 @@ class MemoryStatisticsCfg:
             syslog.syslog(syslog.LOG_ERR, f"MemoryStatisticsCfg: Invalid key '{key}' received.")
             return
 
-        data = str(data)  
+        data = str(data)
 
         if key in ["retention_period", "sampling_interval"] and (not data.isdigit() or int(data) <= 0):
             syslog.syslog(syslog.LOG_ERR, f"MemoryStatisticsCfg: Invalid value '{data}' for key '{key}'. Must be a positive integer.")
@@ -1807,7 +1807,7 @@ class MemoryStatisticsCfg:
             syslog.syslog(syslog.LOG_INFO, f"MemoryStatisticsCfg: Detected change in '{key}' to '{data}'")
             try:
                 self.apply_setting(key, data)
-                self.cache[key] = data  
+                self.cache[key] = data
             except Exception as e:
                 syslog.syslog(syslog.LOG_ERR, f'MemoryStatisticsCfg: Failed to manage MemoryStatisticsDaemon: {e}')
 
@@ -1834,7 +1834,7 @@ class MemoryStatisticsCfg:
         """Restarts the memory statistics daemon by first shutting it down (if running) and then starting it again."""
         try:
             self.shutdown_memory_statistics()
-            time.sleep(1)  
+            time.sleep(1)
             syslog.syslog(syslog.LOG_INFO, "MemoryStatisticsCfg: Starting MemoryStatisticsDaemon")
             subprocess.Popen([self.DAEMON_EXEC_PATH])
         except Exception as e:
@@ -2367,7 +2367,7 @@ class HostConfigDaemon:
         # Handle DEVICE_MEATADATA changes
         self.config_db.subscribe(swsscommon.CFG_DEVICE_METADATA_TABLE_NAME,
                                  make_callback(self.device_metadata_handler))
-        
+
         # Handle MGMT_VRF_CONFIG changes
         self.config_db.subscribe(swsscommon.CFG_MGMT_VRF_CONFIG_TABLE_NAME,
                                  make_callback(self.mgmt_vrf_handler))

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1194,12 +1194,13 @@ class KdumpCfg(object):
                 remote = data.get("remote")
             run_cmd(["sonic-kdump-config", "--remote", remote])
 
-            # SSH key
-            if data.get("ssh_key") is not None and (data.get("ssh_key") != self.kdump_defaults["ssh_key"]):
-                    run_cmd(["sonic-kdump-config", "--ssh_key", data.get("ssh_key")])
+            ssh_key = self.kdump_defaults["ssh_key"]
+            if data.get("ssh_key") is not None:
+                    run_cmd(["sonic-kdump-config", "--ssh_key", ssh_key])
             # ssh_path
-            if data.get("ssh_path") is not None and (data.get("ssh_path") != self.kdump_defaults["ssh_path"]):
-                    run_cmd(["sonic-kdump-config", "--ssh_path", data.get("ssh_path")])
+            ssh_path= self.kdump_defaults["ssh_path"]
+            if data.get("ssh_path") is not None:
+                    run_cmd(["sonic-kdump-config", "--ssh_path", ssh_path])
 
 class NtpCfg(object):
     """

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -221,6 +221,7 @@ class TestHostcfgdDaemon(TestCase):
             call(['sonic-kdump-config', '--ssh_key', '<user@server>']),  # Covering ssh_key
             call(['sonic-kdump-config', '--ssh_path', '<path>'])  # Covering ssh_path
         ]
+
         mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)
 
     def test_devicemeta_event(self):

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -199,7 +199,18 @@ class TestHostcfgdDaemon(TestCase):
             mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)
 
     def test_kdump_event(self):
-        MockConfigDb.set_config_db(HOSTCFG_DAEMON_CFG_DB)
+        MockConfigDb.set_config_db({
+            "KDUMP": {
+                "config": {
+                    "enabled": "false",
+                    "num_dumps": "3",
+                    "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
+                    "remote": "true",  # Explicitly setting to "true"
+                    "ssh_key": "<user@server>",
+                    "ssh_path": "<path>"
+                }
+            }
+        })
         daemon = hostcfgd.HostConfigDaemon()
         daemon.register_callbacks()
         MockConfigDb.event_queue = [('KDUMP', 'config')]
@@ -217,12 +228,13 @@ class TestHostcfgdDaemon(TestCase):
                 call(['sonic-kdump-config', '--disable']),
                 call(['sonic-kdump-config', '--num_dumps', '3']),
                 call(['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M']),
-                call(['sonic-kdump-config', '--remote', 'true']),  # Covering remote
-                call(['sonic-kdump-config', '--ssh_key', '<user@server>']),  # Covering ssh_key
-                call(['sonic-kdump-config', '--ssh_path', '<path>'])  # Covering ssh_path
+                call(['sonic-kdump-config', '--remote', 'true']),  # Now explicitly set
+                call(['sonic-kdump-config', '--ssh_key', '<user@server>']),
+                call(['sonic-kdump-config', '--ssh_path', '<path>'])
             ]
 
             mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)
+
 
     def test_devicemeta_event(self):
         """

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -217,7 +217,7 @@ class TestHostcfgdDaemon(TestCase):
                 call(['sonic-kdump-config', '--disable']),
                 call(['sonic-kdump-config', '--num_dumps', '3']),
                 call(['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M']),
-                call(['sonic-kdump-config', '--remote', 'false']),  # Covering remote
+                call(['sonic-kdump-config', '--remote', 'true']),  # Covering remote
                 call(['sonic-kdump-config', '--ssh_key', '<user@server>']),  # Covering ssh_key
                 call(['sonic-kdump-config', '--ssh_path', '<path>'])  # Covering ssh_path
             ]

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -199,30 +199,30 @@ class TestHostcfgdDaemon(TestCase):
             mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)
 
     def test_kdump_event(self):
-    MockConfigDb.set_config_db(HOSTCFG_DAEMON_CFG_DB)
-    daemon = hostcfgd.HostConfigDaemon()
-    daemon.register_callbacks()
-    MockConfigDb.event_queue = [('KDUMP', 'config')]
+        MockConfigDb.set_config_db(HOSTCFG_DAEMON_CFG_DB)
+        daemon = hostcfgd.HostConfigDaemon()
+        daemon.register_callbacks()
+        MockConfigDb.event_queue = [('KDUMP', 'config')]
 
-    with mock.patch('hostcfgd.subprocess') as mocked_subprocess:
-        popen_mock = mock.Mock()
-        attrs = {'communicate.return_value': ('output', 'error')}
-        popen_mock.configure_mock(**attrs)
-        mocked_subprocess.Popen.return_value = popen_mock
-        try:
-            daemon.start()
-        except TimeoutError:
-            pass
-        expected = [
-            call(['sonic-kdump-config', '--disable']),
-            call(['sonic-kdump-config', '--num_dumps', '3']),
-            call(['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M']),
-            call(['sonic-kdump-config', '--remote', 'false']),  # Covering remote
-            call(['sonic-kdump-config', '--ssh_key', '<user@server>']),  # Covering ssh_key
-            call(['sonic-kdump-config', '--ssh_path', '<path>'])  # Covering ssh_path
-        ]
+        with mock.patch('hostcfgd.subprocess') as mocked_subprocess:
+            popen_mock = mock.Mock()
+            attrs = {'communicate.return_value': ('output', 'error')}
+            popen_mock.configure_mock(**attrs)
+            mocked_subprocess.Popen.return_value = popen_mock
+            try:
+                daemon.start()
+            except TimeoutError:
+                pass
+            expected = [
+                call(['sonic-kdump-config', '--disable']),
+                call(['sonic-kdump-config', '--num_dumps', '3']),
+                call(['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M']),
+                call(['sonic-kdump-config', '--remote', 'false']),  # Covering remote
+                call(['sonic-kdump-config', '--ssh_key', '<user@server>']),  # Covering ssh_key
+                call(['sonic-kdump-config', '--ssh_path', '<path>'])  # Covering ssh_path
+            ]
 
-        mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)
+            mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)
 
     def test_devicemeta_event(self):
         """

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -199,22 +199,10 @@ class TestHostcfgdDaemon(TestCase):
             mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)
 
     def test_kdump_event(self):
-        MockConfigDb.set_config_db({
-            "KDUMP": {
-                "config": {
-                    "enabled": "false",
-                    "num_dumps": "3",
-                    "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
-                    "remote": "true",  # Explicitly setting to "true"
-                    "ssh_key": "<user@server>",
-                    "ssh_path": "<path>"
-                }
-            }
-        })
+        MockConfigDb.set_config_db(HOSTCFG_DAEMON_CFG_DB)
         daemon = hostcfgd.HostConfigDaemon()
         daemon.register_callbacks()
         MockConfigDb.event_queue = [('KDUMP', 'config')]
-
         with mock.patch('hostcfgd.subprocess') as mocked_subprocess:
             popen_mock = mock.Mock()
             attrs = {'communicate.return_value': ('output', 'error')}
@@ -228,13 +216,11 @@ class TestHostcfgdDaemon(TestCase):
                 call(['sonic-kdump-config', '--disable']),
                 call(['sonic-kdump-config', '--num_dumps', '3']),
                 call(['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M']),
-                call(['sonic-kdump-config', '--remote', 'true']),  # Now explicitly set
-                call(['sonic-kdump-config', '--ssh_key', '<user@server>']),
-                call(['sonic-kdump-config', '--ssh_path', '<path>'])
+                call(['sonic-kdump-config', '--remote', 'false']),  # Covering remote
+                call(['sonic-kdump-config', '--ssh_key', '<user@server>']),  # Covering ssh_key
+                call(['sonic-kdump-config', '--ssh_path', '<path>'])  # Covering ssh_path
             ]
-
             mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)
-
 
     def test_devicemeta_event(self):
         """

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -199,23 +199,29 @@ class TestHostcfgdDaemon(TestCase):
             mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)
 
     def test_kdump_event(self):
-        MockConfigDb.set_config_db(HOSTCFG_DAEMON_CFG_DB)
-        daemon = hostcfgd.HostConfigDaemon()
-        daemon.register_callbacks()
-        MockConfigDb.event_queue = [('KDUMP', 'config')]
-        with mock.patch('hostcfgd.subprocess') as mocked_subprocess:
-            popen_mock = mock.Mock()
-            attrs = {'communicate.return_value': ('output', 'error')}
-            popen_mock.configure_mock(**attrs)
-            mocked_subprocess.Popen.return_value = popen_mock
-            try:
-                daemon.start()
-            except TimeoutError:
-                pass
-            expected = [call(['sonic-kdump-config', '--disable']),
-                        call(['sonic-kdump-config', '--num_dumps', '3']),
-                        call(['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M'])]
-            mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)
+    MockConfigDb.set_config_db(HOSTCFG_DAEMON_CFG_DB)
+    daemon = hostcfgd.HostConfigDaemon()
+    daemon.register_callbacks()
+    MockConfigDb.event_queue = [('KDUMP', 'config')]
+
+    with mock.patch('hostcfgd.subprocess') as mocked_subprocess:
+        popen_mock = mock.Mock()
+        attrs = {'communicate.return_value': ('output', 'error')}
+        popen_mock.configure_mock(**attrs)
+        mocked_subprocess.Popen.return_value = popen_mock
+        try:
+            daemon.start()
+        except TimeoutError:
+            pass
+        expected = [
+            call(['sonic-kdump-config', '--disable']),
+            call(['sonic-kdump-config', '--num_dumps', '3']),
+            call(['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M']),
+            call(['sonic-kdump-config', '--remote', 'false']),  # Covering remote
+            call(['sonic-kdump-config', '--ssh_key', '<user@server>']),  # Covering ssh_key
+            call(['sonic-kdump-config', '--ssh_path', '<path>'])  # Covering ssh_path
+        ]
+        mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)
 
     def test_devicemeta_event(self):
         """
@@ -272,7 +278,7 @@ class TestHostcfgdDaemon(TestCase):
             with mock.patch('hostcfgd.subprocess') as mocked_subprocess:
                 mocked_syslog.LOG_INFO = original_syslog.LOG_INFO
                 try:
-                    daemon.start() 
+                    daemon.start()
                 except TimeoutError:
                     pass
 
@@ -496,7 +502,7 @@ class TestMemoryStatisticsCfgd(TestCase):
         """
         mock_process = mock.Mock()
         mock_process.name.return_value = "memory_statistics_service.py"
-        
+
         with mock.patch('builtins.open', mock.mock_open(read_data="123")), \
              mock.patch('hostcfgd.psutil.pid_exists', return_value=True), \
              mock.patch('hostcfgd.psutil.Process', return_value=mock_process):
@@ -536,7 +542,7 @@ class TestMemoryStatisticsCfgd(TestCase):
         mock_process_instance = mock.Mock()
         mock_process_instance.name.return_value = "wrong_process"
         mock_process.return_value = mock_process_instance
-        
+
         mock_open = mock.mock_open(read_data="123")
         with mock.patch('builtins.open', mock_open):
             with mock.patch('hostcfgd.syslog.syslog') as mock_syslog:
@@ -591,28 +597,28 @@ class TestMemoryStatisticsCfgd(TestCase):
     def test_memory_statistics_disable_with_shutdown(self):
         """Test disabling memory statistics with full shutdown chain"""
         self.mem_stat_cfg.cache['enabled'] = 'true'
-        
+
         with mock.patch.object(self.mem_stat_cfg, 'get_memory_statistics_pid', return_value=123) as mock_get_pid, \
              mock.patch('hostcfgd.os.kill') as mock_kill, \
              mock.patch.object(self.mem_stat_cfg, 'wait_for_shutdown') as mock_wait:
-            
+
             self.mem_stat_cfg.memory_statistics_update('enabled', 'false')
-            
+
             mock_get_pid.assert_called_once()
             mock_kill.assert_called_once_with(123, signal.SIGTERM)
             mock_wait.assert_called_once_with(123)
-            
+
             self.assertEqual(self.mem_stat_cfg.cache['enabled'], 'false')
 
     def test_memory_statistics_disable_no_running_daemon(self):
         """Test disabling memory statistics when daemon is not running"""
         self.mem_stat_cfg.cache['enabled'] = 'true'
-        
+
         with mock.patch.object(self.mem_stat_cfg, 'get_memory_statistics_pid', return_value=None) as mock_get_pid:
             self.mem_stat_cfg.memory_statistics_update('enabled', 'false')
-            
+
             mock_get_pid.assert_called_once()
-            
+
             self.assertEqual(self.mem_stat_cfg.cache['enabled'], 'false')
 
     # Group 6: Reload Tests
@@ -642,9 +648,9 @@ class TestMemoryStatisticsCfgd(TestCase):
         with mock.patch.object(self.mem_stat_cfg, 'get_memory_statistics_pid', return_value=123) as mock_get_pid, \
             mock.patch('hostcfgd.os.kill', side_effect=Exception("Test error")), \
             mock.patch('hostcfgd.syslog.syslog') as mock_syslog:
-            
+
             self.mem_stat_cfg.reload_memory_statistics()
-            
+
             mock_get_pid.assert_called_once()
             mock_syslog.assert_any_call(mock.ANY, "MemoryStatisticsCfg: Failed to reload MemoryStatisticsDaemon: Test error")
 
@@ -677,7 +683,7 @@ class TestMemoryStatisticsCfgd(TestCase):
     def test_wait_for_shutdown_no_process(self, mock_process):
         """Test shutdown waiting when process doesn't exist"""
         mock_process.side_effect = psutil.NoSuchProcess(123)
-        
+
         with mock.patch('hostcfgd.syslog.syslog') as mock_syslog:
             self.mem_stat_cfg.wait_for_shutdown(123)
             mock_syslog.assert_any_call(mock.ANY, "MemoryStatisticsCfg: MemoryStatisticsDaemon process not found.")
@@ -687,9 +693,9 @@ class TestMemoryStatisticsCfgd(TestCase):
         with mock.patch.object(self.mem_stat_cfg, 'get_memory_statistics_pid', return_value=123) as mock_get_pid, \
             mock.patch('hostcfgd.os.kill', side_effect=Exception("Test error")), \
             mock.patch('hostcfgd.syslog.syslog') as mock_syslog:
-            
+
             self.mem_stat_cfg.shutdown_memory_statistics()
-            
+
             mock_get_pid.assert_called_once()
             mock_syslog.assert_any_call(mock.ANY, "MemoryStatisticsCfg: Failed to shutdown MemoryStatisticsDaemon: Test error")
 
@@ -698,9 +704,9 @@ class TestMemoryStatisticsCfgd(TestCase):
         mock_process = mock.Mock()
         with mock.patch('hostcfgd.psutil.Process', return_value=mock_process) as mock_process_class, \
             mock.patch('hostcfgd.syslog.syslog') as mock_syslog:
-            
+
             self.mem_stat_cfg.wait_for_shutdown(123)
-            
+
             mock_process_class.assert_called_once_with(123)
             mock_process.wait.assert_called_once_with(timeout=10)
             mock_syslog.assert_any_call(mock.ANY, "MemoryStatisticsCfg: MemoryStatisticsDaemon stopped gracefully")
@@ -718,11 +724,11 @@ class TestMemoryStatisticsCfgd(TestCase):
 
     def test_apply_setting_exception(self):
         """Test exception handling in apply_setting"""
-        with mock.patch.object(self.mem_stat_cfg, 'restart_memory_statistics', 
+        with mock.patch.object(self.mem_stat_cfg, 'restart_memory_statistics',
                              side_effect=Exception("Test error")):
             with mock.patch('hostcfgd.syslog.syslog') as mock_syslog:
                 self.mem_stat_cfg.apply_setting('enabled', 'true')
-                mock_syslog.assert_any_call(mock.ANY, 
+                mock_syslog.assert_any_call(mock.ANY,
                     "MemoryStatisticsCfg: Exception in apply_setting() for key 'enabled': Test error")
 
     @mock.patch('hostcfgd.psutil.Process')
@@ -730,23 +736,23 @@ class TestMemoryStatisticsCfgd(TestCase):
         """Test general exception handling in get_memory_statistics_pid"""
         mock_process.side_effect = Exception("Unexpected error")
         mock_open = mock.mock_open(read_data="123")
-        
+
         with mock.patch('hostcfgd.psutil.pid_exists', return_value=True):
             with mock.patch('builtins.open', mock_open):
                 with mock.patch('hostcfgd.syslog.syslog') as mock_syslog:
                     pid = self.mem_stat_cfg.get_memory_statistics_pid()
                     self.assertIsNone(pid)
-                    mock_syslog.assert_any_call(mock.ANY, 
+                    mock_syslog.assert_any_call(mock.ANY,
                         "MemoryStatisticsCfg: Exception failed to retrieve MemoryStatisticsDaemon PID: Unexpected error")
-                    
+
     def test_memory_statistics_handler_exception(self):
         """Test exception handling in memory_statistics_handler"""
         daemon = hostcfgd.HostConfigDaemon()
-        with mock.patch.object(daemon.memorystatisticscfg, 'memory_statistics_update', 
+        with mock.patch.object(daemon.memorystatisticscfg, 'memory_statistics_update',
                              side_effect=Exception("Handler error")):
             with mock.patch('hostcfgd.syslog.syslog') as mock_syslog:
                 daemon.memory_statistics_handler('enabled', None, 'true')
-                mock_syslog.assert_any_call(mock.ANY, 
+                mock_syslog.assert_any_call(mock.ANY,
                     "MemoryStatisticsCfg: Error while handling memory statistics update: Handler error")
 
     @mock.patch('hostcfgd.psutil.Process')
@@ -755,7 +761,7 @@ class TestMemoryStatisticsCfgd(TestCase):
         mock_process.side_effect = Exception("Unexpected shutdown error")
         with mock.patch('hostcfgd.syslog.syslog') as mock_syslog:
             self.mem_stat_cfg.wait_for_shutdown(123)
-            mock_syslog.assert_any_call(mock.ANY, 
+            mock_syslog.assert_any_call(mock.ANY,
                 "MemoryStatisticsCfg: Exception in wait_for_shutdown(): Unexpected shutdown error")
 
     def test_process_name_mismatch(self):
@@ -765,7 +771,7 @@ class TestMemoryStatisticsCfgd(TestCase):
         """
         mock_process = mock.Mock()
         mock_process.name.return_value = "wrong_process_name"
-        
+
         with mock.patch('builtins.open', mock.mock_open(read_data="123")), \
              mock.patch('hostcfgd.psutil.pid_exists', return_value=True), \
              mock.patch('hostcfgd.psutil.Process', return_value=mock_process), \


### PR DESCRIPTION
Updated SSH_KEY to ssh_key and SSH_PATH to ssh_path and ssh_path respectively to maintain consistency with lowercase naming conventions in the configuration and YANG model. This change ensures uniform key formatting across the system.