### PR TITLE
Handle NotImplementedError in determine-reboot-cause that will be thrown on VS Chassis platform

### DIFF
--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -118,7 +118,7 @@ def get_reboot_cause_from_platform():
         hardware_reboot_cause_major, hardware_reboot_cause_minor = REBOOT_CAUSE_NON_HARDWARE, "N/A"
     except (NotImplementedError):
         sonic_logger.log_warning("sonic_platform package not implemented. Unable to detect hardware reboot causes.")
-        hardware_reboot_cause_major, hardware_reboot_cause_minor = REBOOT_CAUSE_NON_HARDWARE, "N/A"
+        hardware_reboot_cause_major, hardware_reboot_cause_minor = REBOOT_CAUSE_NON_HARDWARE, "Platform pkg not implemented"
 
     return hardware_reboot_cause_major, hardware_reboot_cause_minor
 

--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -115,6 +115,9 @@ def get_reboot_cause_from_platform():
     except (ImportError, FileNotFoundError):
         sonic_logger.log_warning("sonic_platform package not installed. Unable to detect hardware reboot causes.")
         hardware_reboot_cause_major, hardware_reboot_cause_minor = REBOOT_CAUSE_NON_HARDWARE, "N/A"
+    except (NotImplementedError):
+        sonic_logger.log_warning("sonic_platform package not implemented. Unable to detect hardware reboot causes.")
+        hardware_reboot_cause_major, hardware_reboot_cause_minor = REBOOT_CAUSE_NON_HARDWARE, "N/A"
 
     return hardware_reboot_cause_major, hardware_reboot_cause_minor
 
@@ -142,7 +145,7 @@ def get_reboot_cause_dict(previous_reboot_cause, comment, gen_time):
     If user issused a command to reboot device, then user, command and time will be
     stored into a dictionary.
 
-    If device was rebooted due to the kernel panic, then the string `Kernel Panic` 
+    If device was rebooted due to the kernel panic, then the string `Kernel Panic`
     and time will be stored into a dictionary.
     """
     reboot_cause_dict = {}
@@ -164,7 +167,7 @@ def get_reboot_cause_dict(previous_reboot_cause, comment, gen_time):
         if match is not None:
             reboot_cause_dict['cause'] = "Kernel Panic"
             reboot_cause_dict['time'] = match.group(1)
- 
+
     return reboot_cause_dict
 
 def determine_reboot_cause():
@@ -184,12 +187,12 @@ def determine_reboot_cause():
     software_reboot_cause = find_software_reboot_cause()
 
     # The main decision logic of the reboot cause:
-    # If there is a valid hardware reboot cause indicated by platform API, 
+    # If there is a valid hardware reboot cause indicated by platform API,
     #    check the software reboot cause to add additional rebot cause.
     # If there is a reboot cause indicated by /proc/cmdline, and/or warmreboot/fastreboot/softreboot
     #   the software_reboot_cause which is the content of /hosts/reboot-cause/reboot-cause.txt
     #   will be treated as the additional reboot cause
-    # Elif there is a cmdline reboot cause, 
+    # Elif there is a cmdline reboot cause,
     #   the software_reboot_cause will be treated as the reboot cause if it's not unknown
     #   otherwise, the cmdline_reboot_cause will be treated as the reboot cause if it's not none
     # Else the software_reboot_cause will be treated as the reboot cause
@@ -244,7 +247,7 @@ def main():
     # Write the previous reboot cause to REBOOT_CAUSE_HISTORY_FILE as a JSON format
     with open(REBOOT_CAUSE_HISTORY_FILE, "w") as reboot_cause_history_file:
         json.dump(reboot_cause_dict, reboot_cause_history_file)
- 
+
     # Remove stale PREVIOUS_REBOOT_CAUSE_FILE if it exists
     if os.path.exists(PREVIOUS_REBOOT_CAUSE_FILE) or os.path.islink(PREVIOUS_REBOOT_CAUSE_FILE):
         os.remove(PREVIOUS_REBOOT_CAUSE_FILE)

--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -113,12 +113,9 @@ def get_reboot_cause_from_platform():
         chassis  = platform.get_chassis()
         hardware_reboot_cause_major, hardware_reboot_cause_minor = chassis.get_reboot_cause()
         sonic_logger.log_info("Platform api returns reboot cause {}, {}".format(hardware_reboot_cause_major, hardware_reboot_cause_minor))
-    except (ImportError, FileNotFoundError):
-        sonic_logger.log_warning("sonic_platform package not installed. Unable to detect hardware reboot causes.")
+    except (ImportError, FileNotFoundError, NotImplementedError):
+        sonic_logger.log_warning("sonic_platform package not installed or not implemented. Unable to detect hardware reboot causes.")
         hardware_reboot_cause_major, hardware_reboot_cause_minor = REBOOT_CAUSE_NON_HARDWARE, "N/A"
-    except (NotImplementedError):
-        sonic_logger.log_warning("sonic_platform package not implemented. Unable to detect hardware reboot causes.")
-        hardware_reboot_cause_major, hardware_reboot_cause_minor = REBOOT_CAUSE_NON_HARDWARE, "Platform pkg not implemented"
 
     return hardware_reboot_cause_major, hardware_reboot_cause_minor
 

--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -189,7 +189,7 @@ def determine_reboot_cause():
 
     # The main decision logic of the reboot cause:
     # If there is a valid hardware reboot cause indicated by platform API,
-    #    check the software reboot cause to add additional rebot cause.
+    #    check the software reboot cause to add additional reboot cause.
     # If there is a reboot cause indicated by /proc/cmdline, and/or warmreboot/fastreboot/softreboot
     #   the software_reboot_cause which is the content of /hosts/reboot-cause/reboot-cause.txt
     #   will be treated as the additional reboot cause

--- a/tests/determine-reboot-cause_test.py
+++ b/tests/determine-reboot-cause_test.py
@@ -132,7 +132,7 @@ class TestDetermineRebootCause(object):
 
     def test_find_hardware_reboot_cause_not_implemented(self):
         result = determine_reboot_cause.find_hardware_reboot_cause()
-        assert result == REBOOT_CAUSE_NON_HARDWARE + " (N/A)"
+        assert result == REBOOT_CAUSE_NON_HARDWARE + " (Platform pkg not implemented)"
 
     def test_get_reboot_cause_dict_watchdog(self):
         reboot_cause_dict = determine_reboot_cause.get_reboot_cause_dict(REBOOT_CAUSE_WATCHDOG, "", GEN_TIME_WATCHDOG)
@@ -214,7 +214,7 @@ class TestDetermineRebootCause(object):
         with mock.patch("os.geteuid", return_value=0):
             determine_reboot_cause.main()
             assert os.path.exists("host/reboot-cause/reboot-cause.txt") == True
-            assert os.path.exists("host/reboot-cause/previous-reboot-cause.json") == True   
+            assert os.path.exists("host/reboot-cause/previous-reboot-cause.json") == True
 
     def create_mock_platform_json(self, dpus):
         """Helper function to create a mock platform.json file."""

--- a/tests/determine-reboot-cause_test.py
+++ b/tests/determine-reboot-cause_test.py
@@ -125,6 +125,10 @@ class TestDetermineRebootCause(object):
             result = determine_reboot_cause.find_hardware_reboot_cause()
             assert result == "Powerloss (under-voltage)"
 
+    def test_find_hardware_reboot_cause_not_implemented(self):
+        result = determine_reboot_cause.find_hardware_reboot_cause()
+        assert result == REBOOT_CAUSE_NON_HARDWARE + " (N/A)"
+
     def test_get_reboot_cause_dict_watchdog(self):
         reboot_cause_dict = determine_reboot_cause.get_reboot_cause_dict(REBOOT_CAUSE_WATCHDOG, "", GEN_TIME_WATCHDOG)
         assert reboot_cause_dict == EXPECTED_WATCHDOG_REBOOT_CAUSE_DICT
@@ -205,4 +209,4 @@ class TestDetermineRebootCause(object):
         with mock.patch("os.geteuid", return_value=0):
             determine_reboot_cause.main()
             assert os.path.exists("host/reboot-cause/reboot-cause.txt") == True
-            assert os.path.exists("host/reboot-cause/previous-reboot-cause.json") == True   
+            assert os.path.exists("host/reboot-cause/previous-reboot-cause.json") == True

--- a/tests/determine-reboot-cause_test.py
+++ b/tests/determine-reboot-cause_test.py
@@ -130,9 +130,9 @@ class TestDetermineRebootCause(object):
             result = determine_reboot_cause.find_hardware_reboot_cause()
             assert result == "Powerloss (under-voltage)"
 
-    def test_find_hardware_reboot_cause_not_implemented(self):
+    def test_find_hardware_reboot_cause_not_installed_or_not_implemented(self):
         result = determine_reboot_cause.find_hardware_reboot_cause()
-        assert result == REBOOT_CAUSE_NON_HARDWARE + " (Platform pkg not implemented)"
+        assert result == REBOOT_CAUSE_NON_HARDWARE + " (N/A)"
 
     def test_get_reboot_cause_dict_watchdog(self):
         reboot_cause_dict = determine_reboot_cause.get_reboot_cause_dict(REBOOT_CAUSE_WATCHDOG, "", GEN_TIME_WATCHDOG)


### PR DESCRIPTION
On VS Chassis platform, the sonic_platform package is not implemented since there is no hardware associated with it. So the chassis.get_reboot_cause API will throw NotImplementedError. I added the code change to handle this exception and return the reboot cause as "N/A" in this case.