### PR TITLE
Fixed: Reverted "ssh_key" to "ssh_string"

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1141,7 +1141,7 @@ class KdumpCfg(object):
             "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
             "num_dumps": "3",
             "remote": "false",            # New feature: remote, default is "false"
-            "ssh_key": "<user@server>",   # New feature: SSH key, default value
+            "ssh_string": "<user@server>",   # New feature: SSH key, default value
             "ssh_path": "<path>"          # New feature: SSH path, default value
         }
 
@@ -1194,9 +1194,9 @@ class KdumpCfg(object):
                 remote = data.get("remote")
             run_cmd(["sonic-kdump-config", "--remote", remote])
 
-            ssh_key = self.kdump_defaults["ssh_key"]
-            if data.get("ssh_key") is not None:
-                    run_cmd(["sonic-kdump-config", "--ssh_key", ssh_key])
+            ssh_string = self.kdump_defaults["ssh_string"]
+            if data.get("ssh_string") is not None:
+                    run_cmd(["sonic-kdump-config", "--ssh_string", ssh_string])
             # ssh_path
             ssh_path= self.kdump_defaults["ssh_path"]
             if data.get("ssh_path") is not None:

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -217,7 +217,7 @@ class TestHostcfgdDaemon(TestCase):
                 call(['sonic-kdump-config', '--num_dumps', '3']),
                 call(['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M']),
                 call(['sonic-kdump-config', '--remote', 'false']),  # Covering remote
-                call(['sonic-kdump-config', '--ssh_key', '<user@server>']),  # Covering ssh_key
+                call(['sonic-kdump-config', '--ssh_string', '<user@server>']),  # Covering ssh_string
                 call(['sonic-kdump-config', '--ssh_path', '<path>'])  # Covering ssh_path
             ]
             mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)


### PR DESCRIPTION
Link to all PRs of the KDUMP = [KDUMP SONiC HLD PR](https://github.com/sonic-net/SONiC/pull/1714)

Related YANG model : [KDUMP YANG MODEL - remote - ssh_string - ssh_path](https://github.com/Azure/sonic-buildimage/pull/19540)

Issue:

- There were variables error in the [hostcfgd pr](https://github.com/sonic-net/sonic-host-services/pull/166), which were not reflecting with the YANG model. 
- To fix, this created a [PR - Updated Key and Path](https://github.com/sonic-net/sonic-host-services/pull/209). but there was a typo from my end. 
- Now to fix everything, this last PR has been created by to sync YANG model with the hostcfgd. In this PR, I have "ssh_key" with "ssh_string", matching YANG string keys.

