### PR TITLE
make multi_asic_ns_to_host_fwd False for EXTERNAL_CLIENT ACL service

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -106,7 +106,7 @@ class ControlPlaneAclManager(logger.Logger):
         },
         "EXTERNAL_CLIENT": {
             "ip_protocols": ["tcp"],
-            "multi_asic_ns_to_host_fwd":True
+            "multi_asic_ns_to_host_fwd":False
         },
         "ANY": {
             "ip_protocols": ["any"],


### PR DESCRIPTION
MSFT ADO 31389706
`EXTERNAL_CLIENT` is not needed for multiasic platforms, so making the `multi_asic_ns_to_host_fwd` to `False`