### PR TITLE
azure-pipelines: update to libyang3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ stages:
         sudo dpkg -i libnl-genl-3-200_*.deb
         sudo dpkg -i libnl-route-3-200_*.deb
         sudo dpkg -i libnl-nf-3-200_*.deb
-        sudo dpkg -i libyang_1.0.73_*.deb
+        sudo dpkg -i libyang_3.*.deb
         sudo dpkg -i libswsscommon_1.0.0_amd64.deb
         sudo dpkg -i python3-swsscommon_1.0.0_amd64.deb
       workingDirectory: $(Pipeline.Workspace)/target/debs/bookworm/


### PR DESCRIPTION
#### Description

Port from libyang1 to libyang3. This depends on changes to sonic-buildimage.

Main Tracking PR here: https://github.com/sonic-net/sonic-buildimage/pull/21679