### PR TITLE
Process KDUMP attributes in CFG_DB on init

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1156,7 +1156,7 @@ class KdumpCfg(object):
             if not kdump_conf.get(row):
                 self.config_db.mod_entry("KDUMP", "config", {row: value})
             else:
-                value = kdump_conf.get(row)
+                value = kdump_conf[row]
             data[row] = value
         self.kdump_update("config", data)
 

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1149,15 +1149,16 @@ class KdumpCfg(object):
         Set the KDUMP table in CFG DB to kdump_defaults if not set by the user
         """
         syslog.syslog(syslog.LOG_INFO, "KdumpCfg init ...")
+        data = {}
         kdump_conf = kdump_table.get("config", {})
         for row in self.kdump_defaults:
             value = self.kdump_defaults.get(row)
             if not kdump_conf.get(row):
                 self.config_db.mod_entry("KDUMP", "config", {row: value})
-
-        # Configure num_dumps
-        num_dumps = kdump_conf.get("num_dumps") or self.kdump_defaults["num_dumps"]
-        run_cmd(["sonic-kdump-config", "--num_dumps", num_dumps])
+            else:
+                value = kdump_conf.get(row)
+            data[row] = value
+        self.kdump_update("config", data)
 
     def kdump_update(self, key, data):
         syslog.syslog(syslog.LOG_INFO, "Kdump global configuration update")

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -222,6 +222,28 @@ class TestHostcfgdDaemon(TestCase):
             ]
             mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)
 
+    def test_kdump_load(self):
+        MockConfigDb.set_config_db(HOSTCFG_DAEMON_INIT_CFG_DB)
+        MockConfigDb.CONFIG_DB['KDUMP'] = {
+            'config': {
+                "enabled": "true",
+            }
+        }
+        daemon = hostcfgd.HostConfigDaemon()
+        with mock.patch('hostcfgd.subprocess') as mocked_subprocess:
+            daemon.kdumpCfg.load(MockConfigDb.CONFIG_DB['KDUMP'])
+
+            expected = [
+                call(['sonic-kdump-config', '--enable']),
+                call(['sonic-kdump-config', '--num_dumps', '3']),
+                call(['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M']),
+                call(['sonic-kdump-config', '--remote', 'false']),  # Covering remote
+                call(['sonic-kdump-config', '--ssh_string', 'user@localhost']),  # Covering ssh_string
+                call(['sonic-kdump-config', '--ssh_path', '/a/b/c'])  # Covering ssh_path
+            ]
+
+            mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)
+
     def test_devicemeta_event(self):
         """
         Test handling DEVICE_METADATA events.


### PR DESCRIPTION
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/21625

Confirmed that with this change I see the values in config_db.json propagated to the kernel arguments on init.

E.G.
- Write KDUMP|config enabled="true" in config_db.json
- Reboot box
- I now see the expected operational output `Ready after reboot`
```
root@nfc406-7:~# sonic-db-cli CONFIG_DB hgetall "KDUMP|config"
{'enabled': 'true', 'memory': '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M', 'num_dumps': '3'}

root@nfc406-7:~# show kdump config
Kdump administrative mode: Enabled
Kdump operational mode: Ready after reboot
```

- If I do one more reboot it now becomes `ready`
```
root@nfc406-7:~# show kdump config
Kdump administrative mode: Enabled
Kdump operational mode: Ready
```