### PR TITLE
Periodically check the status of the pmon container during HALT and return early if it has stopped

### DIFF
--- a/host_modules/reboot.py
+++ b/host_modules/reboot.py
@@ -112,9 +112,17 @@ class Reboot(host_service.HostModule):
            For Halt reboot_method, wait for 60 secs timeout. we expect pmon, syncd containers are killed, 
            if Halt reboot is Successful."""
         if reboot_method in REBOOT_METHOD_HALT_BOOT_VALUES:
-            time.sleep(HALT_TIMEOUT)
-            is_pmon_running = self.is_container_running("pmon")
-            if is_pmon_running:
+            # Periodically check every 5 seconds until PMON container is stopped or timeout occurs
+            timeout = HALT_TIMEOUT
+            while timeout > 0:
+                if not self.is_container_running("pmon"):
+                    logger.warning("%s: Pmon conatiner has stopped after Halt reboot execution", MOD_NAME)
+                    return
+                time.sleep(5)
+                timout -= 5
+
+            # Check if PMON container is still running after timeout
+            if self.is_container_running("pmon"):
                 #Halt reboot has failed, as pmon is still running.
                 logger.error("%s: HALT reboot failed: pmon is still running", MOD_NAME)
                 self.populate_reboot_status_flag()

--- a/host_modules/reboot.py
+++ b/host_modules/reboot.py
@@ -114,21 +114,21 @@ class Reboot(host_service.HostModule):
         if reboot_method in REBOOT_METHOD_HALT_BOOT_VALUES:
             # Periodically check every 5 seconds until PMON container is stopped or timeout occurs
             timeout = HALT_TIMEOUT
-            while timeout > 0:
+            start_time = time.monotonic()
+            while time.monotonic() - start_time < timeout:
                 if not self.is_container_running("pmon"):
-                    logger.warning("%s: Pmon conatiner has stopped after Halt reboot execution", MOD_NAME)
+                    logger.warning("%s: PMON conatiner has stopped after Halt reboot execution", MOD_NAME)
                     return
                 time.sleep(5)
-                timout -= 5
 
             # Check if PMON container is still running after timeout
             if self.is_container_running("pmon"):
                 #Halt reboot has failed, as pmon is still running.
-                logger.error("%s: HALT reboot failed: pmon is still running", MOD_NAME)
+                logger.error("%s: HALT reboot failed: PMON is still running", MOD_NAME)
                 self.populate_reboot_status_flag()
                 return
             else:
-                logger.warning("%s: Pmon conatiner has stopped after Halt reboot execution", MOD_NAME)
+                logger.warning("%s: PMON conatiner has stopped after Halt reboot execution", MOD_NAME)
 
         else:
             time.sleep(REBOOT_TIMEOUT)

--- a/host_modules/reboot.py
+++ b/host_modules/reboot.py
@@ -125,6 +125,7 @@ class Reboot(host_service.HostModule):
            if Halt reboot is Successful."""
         if reboot_method in REBOOT_METHOD_HALT_BOOT_VALUES:
             # Periodically check every 5 seconds until PMON container is stopped or timeout occurs
+            logger.info("%s: Waiting until services are halted or timeout occurs", MOD_NAME)
             timeout = HALT_TIMEOUT
             start_time = time.monotonic()
             while time.monotonic() - start_time < timeout:


### PR DESCRIPTION
This pull request introduces several updates and improvements to the `reboot.py` module in the host_modules directory:

**1. New Method:**

Implemented `is_halt_command_running` method to check if the halt command is currently running. This method iterates through system processes to identify if any process name contains "reboot".

**2. Enhanced Reboot Logic:**

Modified the `execute_reboot `method to periodically check every 5 seconds whether the halt command is running and whether the PMON container is stopped. The loop continues until either the conditions are met or the timeout occurs.
Improved logging to provide more detailed information about the reboot process, including successful halts and failures.

**3. Timeout Handling:**

Replaced direct sleep calls with a periodic check mechanism to improve the responsiveness and reliability of the halt reboot method. Updated log messages to reflect the new behavior and provide clearer information about the status of services during the halt reboot process.

These changes enhance the robustness and clarity of the reboot process, ensuring better management and logging of the system's state during HALT method reboots.