### PR TITLE
[featured] fix non existing feature start

### DIFF
--- a/scripts/featured
+++ b/scripts/featured
@@ -266,11 +266,13 @@ class FeatureHandler(object):
             return True
 
         if enable:
-            self.enable_feature(feature)
+            if not self.enable_feature(feature):
+                return False
             syslog.syslog(syslog.LOG_INFO, "Feature {} is enabled and started".format(feature.name))
 
         if disable:
-            self.disable_feature(feature)
+            if not self.disable_feature(feature):
+                return False
             syslog.syslog(syslog.LOG_INFO, "Feature {} is stopped and disabled".format(feature.name))
 
         return True
@@ -405,7 +407,7 @@ class FeatureHandler(object):
         for feature_name in feature_names:
             # Check if it is already enabled, if yes skip the system call
             unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
-            if unit_file_state == "enabled" or not unit_file_state:
+            if unit_file_state == "enabled":
                 continue
             cmds = []
             for suffix in feature_suffixes:
@@ -425,16 +427,17 @@ class FeatureHandler(object):
                     syslog.syslog(syslog.LOG_ERR, "Feature '{}.{}' failed to be enabled and started"
                                   .format(feature.name, feature_suffixes[-1]))
                     self.set_feature_state(feature, self.FEATURE_STATE_FAILED)
-                    return
+                    return False
 
         self.set_feature_state(feature, self.FEATURE_STATE_ENABLED)
+        return True
 
     def disable_feature(self, feature):
         feature_names, feature_suffixes = self.get_multiasic_feature_instances(feature)
         for feature_name in feature_names:
             # Check if it is already disabled, if yes skip the system call
             unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
-            if unit_file_state in ("disabled", "masked") or not unit_file_state:
+            if unit_file_state in ("disabled", "masked"):
                 continue
             cmds = []
             for suffix in reversed(feature_suffixes):
@@ -449,9 +452,10 @@ class FeatureHandler(object):
                     syslog.syslog(syslog.LOG_ERR, "Feature '{}.{}' failed to be stopped and disabled"
                                   .format(feature.name, feature_suffixes[-1]))
                     self.set_feature_state(feature, self.FEATURE_STATE_FAILED)
-                    return
+                    return False
 
         self.set_feature_state(feature, self.FEATURE_STATE_DISABLED)
+        return True
 
     def resync_feature_state(self, feature):
         current_entry = self._config_db.get_entry('FEATURE', feature.name)


### PR DESCRIPTION
Fix an issue that when starting a non existing feature and then installing it with sonic-package-manager it won't start.

E.g:

```
admin@sonic:~$ redis-cli -n 4 hmset 'FEATURE|non-existing' state enabled OK
admin@sonic:~$ sudo zless /var/log/syslog | grep featured 2025 Mar 26 15:19:33.237090 sonic INFO featured: Feature non-existing is enabled and started
```

With this patch an error is recordded and feature state is not cached:

```
2025 Mar 26 15:35:32.794640 sonic INFO featured: Running cmd: '['sudo', 'systemctl', 'unmask', 'non-existing.service']'
2025 Mar 26 15:35:33.233685 sonic INFO featured: Output:  , Stderr: Unit non-existing.service does not exist, proceeding anyway.
2025 Mar 26 15:35:33.233743 sonic INFO featured: Running cmd: '['sudo', 'systemctl', 'enable', 'non-existing.service']'
2025 Mar 26 15:35:33.247238 sonic ERR featured: ['sudo', 'systemctl', 'enable', 'non-existing.service'] - failed: return code - 1, output:
2025 Mar 26 15:35:33.247300 sonic ERR featured: Feature 'non-existing.service' failed to be enabled and started
2025 Mar 26 15:35:39.331762 sonic INFO featured: Running cmd: '['sudo', 'systemctl', 'unmask', 'non-existing.service']'
2025 Mar 26 15:35:39.780474 sonic INFO featured: Output:  , Stderr: Unit non-existing.service does not exist, proceeding anyway.
2025 Mar 26 15:35:39.780513 sonic INFO featured: Running cmd: '['sudo', 'systemctl', 'enable', 'non-existing.service']'
2025 Mar 26 15:35:39.795113 sonic ERR featured: ['sudo', 'systemctl', 'enable', 'non-existing.service'] - failed: return code - 1, output:
2025 Mar 26 15:35:39.795153 sonic ERR featured: Feature 'non-existing.service' failed to be enabled and started
```

Feature will start next time when setting state field in FEATURE table