### PR TITLE
SSH hardening configuration options

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -56,14 +56,21 @@ LINUX_DEFAULT_PASS_MAX_DAYS = 99999
 LINUX_DEFAULT_PASS_WARN_AGE = 7
 
 # Ssh min-max values
+SSH_INT_VALUES=[ "authentication_retries", "login_timeout", "inactivity_timeout", "max_sessions" ]
 SSH_MIN_VALUES={"authentication_retries": 3, "login_timeout": 1, "ports": 1,
                 "inactivity_timeout": 0, "max_sessions": 0}
 SSH_MAX_VALUES={"authentication_retries": 100, "login_timeout": 600,
                 "ports": 65535, "inactivity_timeout": 35000,
                 "max_sessions": 100}
 SSH_CONFIG_NAMES={"authentication_retries": "MaxAuthTries",
-                  "login_timeout": "LoginGraceTime", "ports": "Port",
-                  "inactivity_timeout": "ClientAliveInterval"}
+                  "login_timeout": "LoginGraceTime",
+                  "ports": "Port",
+                  "inactivity_timeout": "ClientAliveInterval",
+                  "permit_root_login": "PermitRootLogin",
+                  "password_authentication": "PasswordAuthentication",
+                  "ciphers": "Ciphers",
+                  "kex_algorithms": "KexAlgorithms",
+                  "macs": "MACs"}
 
 ACCOUNT_NAME = 0 # index of account name
 AGE_DICT = { 'MAX_DAYS': {'REGEX_DAYS': r'^PASS_MAX_DAYS[ \t]*(?P<max_days>-?\d*)', 'DAYS': 'max_days', 'CHAGE_FLAG': '-M '},
@@ -1104,13 +1111,26 @@ class SshServer(object):
                 if not self.handle_ports_set(value):
                     syslog.syslog(syslog.LOG_ERR, "Failed to update sshd config files - wrong port configuration")
                     return
-            elif int(value) < SSH_MIN_VALUES.get(key, 65535) or SSH_MAX_VALUES.get(key, -1) < int(value):
+                continue
+
+            if key in SSH_INT_VALUES and (int(value) < SSH_MIN_VALUES.get(key, 65535) or
+                                            SSH_MAX_VALUES.get(key, -1) < int(value)):
                 syslog.syslog(syslog.LOG_ERR, "Ssh {} {} out of range".format(key, value))
-            elif key in SSH_CONFIG_NAMES:
+
+            if SSH_CONFIG_NAMES.get(key) is not None:
                 # search replace configuration - if not in config file - append
                 if key == "inactivity_timeout":
                     # translate min to sec.
                     value = int(value) * 60
+                elif key in [ "permit_root_login", "password_authentication" ]:
+                    # translate boolean to yes/no
+                    if isinstance(value, str):
+                        value = "no" if value.lower() in [ "false" ] else "yes"
+                    else:
+                        value = "yes" if bool(value) else "no"
+                elif key in [ "ciphers", "kex_algorithms", "macs" ]:
+                    # convert list to comma-delimited list
+                    value = ",".join(value)
                 kv_str = "{} {}".format(SSH_CONFIG_NAMES[key], str(value)) # name +' '+ value format
                 modify_single_file_inplace(SSH_CONFG_TMP,['-E', "/^#?" + SSH_CONFIG_NAMES[key]+"/{h;s/.*/"+
                  kv_str + "/};${x;/^$/{s//" + kv_str + "/;H};x}"])

--- a/tests/hostcfgd/hostcfgd_ssh_server_test.py
+++ b/tests/hostcfgd/hostcfgd_ssh_server_test.py
@@ -152,6 +152,81 @@ class TestHostcfgdSSHServer(TestCase):
         self.check_config(test_name, test_data, "modify_ports")
 
     @parameterized.expand(HOSTCFGD_TEST_SSH_SERVER_VECTOR)
+    def test_hostcfgd_sshs_password_authentication(self, test_name, test_data):
+        """
+            Test SSHS hostcfd daemon initialization
+
+            Args:
+                test_name(str): test name
+                test_data(dict): test data which contains initial Config Db tables, and expected results
+
+            Returns:
+                None
+        """
+
+        self.check_config(test_name, test_data, "modify_password_authentication")
+
+    @parameterized.expand(HOSTCFGD_TEST_SSH_SERVER_VECTOR)
+    def test_hostcfgd_sshs_permit_root_login(self, test_name, test_data):
+        """
+            Test SSHS hostcfd daemon initialization
+
+            Args:
+                test_name(str): test name
+                test_data(dict): test data which contains initial Config Db tables, and expected results
+
+            Returns:
+                None
+        """
+
+        self.check_config(test_name, test_data, "modify_permit_root_login")
+
+    @parameterized.expand(HOSTCFGD_TEST_SSH_SERVER_VECTOR)
+    def test_hostcfgd_sshs_ciphers(self, test_name, test_data):
+        """
+            Test SSHS hostcfd daemon initialization
+
+            Args:
+                test_name(str): test name
+                test_data(dict): test data which contains initial Config Db tables, and expected results
+
+            Returns:
+                None
+        """
+
+        self.check_config(test_name, test_data, "modify_ciphers")
+
+    @parameterized.expand(HOSTCFGD_TEST_SSH_SERVER_VECTOR)
+    def test_hostcfgd_sshs_kex_algorithms(self, test_name, test_data):
+        """
+            Test SSHS hostcfd daemon initialization
+
+            Args:
+                test_name(str): test name
+                test_data(dict): test data which contains initial Config Db tables, and expected results
+
+            Returns:
+                None
+        """
+
+        self.check_config(test_name, test_data, "modify_kex_algorithms")
+
+    @parameterized.expand(HOSTCFGD_TEST_SSH_SERVER_VECTOR)
+    def test_hostcfgd_sshs_macs(self, test_name, test_data):
+        """
+            Test SSHS hostcfd daemon initialization
+
+            Args:
+                test_name(str): test name
+                test_data(dict): test data which contains initial Config Db tables, and expected results
+
+            Returns:
+                None
+        """
+
+        self.check_config(test_name, test_data, "modify_macs")
+
+    @parameterized.expand(HOSTCFGD_TEST_SSH_SERVER_VECTOR)
     def test_hostcfgd_sshs_all(self, test_name, test_data):
         """
             Test SSHS hostcfd daemon initialization

--- a/tests/hostcfgd/sample_output/SSH_SERVER_modify_ciphers/sshd_config
+++ b/tests/hostcfgd/sample_output/SSH_SERVER_modify_ciphers/sshd_config
@@ -10,7 +10,6 @@
 # possible, but leave them commented.  Uncommented options override the
 # default value.
 
-Port 222
 Port 22
 #AddressFamily any
 #ListenAddress 0.0.0.0
@@ -29,9 +28,9 @@ Port 22
 
 # Authentication:
 
-LoginGraceTime 140
+LoginGraceTime 60
 #StrictModes yes
-MaxAuthTries 16
+MaxAuthTries 6
 #MaxSessions 10
 
 #PubkeyAuthentication yes
@@ -53,7 +52,7 @@ MaxAuthTries 16
 #IgnoreRhosts yes
 
 # To disable tunneled clear text passwords, change to no here!
-PasswordAuthentication no
+PasswordAuthentication yes
 #PermitEmptyPasswords no
 
 # Change to yes to enable challenge-response passwords (beware issues with
@@ -75,11 +74,11 @@ ChallengeResponseAuthentication no
 # Set this to 'yes' to enable PAM authentication, account processing,
 # and session processing. If this is enabled, PAM authentication will
 # be allowed through the ChallengeResponseAuthentication and
-PasswordAuthentication no
+PasswordAuthentication yes
 # PAM authentication via ChallengeResponseAuthentication may bypass
-PermitRootLogin no
+PermitRootLogin yes
 # If you just want the PAM account and session checks to run without
-PasswordAuthentication no
+PasswordAuthentication yes
 # and ChallengeResponseAuthentication to 'no'.
 UsePAM yes
 
@@ -118,8 +117,6 @@ Subsystem	sftp	/usr/lib/openssh/sftp-server
 #	AllowTcpForwarding no
 #	PermitTTY no
 #	ForceCommand cvs server
-PermitRootLogin no
+PermitRootLogin yes
 ClientAliveInterval 900
 Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com
-KexAlgorithms sntrup761x25519-sha512,curve25519-sha256,ecdh-sha2-nistp521
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-512

--- a/tests/hostcfgd/sample_output/SSH_SERVER_modify_kex_algorithms/sshd_config
+++ b/tests/hostcfgd/sample_output/SSH_SERVER_modify_kex_algorithms/sshd_config
@@ -10,7 +10,6 @@
 # possible, but leave them commented.  Uncommented options override the
 # default value.
 
-Port 222
 Port 22
 #AddressFamily any
 #ListenAddress 0.0.0.0
@@ -29,9 +28,9 @@ Port 22
 
 # Authentication:
 
-LoginGraceTime 140
+LoginGraceTime 60
 #StrictModes yes
-MaxAuthTries 16
+MaxAuthTries 6
 #MaxSessions 10
 
 #PubkeyAuthentication yes
@@ -53,7 +52,7 @@ MaxAuthTries 16
 #IgnoreRhosts yes
 
 # To disable tunneled clear text passwords, change to no here!
-PasswordAuthentication no
+PasswordAuthentication yes
 #PermitEmptyPasswords no
 
 # Change to yes to enable challenge-response passwords (beware issues with
@@ -75,11 +74,11 @@ ChallengeResponseAuthentication no
 # Set this to 'yes' to enable PAM authentication, account processing,
 # and session processing. If this is enabled, PAM authentication will
 # be allowed through the ChallengeResponseAuthentication and
-PasswordAuthentication no
+PasswordAuthentication yes
 # PAM authentication via ChallengeResponseAuthentication may bypass
-PermitRootLogin no
+PermitRootLogin yes
 # If you just want the PAM account and session checks to run without
-PasswordAuthentication no
+PasswordAuthentication yes
 # and ChallengeResponseAuthentication to 'no'.
 UsePAM yes
 
@@ -118,8 +117,6 @@ Subsystem	sftp	/usr/lib/openssh/sftp-server
 #	AllowTcpForwarding no
 #	PermitTTY no
 #	ForceCommand cvs server
-PermitRootLogin no
+PermitRootLogin yes
 ClientAliveInterval 900
-Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com
 KexAlgorithms sntrup761x25519-sha512,curve25519-sha256,ecdh-sha2-nistp521
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-512

--- a/tests/hostcfgd/sample_output/SSH_SERVER_modify_macs/sshd_config
+++ b/tests/hostcfgd/sample_output/SSH_SERVER_modify_macs/sshd_config
@@ -10,7 +10,6 @@
 # possible, but leave them commented.  Uncommented options override the
 # default value.
 
-Port 222
 Port 22
 #AddressFamily any
 #ListenAddress 0.0.0.0
@@ -29,9 +28,9 @@ Port 22
 
 # Authentication:
 
-LoginGraceTime 140
+LoginGraceTime 60
 #StrictModes yes
-MaxAuthTries 16
+MaxAuthTries 6
 #MaxSessions 10
 
 #PubkeyAuthentication yes
@@ -53,7 +52,7 @@ MaxAuthTries 16
 #IgnoreRhosts yes
 
 # To disable tunneled clear text passwords, change to no here!
-PasswordAuthentication no
+PasswordAuthentication yes
 #PermitEmptyPasswords no
 
 # Change to yes to enable challenge-response passwords (beware issues with
@@ -75,11 +74,11 @@ ChallengeResponseAuthentication no
 # Set this to 'yes' to enable PAM authentication, account processing,
 # and session processing. If this is enabled, PAM authentication will
 # be allowed through the ChallengeResponseAuthentication and
-PasswordAuthentication no
+PasswordAuthentication yes
 # PAM authentication via ChallengeResponseAuthentication may bypass
-PermitRootLogin no
+PermitRootLogin yes
 # If you just want the PAM account and session checks to run without
-PasswordAuthentication no
+PasswordAuthentication yes
 # and ChallengeResponseAuthentication to 'no'.
 UsePAM yes
 
@@ -118,8 +117,6 @@ Subsystem	sftp	/usr/lib/openssh/sftp-server
 #	AllowTcpForwarding no
 #	PermitTTY no
 #	ForceCommand cvs server
-PermitRootLogin no
+PermitRootLogin yes
 ClientAliveInterval 900
-Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com
-KexAlgorithms sntrup761x25519-sha512,curve25519-sha256,ecdh-sha2-nistp521
 MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-512

--- a/tests/hostcfgd/sample_output/SSH_SERVER_modify_password_authentication/sshd_config
+++ b/tests/hostcfgd/sample_output/SSH_SERVER_modify_password_authentication/sshd_config
@@ -10,7 +10,6 @@
 # possible, but leave them commented.  Uncommented options override the
 # default value.
 
-Port 222
 Port 22
 #AddressFamily any
 #ListenAddress 0.0.0.0
@@ -29,9 +28,9 @@ Port 22
 
 # Authentication:
 
-LoginGraceTime 140
+LoginGraceTime 60
 #StrictModes yes
-MaxAuthTries 16
+MaxAuthTries 6
 #MaxSessions 10
 
 #PubkeyAuthentication yes
@@ -77,7 +76,7 @@ ChallengeResponseAuthentication no
 # be allowed through the ChallengeResponseAuthentication and
 PasswordAuthentication no
 # PAM authentication via ChallengeResponseAuthentication may bypass
-PermitRootLogin no
+PermitRootLogin yes
 # If you just want the PAM account and session checks to run without
 PasswordAuthentication no
 # and ChallengeResponseAuthentication to 'no'.
@@ -118,8 +117,5 @@ Subsystem	sftp	/usr/lib/openssh/sftp-server
 #	AllowTcpForwarding no
 #	PermitTTY no
 #	ForceCommand cvs server
-PermitRootLogin no
+PermitRootLogin yes
 ClientAliveInterval 900
-Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com
-KexAlgorithms sntrup761x25519-sha512,curve25519-sha256,ecdh-sha2-nistp521
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-512

--- a/tests/hostcfgd/sample_output/SSH_SERVER_modify_permit_root_login/sshd_config
+++ b/tests/hostcfgd/sample_output/SSH_SERVER_modify_permit_root_login/sshd_config
@@ -10,7 +10,6 @@
 # possible, but leave them commented.  Uncommented options override the
 # default value.
 
-Port 222
 Port 22
 #AddressFamily any
 #ListenAddress 0.0.0.0
@@ -29,9 +28,9 @@ Port 22
 
 # Authentication:
 
-LoginGraceTime 140
+LoginGraceTime 60
 #StrictModes yes
-MaxAuthTries 16
+MaxAuthTries 6
 #MaxSessions 10
 
 #PubkeyAuthentication yes
@@ -53,7 +52,7 @@ MaxAuthTries 16
 #IgnoreRhosts yes
 
 # To disable tunneled clear text passwords, change to no here!
-PasswordAuthentication no
+PasswordAuthentication yes
 #PermitEmptyPasswords no
 
 # Change to yes to enable challenge-response passwords (beware issues with
@@ -75,11 +74,11 @@ ChallengeResponseAuthentication no
 # Set this to 'yes' to enable PAM authentication, account processing,
 # and session processing. If this is enabled, PAM authentication will
 # be allowed through the ChallengeResponseAuthentication and
-PasswordAuthentication no
+PasswordAuthentication yes
 # PAM authentication via ChallengeResponseAuthentication may bypass
 PermitRootLogin no
 # If you just want the PAM account and session checks to run without
-PasswordAuthentication no
+PasswordAuthentication yes
 # and ChallengeResponseAuthentication to 'no'.
 UsePAM yes
 
@@ -120,6 +119,3 @@ Subsystem	sftp	/usr/lib/openssh/sftp-server
 #	ForceCommand cvs server
 PermitRootLogin no
 ClientAliveInterval 900
-Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com
-KexAlgorithms sntrup761x25519-sha512,curve25519-sha256,ecdh-sha2-nistp521
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-512

--- a/tests/hostcfgd/test_ssh_server_vectors.py
+++ b/tests/hostcfgd/test_ssh_server_vectors.py
@@ -12,7 +12,7 @@ HOSTCFGD_TEST_SSH_SERVER_VECTOR = [
                         "login_timeout": "120",
                         "ports": "22",
                         "inactivity_timeout": "15",
-                        "max_sessions": "0",
+                        "max_sessions": "0"
                     }
                 },
                 "DEVICE_METADATA": {
@@ -165,6 +165,211 @@ HOSTCFGD_TEST_SSH_SERVER_VECTOR = [
                     }
                 }
             },
+           "modify_password_authentication":{
+                "SSH_SERVER": {
+                    "POLICIES":{
+                        "authentication_retries": "6",
+                        "login_timeout": "60",
+                        "ports": "22",
+                        "inactivity_timeout": "15",
+                        "max_sessions": "0",
+                        "password_authentication": "false"
+                    }
+                },
+                "DEVICE_METADATA": {
+                    "localhost": {
+                        "hostname": "radius",
+                    }
+                },
+                "FEATURE": {
+                    "dhcp_relay": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "kube",
+                        "state": "enabled"
+                    },
+                },
+                "KDUMP": {
+                    "config": {
+                        "enabled": "false",
+                        "num_dumps": "3",
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                    }
+                },
+                "SERIAL_CONSOLE": {
+                    "POLICIES":{
+                        "inactivity_timeout": "15",
+                        "sysrq_capabilities": "disabled"
+                    }
+                }
+            },
+           "modify_permit_root_login":{
+                "SSH_SERVER": {
+                    "POLICIES":{
+                        "authentication_retries": "6",
+                        "login_timeout": "60",
+                        "ports": "22",
+                        "inactivity_timeout": "15",
+                        "max_sessions": "0",
+                        "permit_root_login": "false"
+                    }
+                },
+                "DEVICE_METADATA": {
+                    "localhost": {
+                        "hostname": "radius",
+                    }
+                },
+                "FEATURE": {
+                    "dhcp_relay": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "kube",
+                        "state": "enabled"
+                    },
+                },
+                "KDUMP": {
+                    "config": {
+                        "enabled": "false",
+                        "num_dumps": "3",
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                    }
+                },
+                "SERIAL_CONSOLE": {
+                    "POLICIES":{
+                        "inactivity_timeout": "15",
+                        "sysrq_capabilities": "disabled"
+                    }
+                }
+            },
+           "modify_ciphers":{
+                "SSH_SERVER": {
+                    "POLICIES":{
+                        "authentication_retries": "6",
+                        "login_timeout": "60",
+                        "ports": "22",
+                        "inactivity_timeout": "15",
+                        "max_sessions": "0",
+                        "ciphers": [ "chacha20-poly1305@openssh.com", "aes256-gcm@openssh.com" ]
+                    }
+                },
+                "DEVICE_METADATA": {
+                    "localhost": {
+                        "hostname": "radius",
+                    }
+                },
+                "FEATURE": {
+                    "dhcp_relay": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "kube",
+                        "state": "enabled"
+                    },
+                },
+                "KDUMP": {
+                    "config": {
+                        "enabled": "false",
+                        "num_dumps": "3",
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                    }
+                },
+                "SERIAL_CONSOLE": {
+                    "POLICIES":{
+                        "inactivity_timeout": "15",
+                        "sysrq_capabilities": "disabled"
+                    }
+                }
+            },
+            "modify_kex_algorithms":{
+                "SSH_SERVER": {
+                    "POLICIES":{
+                        "authentication_retries": "6",
+                        "login_timeout": "60",
+                        "ports": "22",
+                        "inactivity_timeout": "15",
+                        "max_sessions": "0",
+                        "kex_algorithms": [ "sntrup761x25519-sha512", "curve25519-sha256", "ecdh-sha2-nistp521" ]
+                    }
+                },
+                "DEVICE_METADATA": {
+                    "localhost": {
+                        "hostname": "radius",
+                    }
+                },
+                "FEATURE": {
+                    "dhcp_relay": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "kube",
+                        "state": "enabled"
+                    },
+                },
+                "KDUMP": {
+                    "config": {
+                        "enabled": "false",
+                        "num_dumps": "3",
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                    }
+                },
+                "SERIAL_CONSOLE": {
+                    "POLICIES":{
+                        "inactivity_timeout": "15",
+                        "sysrq_capabilities": "disabled"
+                    }
+                }
+            },
+            "modify_macs":{
+                "SSH_SERVER": {
+                    "POLICIES":{
+                        "authentication_retries": "6",
+                        "login_timeout": "60",
+                        "ports": "22",
+                        "inactivity_timeout": "15",
+                        "max_sessions": "0",
+                        "macs": [ "hmac-sha2-512-etm@openssh.com", "hmac-sha2-512" ]
+                    }
+                },
+                "DEVICE_METADATA": {
+                    "localhost": {
+                        "hostname": "radius",
+                    }
+                },
+                "FEATURE": {
+                    "dhcp_relay": {
+                        "auto_restart": "enabled",
+                        "has_global_scope": "True",
+                        "has_per_asic_scope": "False",
+                        "has_timer": "False",
+                        "high_mem_alert": "disabled",
+                        "set_owner": "kube",
+                        "state": "enabled"
+                    },
+                },
+                "KDUMP": {
+                    "config": {
+                        "enabled": "false",
+                        "num_dumps": "3",
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                    }
+                },
+                "SERIAL_CONSOLE": {
+                    "POLICIES":{
+                        "inactivity_timeout": "15",
+                        "sysrq_capabilities": "disabled"
+                    }
+                }
+            },
             "modify_all":{
                 "SSH_SERVER": {
                     "POLICIES":{
@@ -173,6 +378,11 @@ HOSTCFGD_TEST_SSH_SERVER_VECTOR = [
                         "ports": "22,222",
                         "inactivity_timeout": "15",
                         "max_sessions": "0",
+                        "permit_root_login": "false",
+                        "password_authentication": "false",
+                        "ciphers": [ "chacha20-poly1305@openssh.com", "aes256-gcm@openssh.com" ],
+                        "kex_algorithms": [ "sntrup761x25519-sha512", "curve25519-sha256", "ecdh-sha2-nistp521" ],
+                        "macs": [ "hmac-sha2-512-etm@openssh.com", "hmac-sha2-512" ]
                     }
                 },
                 "DEVICE_METADATA": {


### PR DESCRIPTION
The SSH configuration does not contain many of the hardening requirements by the various standards bodies.  This adds support for:
 * password_authentication - ability to disable password auth
 * permit_root_login - ability to prevent root logins
 * ciphers - ability to specify available ciphers
 * kex_algorithms - ability to specify key exchange algorithms
 * macs - ability to specify macs

Depends on https://github.com/sonic-net/sonic-buildimage/pull/22308