### PR TITLE
Fixed def path & string

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1142,7 +1142,7 @@ class KdumpCfg(object):
             "num_dumps": "3",
             "remote": "false",            # New feature: remote, default is "false"
             "ssh_string": "root@127.0.0.1",   # New feature: SSH key, default value
-            "ssh_path": "<path>"          # New feature: SSH path, default value
+            "ssh_path": "/root/.ssh/id_rsa"          # New feature: SSH path, default value
         }
 
     def load(self, kdump_table):

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1141,7 +1141,7 @@ class KdumpCfg(object):
             "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
             "num_dumps": "3",
             "remote": "false",            # New feature: remote, default is "false"
-            "ssh_string": "<user@server>",   # New feature: SSH key, default value
+            "ssh_string": "root@127.0.0.1",   # New feature: SSH key, default value
             "ssh_path": "<path>"          # New feature: SSH path, default value
         }
 

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -217,8 +217,8 @@ class TestHostcfgdDaemon(TestCase):
                 call(['sonic-kdump-config', '--num_dumps', '3']),
                 call(['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M']),
                 call(['sonic-kdump-config', '--remote', 'false']),  # Covering remote
-                call(['sonic-kdump-config', '--ssh_string', '<user@server>']),  # Covering ssh_string
-                call(['sonic-kdump-config', '--ssh_path', '<path>'])  # Covering ssh_path
+                call(['sonic-kdump-config', '--ssh_string', 'root@127.0.0.1']),  # Covering ssh_string
+                call(['sonic-kdump-config', '--ssh_path', '/root/.ssh/id_rsa'])  # Covering ssh_path
             ]
             mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)
 


### PR DESCRIPTION
Parent PR [217](https://github.com/sonic-net/sonic-host-services/pull/217)

To fix Issue

E 2025 Apr 1 20:50:28.747129 vlab-01 ERR hostcfgd: ['sonic-kdump-config', '--disable'] - failed: return code - 1, output:#012None
E 2025 Apr 1 20:50:29.476916 vlab-01 ERR hostcfgd: ['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M'] - failed: return code - 1, output:#012None
E 2025 Apr 1 20:50:30.155442 vlab-01 ERR hostcfgd: ['sonic-kdump-config', '--num_dumps', '3'] - failed: return code - 1, output:#012None
E 2025 Apr 1 20:50:31.815402 vlab-01 ERR hostcfgd: ['sonic-kdump-config', '--remote', 'false'] - failed: return code - 2, output:#012None
E 2025 Apr 1 20:50:33.888242 vlab-01 ERR hostcfgd: ['sonic-kdump-config', '--ssh_string', 'user@localhost'] - failed: return code - 1, output:#012None
E 2025 Apr 1 20:50:35.279408 vlab-01 ERR hostcfgd: ['sonic-kdump-config', '--ssh_path', '/a/b/c'] - failed: return code - 1, output:#012None