### PR TITLE
KDUMP_REMOTE_BUG_FIX

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1141,8 +1141,8 @@ class KdumpCfg(object):
             "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
             "num_dumps": "3",
             "remote": "false",            # New feature: remote, default is "false"
-            "ssh_string": "user@localhost",   # New feature: SSH key, default value
-            "ssh_path": "/a/b/c"          # New feature: SSH path, default value
+            "ssh_string": "root@127.0.0.1",   # New feature: SSH key, default value
+            "ssh_path": "/root/.ssh/id_rsa"          # New feature: SSH path, default value
         }
 
     def load(self, kdump_table):

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -216,7 +216,7 @@ class TestHostcfgdDaemon(TestCase):
                 call(['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M']),
                 call(['sonic-kdump-config', '--remote', 'false']),  # Covering remote
                 call(['sonic-kdump-config', '--ssh_string', 'user@localhost']),  # Covering ssh_string
-                call(['sonic-kdump-config', '--ssh_path', '/a/b/c'])  # Covering ssh_path
+                call(['sonic-kdump-config', '--ssh_path', 'a/b/c'])  # Covering ssh_path
             ]
             mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)
 
@@ -237,7 +237,7 @@ class TestHostcfgdDaemon(TestCase):
                 call(['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M']),
                 call(['sonic-kdump-config', '--remote', 'false']),  # Covering remote
                 call(['sonic-kdump-config', '--ssh_string', 'user@localhost']),  # Covering ssh_string
-                call(['sonic-kdump-config', '--ssh_path', '/a/b/c'])  # Covering ssh_path
+                call(['sonic-kdump-config', '--ssh_path', 'a/b/c'])  # Covering ssh_path
             ]
 
             mocked_subprocess.check_call.assert_has_calls(expected, any_order=True)

--- a/tests/hostcfgd/test_ldap_vectors.py
+++ b/tests/hostcfgd/test_ldap_vectors.py
@@ -28,7 +28,10 @@ HOSTCFGD_TEST_LDAP_VECTOR = [
                     "config": {
                         "enabled": "false",
                         "num_dumps": "3",
-                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
+                        "remote": "disabled",
+                        "ssh_string": "root@127.0.0.1",
+                        "ssh_path": "/root/.ssh/id_rsa"
                         }
                 },
                 "AAA": {
@@ -39,7 +42,7 @@ HOSTCFGD_TEST_LDAP_VECTOR = [
                             "fail-delay": 0,
                             "lockout-reattempt": 15,
                             "lockout-attempts": 5
-                        },                        
+                        },
                         "failthrough": "True",
                         "debug": "True",
                     }
@@ -94,7 +97,7 @@ HOSTCFGD_TEST_LDAP_VECTOR = [
                             "fail-delay": 0,
                             "lockout-reattempt": 15,
                             "lockout-attempts": 5
-                        },   
+                        },
                         "debug": "True",
                     }
                 },

--- a/tests/hostcfgd/test_passwh_vectors.py
+++ b/tests/hostcfgd/test_passwh_vectors.py
@@ -40,7 +40,10 @@ HOSTCFGD_TEST_PASSWH_VECTOR = [
                     "config": {
                         "enabled": "false",
                         "num_dumps": "3",
-                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
+                        "remote": "disabled",
+                        "ssh_string": "root@127.0.0.1",
+                        "ssh_path": "/root/.ssh/id_rsa"
                     }
                 }
             },
@@ -79,7 +82,10 @@ HOSTCFGD_TEST_PASSWH_VECTOR = [
                     "config": {
                         "enabled": "false",
                         "num_dumps": "3",
-                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
+                        "remote": "disabled",
+                        "ssh_string": "root@127.0.0.1",
+                        "ssh_path": "/root/.ssh/id_rsa"
                     }
                 }
             },
@@ -118,7 +124,10 @@ HOSTCFGD_TEST_PASSWH_VECTOR = [
                     "config": {
                         "enabled": "false",
                         "num_dumps": "3",
-                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
+                        "remote": "disabled",
+                        "ssh_string": "root@127.0.0.1",
+                        "ssh_path": "/root/.ssh/id_rsa"
                     }
                 }
             },
@@ -157,7 +166,10 @@ HOSTCFGD_TEST_PASSWH_VECTOR = [
                     "config": {
                         "enabled": "false",
                         "num_dumps": "3",
-                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
+                        "remote": "disabled",
+                        "ssh_string": "root@127.0.0.1",
+                        "ssh_path": "/root/.ssh/id_rsa"
                     }
                 },
             },
@@ -196,7 +208,10 @@ HOSTCFGD_TEST_PASSWH_VECTOR = [
                     "config": {
                         "enabled": "false",
                         "num_dumps": "3",
-                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
+                        "remote": "disabled",
+                        "ssh_string": "root@127.0.0.1",
+                        "ssh_path": "/root/.ssh/id_rsa"
                     }
                 }
             },
@@ -235,7 +250,10 @@ HOSTCFGD_TEST_PASSWH_VECTOR = [
                     "config": {
                         "enabled": "false",
                         "num_dumps": "3",
-                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
+                        "remote": "disabled",
+                        "ssh_string": "root@127.0.0.1",
+                        "ssh_path": "/root/.ssh/id_rsa"
                     }
                 }
             }

--- a/tests/hostcfgd/test_radius_vectors.py
+++ b/tests/hostcfgd/test_radius_vectors.py
@@ -39,7 +39,10 @@ HOSTCFGD_TEST_RADIUS_VECTOR = [
                     "config": {
                         "enabled": "false",
                         "num_dumps": "3",
-                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
+                        "remote": "disabled",
+                        "ssh_string": "root@127.0.0.1",
+                        "ssh_path": "/root/.ssh/id_rsa"
                         }
                 },
                 "AAA": {
@@ -178,7 +181,10 @@ HOSTCFGD_TEST_RADIUS_VECTOR = [
                     "config": {
                         "enabled": "false",
                         "num_dumps": "3",
-                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
+                        "remote": "disabled",
+                        "ssh_string": "root@127.0.0.1",
+                        "ssh_path": "/root/.ssh/id_rsa"
                         }
                 },
                 "AAA": {

--- a/tests/hostcfgd/test_tacacs_vectors.py
+++ b/tests/hostcfgd/test_tacacs_vectors.py
@@ -28,18 +28,21 @@ HOSTCFGD_TEST_TACACS_VECTOR = [
                     "config": {
                         "enabled": "false",
                         "num_dumps": "3",
-                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
-                        }
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
+                        "remote": "disabled",
+                        "ssh_string": "root@127.0.0.1",
+                        "ssh_path": "/root/.ssh/id_rsa"
+                    }
                 },
                 "AAA": {
                     "authentication": {
                         "login": "local"
                     },
                     "authorization": {
-                        "login": "local" 
+                        "login": "local"
                     },
                     "accounting": {
-                        "login": "local" 
+                        "login": "local"
                     }
                 },
                 "TACPLUS": {
@@ -90,18 +93,21 @@ HOSTCFGD_TEST_TACACS_VECTOR = [
                     "config": {
                         "enabled": "false",
                         "num_dumps": "3",
-                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
-                        }
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
+                        "remote": "disabled",
+                        "ssh_string": "root@127.0.0.1",
+                        "ssh_path": "/root/.ssh/id_rsa"
+                    }
                 },
                 "AAA": {
                     "authentication": {
                         "login": "local"
                     },
                     "authorization": {
-                        "login": "tacacs+" 
+                        "login": "tacacs+"
                     },
                     "accounting": {
-                        "login": "tacacs+" 
+                        "login": "tacacs+"
                     }
                 },
                 "TACPLUS": {
@@ -152,18 +158,21 @@ HOSTCFGD_TEST_TACACS_VECTOR = [
                     "config": {
                         "enabled": "false",
                         "num_dumps": "3",
-                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
-                        }
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
+                        "remote": "disabled",
+                        "ssh_string": "root@127.0.0.1",
+                        "ssh_path": "/root/.ssh/id_rsa"
+                    }
                 },
                 "AAA": {
                     "authentication": {
                         "login": "local"
                     },
                     "authorization": {
-                        "login": "tacacs+ local" 
+                        "login": "tacacs+ local"
                     },
                     "accounting": {
-                        "login": "tacacs+ local" 
+                        "login": "tacacs+ local"
                     }
                 },
                 "TACPLUS": {
@@ -214,18 +223,21 @@ HOSTCFGD_TEST_TACACS_VECTOR = [
                     "config": {
                         "enabled": "false",
                         "num_dumps": "3",
-                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M"
-                        }
+                        "memory": "0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M",
+                        "remote": "disabled",
+                        "ssh_string": "root@127.0.0.1",
+                        "ssh_path": "/root/.ssh/id_rsa"
+                    }
                 },
                 "AAA": {
                     "authentication": {
                         "login": "local"
                     },
                     "authorization": {
-                        "login": "local" 
+                        "login": "local"
                     },
                     "accounting": {
-                        "login": "disable" 
+                        "login": "disable"
                     }
                 },
                 "TACPLUS": {


### PR DESCRIPTION
Link to all PRs of the KDUMP = [KDUMP SONiC HLD PR](https://github.com/sonic-net/SONiC/pull/1714)

Related Build Issue in PR [remote-kdump-variables-build](https://github.com/sonic-net/sonic-host-services/pull/166)

Issue: There was a build failure for the remote variable in [kdump-sonic-utilities PR](https://github.com/sonic-net/sonic-utilities/pull/3400)

**Following were to be addressed, which are ADDRESSED in this PR**
    
    ```
        E 2025 Apr 1 04:56:08.321576 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--disable'] - failed: return code - 1, output:#012None
        E 2025 Apr 1 04:56:09.638838 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-:448M'] - failed: return code - 1, output:#012None
        E 2025 Apr 1 04:56:11.199498 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--num_dumps', '3'] - failed: return code - 1, output:#012None
        E 2025 Apr 1 04:56:13.969595 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--remote', 'false'] - failed: return code - 2, output:#012None
        E 2025 Apr 1 04:56:16.373762 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--ssh_string', 'user@localhost'] - failed: return code - 1, output:#012None
        E 2025 Apr 1 04:56:17.579657 vlab-02 ERR hostcfgd: ['sonic-kdump-config', '--ssh_path', '/a/b/c'] - failed: return code - 1, output:#012None
```