### PR TITLE
Monitor rsyslog feature flag change and update rsyslog config by restart rsyslog-config service

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1423,6 +1423,7 @@ class DeviceMetaCfg(object):
     def __init__(self):
         self.hostname = ''
         self.timezone = None
+        self.syslog_with_osversion = None
 
     def load(self, dev_meta={}):
         # Get hostname initial
@@ -1431,6 +1432,7 @@ class DeviceMetaCfg(object):
 
         # Load appropriate config
         self.timezone = dev_meta.get('localhost', {}).get('timezone')
+        self.syslog_with_osversion = dev_meta.get('localhost', {}).get('syslog_with_osversion')
 
     def hostname_update(self, data):
         """
@@ -1498,18 +1500,23 @@ class DeviceMetaCfg(object):
         Args:
             data: Read table's key's data.
         """
-        syslog_with_osversion = data.get('syslog_with_osversion')
+        new_syslog_with_osversion = data.get('syslog_with_osversion')
         syslog.syslog(syslog.LOG_DEBUG,
-                      f'DeviceMetaCfg: syslog with os version: {syslog_with_osversion}')
+                      f'DeviceMetaCfg: syslog with os version: {new_syslog_with_osversion}')
 
-        if syslog_with_osversion is None:
+        if new_syslog_with_osversion is None:
             syslog.syslog(syslog.LOG_DEBUG,
                           f'DeviceMetaCfg: syslog with os version feature disabled')
             return
 
+        if new_syslog_with_osversion == self.syslog_with_osversion:
+            syslog.syslog(syslog.LOG_DEBUG,
+                          f'DeviceMetaCfg: syslog with os version feature flag does not change')
+            return
+
         run_cmd(['systemctl', 'restart', 'rsyslog-config'], True, False)
         syslog.syslog(syslog.LOG_INFO, 'DeviceMetaCfg: Restart rsyslog-config after '
-                                        'feature flag change to {}'.format(syslog_with_osversion))
+                                        'feature flag change to {}'.format(new_syslog_with_osversion))
 
 
 class MgmtIfaceCfg(object):

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1491,6 +1491,27 @@ class DeviceMetaCfg(object):
         syslog.syslog(syslog.LOG_INFO, 'DeviceMetaCfg: Restart rsyslog after '
                       'changing timezone')
 
+    def rsyslog_config(self, data):
+        """
+        Apply syslog_with_osversion feature flag.
+        Run the following command in Linux: sudo systemctl restart rsyslog-config
+        Args:
+            data: Read table's key's data.
+        """
+        syslog_with_osversion = data.get('syslog_with_osversion')
+        syslog.syslog(syslog.LOG_DEBUG,
+                      f'DeviceMetaCfg: syslog with os version: {syslog_with_osversion}')
+
+        if syslog_with_osversion is None:
+            syslog.syslog(syslog.LOG_DEBUG,
+                          f'DeviceMetaCfg: syslog with os version feature disabled')
+            return
+
+        run_cmd(['systemctl', 'restart', 'rsyslog-config'], True, False)
+        syslog.syslog(syslog.LOG_INFO, 'DeviceMetaCfg: Restart rsyslog-config after '
+                                        'feature flag change to {}'.format(syslog_with_osversion))
+
+
 class MgmtIfaceCfg(object):
     """
     MgmtIfaceCfg Config Daemon
@@ -2281,6 +2302,7 @@ class HostConfigDaemon:
         syslog.syslog(syslog.LOG_INFO, 'DeviceMeta handler...')
         self.devmetacfg.hostname_update(data)
         self.devmetacfg.timezone_update(data)
+        self.devmetacfg.rsyslog_config(data)
 
     def rsyslog_handler(self):
         rsyslog_config = self.config_db.get_table(

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -318,7 +318,6 @@ class TestHostcfgdDaemon(TestCase):
                     pass
 
                 expected = [
-                    call(['systemctl', 'restart', 'rsyslog-config']),
                     call(original_syslog.LOG_INFO, 'DeviceMetaCfg: Restart rsyslog-config after feature flag change to true')
                 ]
                 mocked_syslog.syslog.assert_has_calls(expected)

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -307,6 +307,7 @@ class TestHostcfgdDaemon(TestCase):
                 ]
                 mocked_syslog.syslog.assert_has_calls(expected)
 
+        daemon.devmetacfg.syslog_with_osversion = "false"
         HOSTCFG_DAEMON_CFG_DB["DEVICE_METADATA"]["localhost"]["syslog_with_osversion"] = 'true'
         MockConfigDb.set_config_db(HOSTCFG_DAEMON_CFG_DB)
         with mock.patch('hostcfgd.syslog') as mocked_syslog:


### PR DESCRIPTION
Monitor rsyslog feature flag change and update rsyslog config by restart rsyslog-config service

#### Why I did it
Another PR add new feature flag syslog_with_osversion
https://github.com/sonic-net/sonic-buildimage/pull/22111

##### Work item tracking
- Microsoft ADO **(number only)**: 31890431

#### How I did it
Update hostcfgd to minitor DEVICE_METADATA table change and restart rsyslog-config service to update rsyslog template.

#### How to verify it
Pass all test case.
Manually verified the code change work:

admin@vlab-01:~$ sonic-db-cli CONFIG_DB hset "DEVICE_METADATA|localhost" "syslog_with_osversion" "true"
1
admin@vlab-01:~$ sudo cat /var/log/syslog | grep "DeviceMetaCfg"
2025 Apr 22 08:38:12.642805 vlab-01 INFO hostcfgd: DeviceMetaCfg: Restart rsyslog-config after feature flag change to true

admin@vlab-01:~$ sonic-db-cli CONFIG_DB hset "DEVICE_METADATA|localhost" "syslog_with_osversion" "false"
0
admin@vlab-01:~$ sudo cat /var/log/syslog | grep "DeviceMetaCfg"
2025 Apr 22 08:38:41.561592 vlab-01 INFO hostcfgd: DeviceMetaCfg: Restart rsyslog-config after feature flag change to false

admin@vlab-01:~$ sudo systemctl status rsyslog-config
● rsyslog-config.service - Update rsyslog configuration
     Loaded: loaded (/lib/systemd/system/rsyslog-config.service; enabled-runtime; preset: enabled)
     Active: active (exited) since Tue 2025-04-22 08:38:41 UTC; 23s ago
    Process: 846029 ExecStart=/usr/bin/rsyslog-config.sh (code=exited, status=0/SUCCESS)
   Main PID: 846029 (code=exited, status=0/SUCCESS)

Apr 22 08:38:40 vlab-01 systemd[1]: Starting rsyslog-config.service - Update rsyslog configuration...
Apr 22 08:38:41 vlab-01 systemd[1]: Finished rsyslog-config.service - Update rsyslog configuration.


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Monitor rsyslog feature flag change and update rsyslog config by restart rsyslog-config service

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

