### PR TITLE
Improve Detection Logic for HALT Command in is_halt_command_running()

### DIFF
--- a/host_modules/reboot.py
+++ b/host_modules/reboot.py
@@ -84,8 +84,8 @@ class Reboot(host_service.HostModule):
     def is_halt_command_running(self):
         """Check if the halt command is running"""
         try:
-            for process in psutil.process_iter(['pid', 'name']):
-                if "reboot" in process.info['name']:
+            for process in psutil.process_iter(['cmdline']):
+                if process.info['cmdline'] and "reboot" in process.info['cmdline'] and "-p" in process.info['cmdline']:
                     return True
             return False
         except Exception as e:

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -144,22 +144,22 @@ class TestReboot(object):
     def test_is_halt_command_running_success(self):
         with mock.patch("psutil.process_iter") as mock_process_iter:
             mock_process = mock.Mock()
-            mock_process.info = {'pid': 1234, 'name': 'reboot'}
+            mock_process.info = {'cmdline': ['reboot', '-p']}
             mock_process_iter.return_value = [mock_process]
 
             result = self.reboot_module.is_halt_command_running()
             assert result is True
-            mock_process_iter.assert_called_once_with(['pid', 'name'])
+            mock_process_iter.assert_called_once_with(['cmdline'])
 
     def test_is_halt_command_running_failure(self):
         with mock.patch("psutil.process_iter") as mock_process_iter:
             mock_process = mock.Mock()
-            mock_process.info = {'pid': 1234, 'name': 'other_process'}
+            mock_process.info = {'cmdline': ['other_process']}
             mock_process_iter.return_value = [mock_process]
 
             result = self.reboot_module.is_halt_command_running()
             assert result is False
-            mock_process_iter.assert_called_once_with(['pid', 'name'])
+            mock_process_iter.assert_called_once_with(['cmdline'])
 
     def test_is_halt_command_running_exception(self, caplog):
         with mock.patch("psutil.process_iter", side_effect=Exception("psutil error")) as mock_process_iter, \


### PR DESCRIPTION
**Summary**
- This PR updates the is_halt_command_running() method in host_modules/reboot.py to enhance the accuracy of detecting an active HALT command.

**Changes Made**
- Replaced the check for "reboot" in the process name with a more specific check in the process command line arguments.
- Now validates if both "reboot" and the "-p" flag (used to power off) are present in the process command line.

**Reason for Change**
- The previous logic could falsely identify unrelated processes whose names include the word "reboot".
- This update ensures that the detection is accurate and only triggers when the actual HALT (reboot -p) command is running.

**Testing**
- Verified that is_halt_command_running() returns True only when reboot -p is actively running.
- Ensured no false positives with other unrelated processes.