### PR TITLE
Fix reboot without message

### DIFF
--- a/host_modules/reboot.py
+++ b/host_modules/reboot.py
@@ -185,7 +185,7 @@ class Reboot(host_service.HostModule):
             return err, errstr
 
         # Sets reboot_status_flag to be in active state
-        self.populate_reboot_status_flag(True, int(time.time()), reboot_request["message"])
+        self.populate_reboot_status_flag(True, int(time.time()), reboot_request.get("message", ""))
 
         # Issue reboot in a new thread and reset the reboot_status_flag if the reboot fails
         try:


### PR DESCRIPTION
#### What I did

Fix gNOI cold reboot no message issue: https://github.com/sonic-net/sonic-buildimage/issues/22545

#### How I did it

Use `get` instead of `[]` to cover no reboot message case

#### How to verify it

Tested gNOI warm reboot on a hardware switch.

```
root@sonic:~# docker exec -it gnmi bash
root@sonic:/# gnoi_client -notls -insecure -module System -rpc Reboot -jsonin '{"method":1}'
System Reboot
root@sonic:/# exit
root@sonic:~# journalctl -u sonic-hostservice.service -f
...
May 06 07:37:47 sonic python3[699742]: reboot: issue_reboot rpc called
May 06 07:37:47 sonic python3[699742]: reboot: Issuing cold reboot
...
May 06 07:38:18 sonic CCmisApi[700542]: reboot: Initiate shutdown command
client_loop: send disconnect: Broken pipe
```

#### Previous command output (if the output of a command-line utility has changed)

```
root@sonic:~# journalctl -u sonic-hostservice.service
...
May 06 01:28:14 sonic python3[514659]: reboot: issue_reboot rpc called
```

no more logs after that

#### New command output (if the output of a command-line utility has changed)

```
root@sonic:~# journalctl -u sonic-hostservice.service
...
May 06 07:37:47 sonic python3[699742]: reboot: issue_reboot rpc called
May 06 07:37:47 sonic python3[699742]: reboot: Issuing cold reboot
...
May 06 07:38:18 sonic CCmisApi[700542]: reboot: Initiate shutdown command
```

reboot is executed successfully 

