### PR TITLE
config_db should not mandate True and False for featured

### DIFF
--- a/scripts/featured
+++ b/scripts/featured
@@ -101,6 +101,15 @@ class Feature(object):
 
         template = jinja2.Template(configuration)
         target_value = template.render(device_config)
+
+        # YANG mandates boolean values are "true" and "false" but this code otherwise expects
+        # python "True" and "False" so map accordingly.  This then gets passed to ast.literal_eval()
+        # to convert it into an actual boolean, so it needs to be in the python case.
+        if target_value == "true":
+            target_value = "True"
+        if target_value == "false":
+            target_value = "False"
+
         if target_value not in expected_values:
             raise ValueError('Invalid value rendered for feature {}: {}'.format(self.name, target_value))
         return target_value

--- a/scripts/featured
+++ b/scripts/featured
@@ -105,10 +105,9 @@ class Feature(object):
         # YANG mandates boolean values are "true" and "false" but this code otherwise expects
         # python "True" and "False" so map accordingly.  This then gets passed to ast.literal_eval()
         # to convert it into an actual boolean, so it needs to be in the python case.
-        if target_value == "true":
-            target_value = "True"
-        if target_value == "false":
-            target_value = "False"
+        # Normalize case and map boolean strings to Python boolean strings
+        boolean_mapping = {"true": "True", "false": "False"}
+        target_value = boolean_mapping.get(target_value.lower(), target_value)
 
         if target_value not in expected_values:
             raise ValueError('Invalid value rendered for feature {}: {}'.format(self.name, target_value))


### PR DESCRIPTION
YANG models mandate true and false are lowercase.  However featured takes "True" and "False" only.  This is a mismatch that causes issue for those using yang models.  There is no reason for these to be case sensitive.  Rewrite.

Fixes https://github.com/sonic-net/sonic-buildimage/issues/22527
Signed-off-by: Brad House <bhouse@nexthop.ai>