### PR TITLE
Module graceful shutdown support

### DIFF
--- a/data/debian/rules
+++ b/data/debian/rules
@@ -20,5 +20,6 @@ override_dh_installsystemd:
 	dh_installsystemd --no-start --name=procdockerstatsd
 	dh_installsystemd --no-start --name=determine-reboot-cause
 	dh_installsystemd --no-start --name=process-reboot-cause
+	dh_installsystemd --no-start --name=gnoi-reboot
 	dh_installsystemd $(HOST_SERVICE_OPTS) --name=sonic-hostservice
 

--- a/data/debian/sonic-host-services-data.gnoi-reboot.service
+++ b/data/debian/sonic-host-services-data.gnoi-reboot.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=SmartSwitch DPU gNOI Reboot Daemon
+After=rc-local.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/env python3 /usr/local/bin/gnoi-reboot-daemon
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/gnoi-reboot-daemon
+++ b/scripts/gnoi-reboot-daemon
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+#
+# gnoi-reboot-daemon
+#
+# This daemon facilitates gNOI-based reboot operations for DPU subcomponents within the SONiC platform.
+# It listens for JSON-formatted reboot requests on a named pipe and executes the corresponding gNOI
+# Reboot RPCs via the gnmi container.
+
+try:
+    import os
+    import json
+    import subprocess
+    from sonic_py_common import syslogger
+
+except ImportError as err:
+    raise ImportError("%s - required module not found" % str(err))
+
+SYSLOG_IDENTIFIER = "gnoi-reboot-daemon"
+
+FIFO_PATH = "/var/run/gnoi_reboot.pipe"
+
+# Global logger class instance
+logger = syslogger.SysLogger(SYSLOG_IDENTIFIER)
+
+def main():
+    # Configure logger to log all messages INFO level and higher
+    logger.set_min_log_priority(sonic_logger.DEFAULT_LOG_LEVEL)
+
+    logger.log_info("Starting up...")
+
+    # Ensure the FIFO exists
+    if not os.path.exists(FIFO_PATH):
+        os.mkfifo(FIFO_PATH)
+
+    # Open the FIFO in read-write mode to prevent blocking
+    fifo_fd = os.open(FIFO_PATH, os.O_RDWR)
+    with os.fdopen(fifo_fd, 'r') as fifo:
+        while True:
+            line = fifo.readline()
+            if not line:
+                continue
+
+            try:
+                msg = json.loads(line)
+                dpu_ip = msg["dpu_ip"]
+                port = msg.get("port", 50052)
+                method = msg.get("method", 1)
+                message = msg.get("message", "User initiated reboot")
+
+                cmd = [
+                    "docker", "exec", "gnmi", "gnoi_client",
+                    f"-target={dpu_ip}:{port}",
+                    "-logtostderr", "-notls",
+                    "-module", "System",
+                    "-rpc", "Reboot",
+                    "-jsonin", f'{{"method":{method}, "message":"{message}"}}'
+                ]
+                result = subprocess.run(cmd, capture_output=True, text=True)
+                if result.stdout:
+                    logger.log_info(f"Command stdout: {result.stdout.strip()}")
+                if result.stderr:
+                    logger.log_warning(f"Command stderr: {result.stderr.strip()}")
+            except Exception as e:
+                logger.log_error(f"Error processing message: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'scripts/procdockerstatsd',
         'scripts/determine-reboot-cause',
         'scripts/process-reboot-cause',
+        'scripts/gnoi-reboot-daemon',
         'scripts/sonic-host-server',
         'scripts/ldap.py'
     ],


### PR DESCRIPTION
Provide support for SmartSwitch DPU module graceful shutdown.

Why I did it
Please refer to the HLD and related PRs:
HLD: # 1991 https://github.com/sonic-net/SONiC/pull/1991
sonic-platform-common: #567  https://github.com/sonic-net/sonic-buildimage/pull/567
sonic-buildimage:  #22611 https://github.com/sonic-net/sonic-buildimage/pull/22611

How to verify it
Issue the "config chassis modules shutdown DPUx" command
Verify the DPU module is gracefully shut by checking the logs in /var/log/syslog on both NPU and DPU