### PR TITLE
Improve reboot status tracking and add reboot count & method to status

### DIFF
--- a/host_modules/reboot.py
+++ b/host_modules/reboot.py
@@ -8,6 +8,7 @@ import docker
 import psutil
 from host_modules import host_service
 from utils.run_cmd import _run_command
+from enum import Enum
 
 MOD_NAME = 'reboot'
 # Reboot method in reboot request
@@ -24,6 +25,12 @@ HALT_TIMEOUT = 60
 EXECUTE_COLD_REBOOT_COMMAND = "sudo reboot"
 EXECUTE_HALT_REBOOT_COMMAND = "sudo reboot -p"
 EXECUTE_WARM_REBOOT_COMMAND = "sudo warm-reboot"
+
+class RebootStatus(Enum):
+    STATUS_UNKNOWN = 0
+    STATUS_SUCCESS = 1
+    STATUS_RETRIABLE_FAILURE = 2
+    STATUS_FAILURE = 3
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +53,7 @@ class Reboot(host_service.HostModule):
         self.populate_reboot_status_flag()
         super(Reboot, self).__init__(mod_name)
 
-    def populate_reboot_status_flag(self, active = False, when = 0, reason = "", method = ""):
+    def populate_reboot_status_flag(self, active = False, when = 0, reason = "", method = "", status = RebootStatus.STATUS_UNKNOWN):
         """Populates the reboot_status_flag with given input params"""
         self.lock.acquire()
         self.reboot_status_flag["active"] = active
@@ -54,6 +61,7 @@ class Reboot(host_service.HostModule):
         self.reboot_status_flag["reason"] = reason
         self.reboot_status_flag["count"] = self.reboot_count
         self.reboot_status_flag["method"] = method
+        self.reboot_status_flag["status"] = status
         self.lock.release()
         return
 
@@ -117,7 +125,7 @@ class Reboot(host_service.HostModule):
 
         rc, stdout, stderr = _run_command(command)
         if rc:
-            self.populate_reboot_status_flag(False, int (time.time()), "Failed to execute reboot command", reboot_method)
+            self.populate_reboot_status_flag(False, int (time.time()), "Failed to execute reboot command", reboot_method, RebootStatus.STATUS_FAILURE)
             logger.error("%s: Reboot failed execution with stdout: %s, "
                          "stderr: %s", MOD_NAME, stdout, stderr)
             return
@@ -138,23 +146,23 @@ class Reboot(host_service.HostModule):
             while time.monotonic() - start_time < timeout:
                 if not self.is_halt_command_running() and not self.is_container_running("pmon"):
                     logger.info("%s: Halting the services is completed on the device", MOD_NAME)
-                    self.populate_reboot_status_flag(False, 0, "Halt reboot completed", reboot_method)
+                    self.populate_reboot_status_flag(False, 0, "Halt reboot completed", reboot_method, RebootStatus.STATUS_SUCCESS)
                     return
                 time.sleep(5)
 
             # Check if PMON container is still running after timeout
             if self.is_halt_command_running() or self.is_container_running("pmon"):
                 #Halt reboot has failed, as pmon is still running.
-                self.populate_reboot_status_flag(False, int(time.time()), "Halt reboot did not complete", reboot_method)
+                self.populate_reboot_status_flag(False, int(time.time()), "Halt reboot did not complete", reboot_method, RebootStatus.STATUS_FAILURE)
                 logger.error("%s: HALT reboot failed: Services are still running", MOD_NAME)
             else:
-                self.populate_reboot_status_flag(False, 0, "Halt reboot completed", reboot_method)
+                self.populate_reboot_status_flag(False, 0, "Halt reboot completed", reboot_method, RebootStatus.STATUS_SUCCESS)
                 logger.info("%s: Halting the services is completed on the device", MOD_NAME)
             return
         else:
             time.sleep(REBOOT_TIMEOUT)
             # Conclude that the reboot has failed if we reach this point
-            self.populate_reboot_status_flag(False, int(time.time()), "Reboot command failed to execute", reboot_method)
+            self.populate_reboot_status_flag(False, int(time.time()), "Reboot command failed to execute", reboot_method, RebootStatus.STATUS_FAILURE)
             return
 
     @host_service.method(host_service.bus_name(MOD_NAME), in_signature='as', out_signature='is')
@@ -193,7 +201,7 @@ class Reboot(host_service.HostModule):
             return err, errstr
 
         # Sets reboot_status_flag to be in active state
-        self.populate_reboot_status_flag(True, int(time.time()), reboot_request["message"], reboot_request["method"])
+        self.populate_reboot_status_flag(True, int(time.time()), reboot_request["message"], reboot_request["method"], RebootStatus.STATUS_UNKNOWN)
 
         # Issue reboot in a new thread and reset the reboot_status_flag if the reboot fails
         try:

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -117,12 +117,12 @@ class TestReboot(object):
             mock_docker.return_value = mock_client
             mock_container = mock.Mock()
             mock_container.name = "pmon"
-            mock_container.status = "running"
+            mock_container.attrs = {'State': {'Running': True}}
             mock_client.containers.list.return_value = [mock_container]
 
             result = self.reboot_module.is_container_running("pmon")
             assert result is True
-            mock_client.containers.list.assert_called_once_with(filters={"name": "pmon"})
+            mock_client.containers.list.assert_called_once_with(filters={"name": "^pmon$"})
 
     def test_is_container_running_failure(self):
         with mock.patch("docker.from_env") as mock_docker:
@@ -132,7 +132,7 @@ class TestReboot(object):
 
             result = self.reboot_module.is_container_running("pmon")
             assert result is False
-            mock_client.containers.list.assert_called_once_with(filters={"name": "pmon"})
+            mock_client.containers.list.assert_called_once_with(filters={"name": "^pmon$"})
 
     def test_is_container_running_exception(self, caplog):
         with mock.patch("docker.from_env", side_effect=Exception("Docker error")) as mock_docker, \
@@ -178,7 +178,7 @@ class TestReboot(object):
             self.reboot_module.execute_reboot("WARM")
             mock_run_command.assert_called_once_with("sudo warm-reboot")
             mock_sleep.assert_called_once_with(260)
-            mock_populate_reboot_status_flag.assert_called_once_with()
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int(time.time()), "Reboot command failed to execute", 'WARM')
 
     def test_execute_reboot_fail_unknown_reboot(self, caplog):
         with caplog.at_level(logging.ERROR):
@@ -198,7 +198,7 @@ class TestReboot(object):
                     "stdout: ['stdout: execute cold reboot'], stderr: "
                     "['stderror: execute cold reboot']")
             assert caplog.records[0].message == msg
-            mock_populate_reboot_status_flag.assert_called_once_with()
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 1)
 
     def test_execute_reboot_fail_issue_reboot_command_halt(self, caplog):
         with (
@@ -212,7 +212,7 @@ class TestReboot(object):
                    "stdout: ['stdout: execute halt reboot'], stderr: "
                    "['stderror: execute halt reboot']")
             assert caplog.records[0].message == msg
-            mock_populate_reboot_status_flag.assert_called_once_with()
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 3)
 
     def test_execute_reboot_success_halt(self):
         with (
@@ -227,7 +227,7 @@ class TestReboot(object):
             mock_run_command.assert_called_once_with("sudo reboot -p")
             mock_is_halt_command_running.assert_called()
             mock_is_container_running.assert_called_with("pmon")
-            mock_populate_reboot_status_flag.assert_not_called()
+            mock_populate_reboot_status_flag.assert_called_once_with(False, 0, 'Halt reboot completed', 3)
 
     def test_execute_reboot_fail_halt_timeout(self, caplog):
         with (
@@ -244,7 +244,7 @@ class TestReboot(object):
             mock_sleep.assert_called_with(5)
             mock_is_halt_command_running.assert_called()
             assert any("HALT reboot failed: Services are still running" in record.message for record in caplog.records)
-            mock_populate_reboot_status_flag.assert_called_once_with()
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int(time.time()), 'Halt reboot did not complete', 3)
 
     def test_execute_reboot_fail_issue_reboot_command_warm(self, caplog):
         with (
@@ -258,7 +258,7 @@ class TestReboot(object):
                     "stdout: ['stdout: execute WARM reboot'], stderr: "
                     "['stderror: execute WARM reboot']")
             assert caplog.records[0].message == msg
-            mock_populate_reboot_status_flag.assert_called_once_with()
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 'WARM')
 
     def test_issue_reboot_success_cold_boot(self):
         with (


### PR DESCRIPTION
# Why I did it
To provide more accurate and detailed tracking of reboot operations on the host. This includes:

- Fixing incorrect or missing values in the reboot_status_flag.
- Adding the ability to track how many times a reboot has been initiated (count).
- Recording which reboot method was used (method), which is critical for debugging and telemetry.

Fixes: https://github.com/sonic-net/sonic-buildimage/issues/22157

# How I did it
- Enhanced the populate_reboot_status_flag() function to also track:
-- count: Number of reboots initiated by the host service.
-- method: Type of reboot (e.g., cold, warm, halt).

- Corrected how container status is evaluated using Docker SDK by checking attrs['State']['Running'] instead of relying on the status string.
- Updated all relevant call sites of populate_reboot_status_flag() to pass the correct parameters.
- Adjusted unit tests to validate updated logic and ensure coverage of new parameters.

# Changelog
- Improved reboot_status_flag tracking with method and count fields.
- More accurate container status check using Docker SDK.
- Fixed bug where reboot failure didn’t update the status properly.
- Updated unit tests accordingly.

