### PR TITLE
[build] Update Azure pipeline to use Ubuntu 24.04 image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ stages:
       DIFF_COVER_CHECK_THRESHOLD: 80
       DIFF_COVER_ENABLE: 'true'
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-24.04
 
     container:
       image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)


### PR DESCRIPTION
Updated the Azure DevOps pipeline configuration to use `ubuntu-24.04` as the virtual machine image instead of `ubuntu-20.04`.