### PR TITLE
[Radius] Add new option "dont_send_msg_auth" to control the addition of "message_authenticator".

### DIFF
--- a/data/templates/common-auth-sonic.j2
+++ b/data/templates/common-auth-sonic.j2
@@ -32,7 +32,7 @@ auth	[success=1 default=ignore]	pam_unix.so nullok try_first_pass
 auth	[success=done new_authtok_reqd=done default=ignore{{ ' auth_err=die maxtries=die' if not auth['failthrough'] }}]	pam_unix.so nullok try_first_pass
 # For the RADIUS servers, on success jump to the cacheing the MPL(Privilege)
 {% for server in servers %}
-auth	[success={{ (servers | count) - loop.index0 }} new_authtok_reqd=done default=ignore{{ ' auth_err=die' if not auth['failthrough'] }}]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/{{ server.ip }}_{{ server.auth_port }}.conf privilege_level protocol={{ server.auth_type }} retry={{ server.retransmit }}{% if server.nas_ip is defined %} nas_ip_address={{ server.nas_ip }}{% endif %}{% if server.nas_id is defined %} client_id={{ server.nas_id }}{% endif %}{% if debug %} debug{% endif %}{% if trace %} trace{% endif %}{% if server.statistics %} statistics={{ server.ip }}{% endif %} try_first_pass {% if not server.skip_msg_auth %}require_message_authenticator{% endif %} 
+auth	[success={{ (servers | count) - loop.index0 }} new_authtok_reqd=done default=ignore{{ ' auth_err=die' if not auth['failthrough'] }}]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/{{ server.ip }}_{{ server.auth_port }}.conf privilege_level protocol={{ server.auth_type }} retry={{ server.retransmit }}{% if server.nas_ip is defined %} nas_ip_address={{ server.nas_ip }}{% endif %}{% if server.nas_id is defined %} client_id={{ server.nas_id }}{% endif %}{% if debug %} debug{% endif %}{% if trace %} trace{% endif %}{% if server.statistics %} statistics={{ server.ip }}{% endif %} try_first_pass {% if not server.skip_msg_auth %}require_message_authenticator{% endif %} {% if server.dont_send_msg_auth %}dont_send_msg_auth{% endif %} 
 {% endfor %}
 auth	requisite	pam_deny.so
 # Cache MPL(Privilege)
@@ -47,7 +47,7 @@ auth	[success=ok default=ignore]	pam_succeed_if.so user = root
 {% endif %}
 # For the RADIUS servers, on success jump to the cache the MPL(Privilege)
 {% for server in servers %}
-auth	[success={{ (servers | count) + 1 - loop.index0 }} new_authtok_reqd=done default=ignore{{ ' auth_err=die' if not auth['failthrough'] }}]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/{{ server.ip }}_{{ server.auth_port }}.conf privilege_level protocol={{ server.auth_type }} retry={{ server.retransmit }}{% if server.nas_ip is defined %} nas_ip_address={{ server.nas_ip }}{% endif %}{% if server.nas_id is defined %} client_id={{ server.nas_id }}{% endif %}{% if debug %} debug{% endif %}{% if trace %} trace{% endif %}{% if server.statistics %} statistics={{ server.ip }}{% endif %} try_first_pass {% if not server.skip_msg_auth %}require_message_authenticator{% endif %} 
+auth	[success={{ (servers | count) + 1 - loop.index0 }} new_authtok_reqd=done default=ignore{{ ' auth_err=die' if not auth['failthrough'] }}]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/{{ server.ip }}_{{ server.auth_port }}.conf privilege_level protocol={{ server.auth_type }} retry={{ server.retransmit }}{% if server.nas_ip is defined %} nas_ip_address={{ server.nas_ip }}{% endif %}{% if server.nas_id is defined %} client_id={{ server.nas_id }}{% endif %}{% if debug %} debug{% endif %}{% if trace %} trace{% endif %}{% if server.statistics %} statistics={{ server.ip }}{% endif %} try_first_pass {% if not server.skip_msg_auth %}require_message_authenticator{% endif %} {% if server.dont_send_msg_auth %}dont_send_msg_auth{% endif %} 
 {% endfor %}
 # Local
 auth	[success=done new_authtok_reqd=done default=ignore{{ ' auth_err=die maxtries=die' if not auth['failthrough'] }}]	pam_unix.so nullok try_first_pass
@@ -60,7 +60,7 @@ auth	[success=1 default=ignore]	pam_exec.so /usr/sbin/cache_radius
 auth	[success={{ (servers | count) + 2 }} default=ignore]	pam_succeed_if.so user = root
 # For the RADIUS servers, on success jump to the cache the MPL(Privilege)
 {% for server in servers %}
-auth	[success={{ (servers | count) - loop.index0 }} new_authtok_reqd=done default=ignore{{ ' auth_err=die' if not auth['failthrough'] }}]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/{{ server.ip }}_{{ server.auth_port }}.conf privilege_level protocol={{ server.auth_type }} retry={{ server.retransmit }}{% if server.nas_ip is defined %} nas_ip_address={{ server.nas_ip }}{% endif %}{% if server.nas_id is defined %} client_id={{ server.nas_id }}{% endif %}{% if debug %} debug{% endif %}{% if trace %} trace{% endif %}{% if server.statistics %} statistics={{ server.ip }}{% endif %} try_first_pass {% if not server.skip_msg_auth %}require_message_authenticator{% endif %} 
+auth	[success={{ (servers | count) - loop.index0 }} new_authtok_reqd=done default=ignore{{ ' auth_err=die' if not auth['failthrough'] }}]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/{{ server.ip }}_{{ server.auth_port }}.conf privilege_level protocol={{ server.auth_type }} retry={{ server.retransmit }}{% if server.nas_ip is defined %} nas_ip_address={{ server.nas_ip }}{% endif %}{% if server.nas_id is defined %} client_id={{ server.nas_id }}{% endif %}{% if debug %} debug{% endif %}{% if trace %} trace{% endif %}{% if server.statistics %} statistics={{ server.ip }}{% endif %} try_first_pass {% if not server.skip_msg_auth %}require_message_authenticator{% endif %} {% if server.dont_send_msg_auth %}dont_send_msg_auth{% endif %} 
 {% endfor %}
 auth	requisite	pam_deny.so
 # Cache MPL(Privilege)

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -87,6 +87,7 @@ RADIUS_SERVER_TIMEOUT_DEFAULT = "5"
 RADIUS_SERVER_AUTH_TYPE_DEFAULT = "pap"
 RADIUS_PAM_AUTH_CONF_DIR = "/etc/pam_radius_auth.d/"
 RADIUS_SERVER_SKIP_MSG_AUTH = False
+RADIUS_SERVER_DONT_SEND_MSG_AUTH = False
 
 # FIPS
 FIPS_CONFIG_FILE = '/etc/sonic/fips.json'
@@ -369,7 +370,8 @@ class AaaCfg(object):
             'retransmit': RADIUS_SERVER_RETRANSMIT_DEFAULT,
             'timeout': RADIUS_SERVER_TIMEOUT_DEFAULT,
             'passkey': RADIUS_SERVER_PASSKEY_DEFAULT,
-            'skip_msg_auth': RADIUS_SERVER_SKIP_MSG_AUTH
+            'skip_msg_auth': RADIUS_SERVER_SKIP_MSG_AUTH,
+            'dont_send_msg_auth': RADIUS_SERVER_DONT_SEND_MSG_AUTH
         }
         self.radius_global = {}
         self.radius_servers = {}
@@ -531,7 +533,9 @@ class AaaCfg(object):
             self.radius_servers[key] = data
             if self.radius_servers[key].get('skip_msg_auth', None) is not None:
                 data['skip_msg_auth'] = is_true(self.radius_servers[key]['skip_msg_auth'])
-
+            if self.radius_servers[key].get('dont_send_msg_auth', None) is not None:
+                data['dont_send_msg_auth'] = is_true(self.radius_servers[key]['dont_send_msg_auth'])
+                
         if modify_conf:
             self.modify_conf_file()
 

--- a/tests/hostcfgd/sample_output/RADIUS/common-auth-sonic
+++ b/tests/hostcfgd/sample_output/RADIUS/common-auth-sonic
@@ -12,11 +12,11 @@
 # root user can only be authenticated locally. Jump to local.
 auth	[success=5 default=ignore]	pam_succeed_if.so user = root
 # For the RADIUS servers, on success jump to the cache the MPL(Privilege)
-auth	[success=6 new_authtok_reqd=done default=ignore auth_err=die]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/10.10.10.1_1645.conf privilege_level protocol=pap retry=1 nas_ip_address=10.10.10.10 debug try_first_pass require_message_authenticator 
-auth	[success=5 new_authtok_reqd=done default=ignore auth_err=die]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/10.10.10.2_1645.conf privilege_level protocol=chap retry=2 nas_ip_address=10.10.10.10 debug try_first_pass require_message_authenticator 
-auth	[success=4 new_authtok_reqd=done default=ignore auth_err=die]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/10.10.10.3_1645.conf privilege_level protocol=chap retry=3 nas_ip_address=10.10.10.10 debug try_first_pass require_message_authenticator 
-auth	[success=3 new_authtok_reqd=done default=ignore auth_err=die]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/10.10.10.4_1645.conf privilege_level protocol=pap retry=4 nas_ip_address=10.10.10.10 debug try_first_pass require_message_authenticator 
-auth	[success=2 new_authtok_reqd=done default=ignore auth_err=die]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/10.10.10.5_1645.conf privilege_level protocol=pap retry=1 nas_ip_address=10.10.10.10 debug try_first_pass  
+auth	[success=6 new_authtok_reqd=done default=ignore auth_err=die]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/10.10.10.1_1645.conf privilege_level protocol=pap retry=1 nas_ip_address=10.10.10.10 debug try_first_pass require_message_authenticator  
+auth	[success=5 new_authtok_reqd=done default=ignore auth_err=die]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/10.10.10.2_1645.conf privilege_level protocol=chap retry=2 nas_ip_address=10.10.10.10 debug try_first_pass require_message_authenticator  
+auth	[success=4 new_authtok_reqd=done default=ignore auth_err=die]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/10.10.10.3_1645.conf privilege_level protocol=chap retry=3 nas_ip_address=10.10.10.10 debug try_first_pass require_message_authenticator  
+auth	[success=3 new_authtok_reqd=done default=ignore auth_err=die]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/10.10.10.4_1645.conf privilege_level protocol=pap retry=4 nas_ip_address=10.10.10.10 debug try_first_pass require_message_authenticator  
+auth	[success=2 new_authtok_reqd=done default=ignore auth_err=die]	pam_radius_auth.so conf=/etc/pam_radius_auth.d/10.10.10.5_1645.conf privilege_level protocol=pap retry=1 nas_ip_address=10.10.10.10 debug try_first_pass  dont_send_msg_auth 
 # Local
 auth	[success=done new_authtok_reqd=done default=ignore auth_err=die maxtries=die]	pam_unix.so nullok try_first_pass
 auth	requisite	pam_deny.so

--- a/tests/hostcfgd/test_radius_vectors.py
+++ b/tests/hostcfgd/test_radius_vectors.py
@@ -91,6 +91,7 @@ HOSTCFGD_TEST_RADIUS_VECTOR = [
                         "timeout": "1",
                         "passkey": "pass1",
                         "skip_msg_auth": "true",
+                        "dont_send_msg_auth": "true",
                     }
                 },
             },
@@ -160,6 +161,7 @@ HOSTCFGD_TEST_RADIUS_VECTOR = [
                         "timeout": "1",
                         "passkey": "pass1",
                         "skip_msg_auth": "true",
+                        "dont_send_msg_auth": "true",
                     }
                 },
             },


### PR DESCRIPTION
To address backward compatibility concerns, add a new option "dont_send_msg_auth" to control the addition of "Message-Authenticator" in the Access-Request packet from pam_radius.