### PR TITLE
Fix PyGObject required version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'dbus-python',
         'systemd-python',
         'Jinja2>=2.10',
-        'PyGObject==3.50.0',
+        'PyGObject',
         'pycairo==1.26.1',
         'psutil'
     ] + sonic_dependencies,

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'dbus-python',
         'systemd-python',
         'Jinja2>=2.10',
-        'PyGObject<=3.50.0',
+        'PyGObject==3.50.0',
         'pycairo==1.26.1',
         'psutil'
     ] + sonic_dependencies,

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'dbus-python',
         'systemd-python',
         'Jinja2>=2.10',
-        'PyGObject==3.50.0',
+        'PyGObject<=3.50.0',
         'pycairo==1.26.1',
         'psutil'
     ] + sonic_dependencies,


### PR DESCRIPTION
Current slave image installs an old version.
files/build/versions/dockers/sonic-slave-bookworm/versions-py3:113:pygobject==3.42.2

Relax the install_requires range of PyGObject to allow any versions.