### PR TITLE
Improve reboot status tracking and add reboot count & method to status

### DIFF
--- a/host_modules/reboot.py
+++ b/host_modules/reboot.py
@@ -8,6 +8,7 @@ import docker
 import psutil
 from host_modules import host_service
 from utils.run_cmd import _run_command
+from enum import Enum
 
 MOD_NAME = 'reboot'
 # Reboot method in reboot request
@@ -25,6 +26,12 @@ EXECUTE_COLD_REBOOT_COMMAND = "sudo reboot"
 EXECUTE_HALT_REBOOT_COMMAND = "sudo reboot -p"
 EXECUTE_WARM_REBOOT_COMMAND = "sudo warm-reboot"
 
+class RebootStatus(Enum):
+    STATUS_UNKNOWN = 0
+    STATUS_SUCCESS = 1
+    STATUS_RETRIABLE_FAILURE = 2
+    STATUS_FAILURE = 3
+
 logger = logging.getLogger(__name__)
 
 
@@ -38,16 +45,23 @@ class Reboot(host_service.HostModule):
         self.lock = threading.Lock()
         # reboot_status_flag is used to keep track of reboot status on host
         self.reboot_status_flag = {}
+
+        # reboot count
+        self.reboot_count = 0
+
         # Populating with default value i.e., no active reboot
         self.populate_reboot_status_flag()
         super(Reboot, self).__init__(mod_name)
 
-    def populate_reboot_status_flag(self, active = False, when = 0, reason = ""):
+    def populate_reboot_status_flag(self, active = False, when = 0, reason = "", method = "", status = RebootStatus.STATUS_UNKNOWN):
         """Populates the reboot_status_flag with given input params"""
         self.lock.acquire()
         self.reboot_status_flag["active"] = active
         self.reboot_status_flag["when"] = when
         self.reboot_status_flag["reason"] = reason
+        self.reboot_status_flag["count"] = self.reboot_count
+        self.reboot_status_flag["method"] = method
+        self.reboot_status_flag["status"] = status
         self.lock.release()
         return
 
@@ -71,10 +85,10 @@ class Reboot(host_service.HostModule):
         """Check if a given container is running using the Docker SDK."""
         try:
             client = docker.from_env()
-            containers = client.containers.list(filters={"name": container_name})
+            containers = client.containers.list(filters={"name": f"^{container_name}$"})
 
             for container in containers:
-                if container.name == container_name and container.status == "running":
+                if container.name == container_name and container.attrs['State']['Running']:
                     return True
             return False
         except Exception as e:
@@ -111,7 +125,7 @@ class Reboot(host_service.HostModule):
 
         rc, stdout, stderr = _run_command(command)
         if rc:
-            self.populate_reboot_status_flag()
+            self.populate_reboot_status_flag(False, int (time.time()), "Failed to execute reboot command", reboot_method, RebootStatus.STATUS_FAILURE)
             logger.error("%s: Reboot failed execution with stdout: %s, "
                          "stderr: %s", MOD_NAME, stdout, stderr)
             return
@@ -128,29 +142,30 @@ class Reboot(host_service.HostModule):
             logger.info("%s: Waiting until services are halted or timeout occurs", MOD_NAME)
             timeout = HALT_TIMEOUT
             start_time = time.monotonic()
+
             while time.monotonic() - start_time < timeout:
                 if not self.is_halt_command_running() and not self.is_container_running("pmon"):
                     logger.info("%s: Halting the services is completed on the device", MOD_NAME)
+                    self.populate_reboot_status_flag(False, 0, "Halt reboot completed", reboot_method, RebootStatus.STATUS_SUCCESS)
                     return
                 time.sleep(5)
 
             # Check if PMON container is still running after timeout
             if self.is_halt_command_running() or self.is_container_running("pmon"):
                 #Halt reboot has failed, as pmon is still running.
+                self.populate_reboot_status_flag(False, int(time.time()), "Halt reboot did not complete", reboot_method, RebootStatus.STATUS_FAILURE)
                 logger.error("%s: HALT reboot failed: Services are still running", MOD_NAME)
-                self.populate_reboot_status_flag()
-                return
             else:
+                self.populate_reboot_status_flag(False, 0, "Halt reboot completed", reboot_method, RebootStatus.STATUS_SUCCESS)
                 logger.info("%s: Halting the services is completed on the device", MOD_NAME)
-
+            return
         else:
             time.sleep(REBOOT_TIMEOUT)
             # Conclude that the reboot has failed if we reach this point
-            self.populate_reboot_status_flag()
+            self.populate_reboot_status_flag(False, int(time.time()), "Reboot command failed to execute", reboot_method, RebootStatus.STATUS_FAILURE)
             return
 
     @host_service.method(host_service.bus_name(MOD_NAME), in_signature='as', out_signature='is')
-
     def issue_reboot(self, options):
         """Initializes reboot thorugh RPC based on the reboot flag assigned.
            Issues reboot after performing the following steps sequentially:
@@ -162,6 +177,7 @@ class Reboot(host_service.HostModule):
         logger.warning("%s: issue_reboot rpc called", MOD_NAME)
         self.lock.acquire()
         is_reboot_ongoing = self.reboot_status_flag["active"]
+        self.reboot_count += 1
         self.lock.release()
         # Return without issuing the reboot if the previous reboot is ongoing
         if is_reboot_ongoing:
@@ -185,7 +201,7 @@ class Reboot(host_service.HostModule):
             return err, errstr
 
         # Sets reboot_status_flag to be in active state
-        self.populate_reboot_status_flag(True, int(time.time()), reboot_request["message"])
+        self.populate_reboot_status_flag(True, int(time.time()), reboot_request.get("message", ""), reboot_request["method"], RebootStatus.STATUS_UNKNOWN)
 
         # Issue reboot in a new thread and reset the reboot_status_flag if the reboot fails
         try:


### PR DESCRIPTION
Why I did it
To provide more accurate and detailed tracking of reboot operations on the host. This includes:

Fixing incorrect or missing values in the reboot_status_flag. Adding the ability to track how many times a reboot has been initiated (count). Recording which reboot method was used (method), which is critical for debugging and telemetry. Fixes: sonic-net/sonic-buildimage#22157

How I did it
Enhanced the populate_reboot_status_flag() function to also track: -- count: Number of reboots initiated by the host service. -- method: Type of reboot (e.g., cold, warm, halt).

Corrected how container status is evaluated using Docker SDK by checking attrs['State']['Running'] instead of relying on the status string.

Updated all relevant call sites of populate_reboot_status_flag() to pass the correct parameters.

Adjusted unit tests to validate updated logic and ensure coverage of new parameters.