### PR TITLE
Include info level logs in reboot cause services

### DIFF
--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -9,6 +9,7 @@
 try:
     import datetime
     import json
+    import logging
     import os
     import pwd
     import re
@@ -236,7 +237,7 @@ def check_and_create_dpu_dirs():
 
 def main():
     # Configure logger to log all messages INFO level and higher
-    sonic_logger.set_min_log_priority(sonic_logger.DEFAULT_LOG_LEVEL)
+    sonic_logger.set_min_log_priority(logging.INFO)
 
     sonic_logger.log_info("Starting up...")
 

--- a/scripts/process-reboot-cause
+++ b/scripts/process-reboot-cause
@@ -8,6 +8,7 @@
 
 try:
     import json
+    import logging
     import os
     import pwd
     import sys
@@ -88,7 +89,7 @@ def read_reboot_cause_files_and_save_to_db(device='npu'):
 
 def main():
     # Configure logger to log all messages INFO level and higher
-    sonic_logger.set_min_log_priority(sonic_logger.DEFAULT_LOG_LEVEL)
+    sonic_logger.set_min_log_priority(logging.INFO)
 
     sonic_logger.log_info("Starting up...")
 


### PR DESCRIPTION
The `process-reboot-cause` and `determine-reboot-cause` services are filtering out INFO level logs. This is unintentional according to the comment "Configure logger to log all messages INFO level and higher".

This PR calls `set_min_log_priority` with **logging.INFO (20)** instead of **sonic_logger.DEFAULT_LOG_LEVEL (21)** as to not filter out the INFO logs.