### PR TITLE
Load TACACS config before SONiC services initialized

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -2177,7 +2177,8 @@ class HostConfigDaemon:
         # Initialize LoggingCfg
         self.loggingcfg = LoggingCfg()
 
-    def load(self, init_data):
+    def load_independent_config(self, init_data):
+        # Load config that does not rely on any services
         aaa = init_data['AAA']
         tacacs_global = init_data['TACPLUS']
         tacacs_server = init_data['TACPLUS_SERVER']
@@ -2185,6 +2186,18 @@ class HostConfigDaemon:
         radius_server = init_data['RADIUS_SERVER']
         ldap_global = init_data['LDAP']
         ldap_server = init_data['LDAP_SERVER']
+        self.aaacfg.load(aaa, tacacs_global, tacacs_server, radius_global, radius_server, ldap_global, ldap_server)
+
+    def load(self, init_data):
+        self.load_independent_config(init_data)
+        
+        syslog.syslog(syslog.LOG_INFO,
+                      "Waiting for systemctl to finish initialization")
+        self.wait_till_system_init_done()
+        syslog.syslog(syslog.LOG_INFO,
+                      "systemctl has finished initialization -- proceeding ...")
+
+        # Load configuration that depends on initialized services
         lpbk_table = init_data['LOOPBACK_INTERFACE']
         kdump = init_data['KDUMP']
         passwh = init_data['PASSW_HARDENING']
@@ -2204,7 +2217,6 @@ class HostConfigDaemon:
         banner_messages = init_data.get(swsscommon.CFG_BANNER_MESSAGE_TABLE_NAME)
         logging = init_data.get(swsscommon.CFG_LOGGING_TABLE_NAME, {})
 
-        self.aaacfg.load(aaa, tacacs_global, tacacs_server, radius_global, radius_server, ldap_global, ldap_server)
         self.iptables.load(lpbk_table)
         self.kdumpCfg.load(kdump)
         self.passwcfg.load(passwh)
@@ -2464,12 +2476,6 @@ class HostConfigDaemon:
         # Handle LOGGING changes
         self.config_db.subscribe(swsscommon.CFG_LOGGING_TABLE_NAME,
                                  make_callback(self.logging_handler))
-
-        syslog.syslog(syslog.LOG_INFO,
-                      "Waiting for systemctl to finish initialization")
-        self.wait_till_system_init_done()
-        syslog.syslog(syslog.LOG_INFO,
-                      "systemctl has finished initialization -- proceeding ...")
 
     def start(self):
         self.config_db.listen(init_data_handler=self.load)


### PR DESCRIPTION
Load TACACS config before SONiC services initialized

#### Why I did it
After upgrading the SONiC OS and performing the first reboot, remote users can log in using the admin account before the TACACS configuration is migrated.
This occurs because the TACACS config migration process waits for all SONiC services to be fully initialized before proceeding.

##### Work item tracking
- Microsoft ADO **(number only)**: 33491336

#### How I did it
Relocate service wait code to execute after TACACS config is loaded


#### How to verify it
Pass all test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Load TACACS config before SONiC services initialized

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

