### PR TITLE
[202411] Fix 202411 pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ stages:
       DIFF_COVER_CHECK_THRESHOLD: 80
       DIFF_COVER_ENABLE: 'true'
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-24.04
 
     container:
       image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ stages:
       vmImage: ubuntu-20.04
 
     container:
-      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bullseye:$(BUILD_BRANCH)
+      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)
 
     steps:
     - checkout: self
@@ -58,7 +58,7 @@ stages:
         sudo dpkg -i libyang_1.0.73_*.deb
         sudo dpkg -i libswsscommon_1.0.0_amd64.deb
         sudo dpkg -i python3-swsscommon_1.0.0_amd64.deb
-      workingDirectory: $(Pipeline.Workspace)/target/debs/bullseye/
+      workingDirectory: $(Pipeline.Workspace)/target/debs/bookworm/
       displayName: 'Install Debian dependencies'
 
     - script: |
@@ -71,20 +71,22 @@ stages:
         sudo pip3 install sonic_config_engine-1.0-py3-none-any.whl
         sudo pip3 install sonic_platform_common-1.0-py3-none-any.whl
         sudo pip3 install sonic_utilities-1.2-py3-none-any.whl
-      workingDirectory: $(Pipeline.Workspace)/target/python-wheels/bullseye/
+      workingDirectory: $(Pipeline.Workspace)/target/python-wheels/bookworm/
       displayName: 'Install Python dependencies'
 
     - script: |
         set -ex
         # Install .NET CORE
         curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-        sudo apt-add-repository https://packages.microsoft.com/debian/11/prod
+        sudo apt-add-repository https://packages.microsoft.com/debian/12/prod
         sudo apt-get update
-        sudo apt-get install -y dotnet-sdk-5.0
+        sudo apt-get install -y dotnet-sdk-8.0
       displayName: "Install .NET CORE"
 
     - script: |
-        python3 setup.py test
+        pip3 install ".[testing]"
+        pip3 uninstall --yes sonic-host-services
+        pytest
       displayName: 'Test Python 3'
 
     - task: PublishTestResults@2
@@ -103,8 +105,7 @@ stages:
       displayName: 'Publish Python 3 test coverage'
 
     - script: |
-        set -e
-        python3 setup.py bdist_wheel
+        python3 -m build -n
       displayName: 'Build Python 3 wheel'
 
     - publish: '$(System.DefaultWorkingDirectory)/dist/'

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -18,7 +18,7 @@ try:
     import threading
     import time
     from sonic_py_common.general import getstatusoutput_noshell_pipe
-    from sonic_py_common import daemon_base, device_info, multi_asic
+    from sonic_py_common import logger, device_info, multi_asic
     from swsscommon import swsscommon
 except ImportError as err:
     raise ImportError("%s - required module not found" % str(err))
@@ -64,7 +64,7 @@ def get_ipv4_networks_from_interface_table(table, intf_name):
 # ============================== Classes ==============================
 
 
-class ControlPlaneAclManager(daemon_base.DaemonBase):
+class ControlPlaneAclManager(logger.Logger):
     """
     Class which reads control plane ACL tables and rules from Config DB,
     translates them into equivalent iptables commands and runs those

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -123,7 +123,7 @@ def run_cmd_pipe(cmd0, cmd1, cmd2, log_err=True, raise_exception=False):
         check_output_pipe(cmd0, cmd1, cmd2)
     except Exception as err:
         if log_err:
-            syslog.syslog(syslog.LOG_ERR, "{} - failed: return code - {}, output:\n{}"
+            syslog.syslog(syslog.LOG_WARNING, "{} - failed: return code - {}, output:\n{}"
                   .format(err.cmd, err.returncode, err.output))
         if raise_exception:
             raise
@@ -1535,6 +1535,9 @@ class MgmtIfaceCfg(object):
                           'services')
             return
 
+        # Update cache
+        self.mgmt_vrf_enabled = enabled
+
         # Remove mgmt if route
         if enabled == 'true':
             """
@@ -1553,15 +1556,11 @@ class MgmtIfaceCfg(object):
                 cmd2 = ['wc', '-l']
                 run_cmd_pipe(cmd0, cmd1, cmd2, True, True)
             except subprocess.CalledProcessError:
-                syslog.syslog(syslog.LOG_ERR, 'MgmtIfaceCfg: Could not delete '
+                syslog.syslog(syslog.LOG_WARNING, 'MgmtIfaceCfg: Could not delete '
                                               'eth0 route')
                 return
 
             run_cmd(["ip", "-4", "route", "del", "default", "dev", "eth0", "metric", "202"], False)
-
-        # Update cache
-        self.mgmt_vrf_enabled = enabled
-
 
 class RSyslogCfg(object):
     """Remote syslog config daemon

--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1017,7 +1017,6 @@ class PasswHardening(object):
             if account_number >= uid_min and account_number <= uid_max:
                 normal_accounts.append(account_spl[ACCOUNT_NAME])
 
-        normal_accounts.append('root') # root is also a candidate to be age modify.
         return normal_accounts
 
     def modify_passw_conf_file(self):

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'dbus-python',
         'systemd-python',
         'Jinja2>=2.10',
-        'PyGObject',
+        'PyGObject==3.50.0',
         'pycairo==1.26.1',
         'psutil'
     ] + sonic_dependencies,

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 import swsscommon as swsscommon_package
+from subprocess import CalledProcessError
 from sonic_py_common import device_info
 from swsscommon import swsscommon
 
@@ -323,6 +324,29 @@ class TestHostcfgdDaemon(TestCase):
                     call(['cat', '/proc/net/route'], ['grep', '-E', r"eth0\s+00000000\s+[0-9A-Z]+\s+[0-9]+\s+[0-9]+\s+[0-9]+\s+202"], ['wc', '-l'])
                 ]
                 mocked_check_output.assert_has_calls(expected)
+
+    def test_mgmtvrf_route_check_failed(self):
+        mgmtiface = hostcfgd.MgmtIfaceCfg()
+        mgmtiface.load({}, {'mgmtVrfEnabled' : "false"})
+        with mock.patch('hostcfgd.check_output_pipe') as mocked_check_output:
+            with mock.patch('hostcfgd.subprocess') as mocked_subprocess:
+                popen_mock = mock.Mock()
+                attrs = {'communicate.return_value': ('output', 'error')}
+                popen_mock.configure_mock(**attrs)
+                mocked_subprocess.Popen.return_value = popen_mock
+                mocked_subprocess.CalledProcessError = CalledProcessError
+                # Simulate the case where there is no default route
+                mocked_check_output.side_effect = CalledProcessError(returncode=1, cmd="", output="")
+
+                mgmtiface.update_mgmt_vrf({'mgmtVrfEnabled' : "true"})
+                expected = [
+                    call(['cat', '/proc/net/route'], ['grep', '-E', r"eth0\s+00000000\s+[0-9A-Z]+\s+[0-9]+\s+[0-9]+\s+[0-9]+\s+202"], ['wc', '-l'])
+                ]
+                mocked_check_output.assert_has_calls(expected)
+                assert mgmtiface.mgmt_vrf_enabled == "true"
+
+                mgmtiface.update_mgmt_vrf({'mgmtVrfEnabled' : "false"})
+                assert mgmtiface.mgmt_vrf_enabled == "false"
 
     def test_dns_events(self):
         MockConfigDb.set_config_db(HOSTCFG_DAEMON_CFG_DB)


### PR DESCRIPTION
Cherrypicks https://github.com/sonic-net/sonic-host-services/pull/260 and https://github.com/sonic-net/sonic-host-services/pull/193

They are clean cherry picks but we need both changes in 1 PR, because without 260 cherry pick, the cherry pick of 193 will never run, and without the cherry pick of 193, the cherry pick of 260 will always fail. So there is a cyclic dependency which can be fixed by including both changes in this PR