### PR TITLE
tests: Ensure hostcfgd tests do not access /proc/cmdline

### DIFF
--- a/tests/hostcfgd/conftest.py
+++ b/tests/hostcfgd/conftest.py
@@ -5,3 +5,18 @@ from unittest import mock
 @pytest.fixture(autouse=True, scope='session')
 def mock_get_device_runtime_metadata():
     device_info.get_device_runtime_metadata = mock.MagicMock(return_value={})
+
+@pytest.fixture(autouse=True, scope='session')
+def mock_open_proc_cmdline():
+    """Automatically mock opening /proc/cmdline for all tests."""
+    EMPTY_LINE = "\n"
+    original_open = open
+
+    def mock_open_side_effect(filename, *args, **kwargs):
+        if filename == "/proc/cmdline":
+            return mock.mock_open(read_data=EMPTY_LINE)()
+        else:
+            return original_open(filename, *args, **kwargs)
+
+    with mock.patch("builtins.open", side_effect=mock_open_side_effect):
+        yield


### PR DESCRIPTION
Some hostcfgd tests override contents of /proc/cmdline using various methods. In the remaining cases, actual /proc/cmdline from the host running the tests is opened and processed.

For example, if `crashkernel=` is present on the test machine, a number of tests will try accessing config db table `KDUMP` and fail.

To avoid influencing test results by the test environment, a new fixture is added to ensure reading /proc/cmdline returns an empty line by default.