### PR TITLE
[Smartswitch] Fix the values being set for reboot_status call during smartswitch DPU reboot

### DIFF
--- a/host_modules/reboot.py
+++ b/host_modules/reboot.py
@@ -61,10 +61,7 @@ class Reboot(host_service.HostModule):
         self.reboot_status_flag["reason"] = reason
         self.reboot_status_flag["count"] = self.reboot_count
         self.reboot_status_flag["method"] = method
-        if isinstance(status, RebootStatus):
-            self.reboot_status_flag["status"] = status.name
-        else:
-            self.reboot_status_flag["status"] = status
+        self.reboot_status_flag["status"] = status.value
         self.lock.release()
         return
 

--- a/host_modules/reboot.py
+++ b/host_modules/reboot.py
@@ -53,7 +53,7 @@ class Reboot(host_service.HostModule):
         self.populate_reboot_status_flag()
         super(Reboot, self).__init__(mod_name)
 
-    def populate_reboot_status_flag(self, active = False, when = 0, reason = "", method = "", status = RebootStatus.STATUS_UNKNOWN):
+    def populate_reboot_status_flag(self, active = False, when = 0, reason = "", method = "", status = RebootStatus.STATUS_UNKNOWN.value):
         """Populates the reboot_status_flag with given input params"""
         self.lock.acquire()
         self.reboot_status_flag["active"] = active
@@ -125,7 +125,7 @@ class Reboot(host_service.HostModule):
 
         rc, stdout, stderr = _run_command(command)
         if rc:
-            self.populate_reboot_status_flag(False, int (time.time()), "Failed to execute reboot command", reboot_method, RebootStatus.STATUS_FAILURE)
+            self.populate_reboot_status_flag(False, int (time.time()), "Failed to execute reboot command", reboot_method, RebootStatus.STATUS_FAILURE.value)
             logger.error("%s: Reboot failed execution with stdout: %s, "
                          "stderr: %s", MOD_NAME, stdout, stderr)
             return
@@ -146,23 +146,23 @@ class Reboot(host_service.HostModule):
             while time.monotonic() - start_time < timeout:
                 if not self.is_halt_command_running() and not self.is_container_running("pmon"):
                     logger.info("%s: Halting the services is completed on the device", MOD_NAME)
-                    self.populate_reboot_status_flag(False, 0, "Halt reboot completed", reboot_method, RebootStatus.STATUS_SUCCESS)
+                    self.populate_reboot_status_flag(False, 0, "Halt reboot completed", reboot_method, RebootStatus.STATUS_SUCCESS.value)
                     return
                 time.sleep(5)
 
             # Check if PMON container is still running after timeout
             if self.is_halt_command_running() or self.is_container_running("pmon"):
                 #Halt reboot has failed, as pmon is still running.
-                self.populate_reboot_status_flag(False, int(time.time()), "Halt reboot did not complete", reboot_method, RebootStatus.STATUS_FAILURE)
+                self.populate_reboot_status_flag(False, int(time.time()), "Halt reboot did not complete", reboot_method, RebootStatus.STATUS_FAILURE.value)
                 logger.error("%s: HALT reboot failed: Services are still running", MOD_NAME)
             else:
-                self.populate_reboot_status_flag(False, 0, "Halt reboot completed", reboot_method, RebootStatus.STATUS_SUCCESS)
+                self.populate_reboot_status_flag(False, 0, "Halt reboot completed", reboot_method, RebootStatus.STATUS_SUCCESS.value)
                 logger.info("%s: Halting the services is completed on the device", MOD_NAME)
             return
         else:
             time.sleep(REBOOT_TIMEOUT)
             # Conclude that the reboot has failed if we reach this point
-            self.populate_reboot_status_flag(False, int(time.time()), "Reboot command failed to execute", reboot_method, RebootStatus.STATUS_FAILURE)
+            self.populate_reboot_status_flag(False, int(time.time()), "Reboot command failed to execute", reboot_method, RebootStatus.STATUS_FAILURE.value)
             return
 
     @host_service.method(host_service.bus_name(MOD_NAME), in_signature='as', out_signature='is')
@@ -201,7 +201,7 @@ class Reboot(host_service.HostModule):
             return err, errstr
 
         # Sets reboot_status_flag to be in active state
-        self.populate_reboot_status_flag(True, int(time.time()), reboot_request.get("message", ""), reboot_request["method"], RebootStatus.STATUS_UNKNOWN)
+        self.populate_reboot_status_flag(True, int(time.time()), reboot_request.get("message", ""), reboot_request["method"], RebootStatus.STATUS_UNKNOWN.value)
 
         # Issue reboot in a new thread and reset the reboot_status_flag if the reboot fails
         try:

--- a/host_modules/reboot.py
+++ b/host_modules/reboot.py
@@ -53,7 +53,7 @@ class Reboot(host_service.HostModule):
         self.populate_reboot_status_flag()
         super(Reboot, self).__init__(mod_name)
 
-    def populate_reboot_status_flag(self, active = False, when = 0, reason = "", method = "", status = RebootStatus.STATUS_UNKNOWN.value):
+    def populate_reboot_status_flag(self, active = False, when = 0, reason = "", method = "", status = RebootStatus.STATUS_UNKNOWN):
         """Populates the reboot_status_flag with given input params"""
         self.lock.acquire()
         self.reboot_status_flag["active"] = active
@@ -61,7 +61,10 @@ class Reboot(host_service.HostModule):
         self.reboot_status_flag["reason"] = reason
         self.reboot_status_flag["count"] = self.reboot_count
         self.reboot_status_flag["method"] = method
-        self.reboot_status_flag["status"] = status
+        if isinstance(status, RebootStatus):
+            self.reboot_status_flag["status"] = status.name
+        else:
+            self.reboot_status_flag["status"] = status
         self.lock.release()
         return
 
@@ -125,7 +128,7 @@ class Reboot(host_service.HostModule):
 
         rc, stdout, stderr = _run_command(command)
         if rc:
-            self.populate_reboot_status_flag(False, int (time.time()), "Failed to execute reboot command", reboot_method, RebootStatus.STATUS_FAILURE.value)
+            self.populate_reboot_status_flag(False, int (time.time()), "Failed to execute reboot command", reboot_method, RebootStatus.STATUS_FAILURE)
             logger.error("%s: Reboot failed execution with stdout: %s, "
                          "stderr: %s", MOD_NAME, stdout, stderr)
             return
@@ -146,23 +149,23 @@ class Reboot(host_service.HostModule):
             while time.monotonic() - start_time < timeout:
                 if not self.is_halt_command_running() and not self.is_container_running("pmon"):
                     logger.info("%s: Halting the services is completed on the device", MOD_NAME)
-                    self.populate_reboot_status_flag(False, 0, "Halt reboot completed", reboot_method, RebootStatus.STATUS_SUCCESS.value)
+                    self.populate_reboot_status_flag(False, 0, "Halt reboot completed", reboot_method, RebootStatus.STATUS_SUCCESS)
                     return
                 time.sleep(5)
 
             # Check if PMON container is still running after timeout
             if self.is_halt_command_running() or self.is_container_running("pmon"):
                 #Halt reboot has failed, as pmon is still running.
-                self.populate_reboot_status_flag(False, int(time.time()), "Halt reboot did not complete", reboot_method, RebootStatus.STATUS_FAILURE.value)
+                self.populate_reboot_status_flag(False, int(time.time()), "Halt reboot did not complete", reboot_method, RebootStatus.STATUS_FAILURE)
                 logger.error("%s: HALT reboot failed: Services are still running", MOD_NAME)
             else:
-                self.populate_reboot_status_flag(False, 0, "Halt reboot completed", reboot_method, RebootStatus.STATUS_SUCCESS.value)
+                self.populate_reboot_status_flag(False, 0, "Halt reboot completed", reboot_method, RebootStatus.STATUS_SUCCESS)
                 logger.info("%s: Halting the services is completed on the device", MOD_NAME)
             return
         else:
             time.sleep(REBOOT_TIMEOUT)
             # Conclude that the reboot has failed if we reach this point
-            self.populate_reboot_status_flag(False, int(time.time()), "Reboot command failed to execute", reboot_method, RebootStatus.STATUS_FAILURE.value)
+            self.populate_reboot_status_flag(False, int(time.time()), "Reboot command failed to execute", reboot_method, RebootStatus.STATUS_FAILURE)
             return
 
     @host_service.method(host_service.bus_name(MOD_NAME), in_signature='as', out_signature='is')
@@ -201,7 +204,7 @@ class Reboot(host_service.HostModule):
             return err, errstr
 
         # Sets reboot_status_flag to be in active state
-        self.populate_reboot_status_flag(True, int(time.time()), reboot_request.get("message", ""), reboot_request["method"], RebootStatus.STATUS_UNKNOWN.value)
+        self.populate_reboot_status_flag(True, int(time.time()), reboot_request.get("message", ""), reboot_request["method"], RebootStatus.STATUS_UNKNOWN)
 
         # Issue reboot in a new thread and reset the reboot_status_flag if the reboot fails
         try:

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -59,7 +59,7 @@ class TestReboot(object):
             assert self.reboot_module.reboot_status_flag["reason"] == ""
             assert self.reboot_module.reboot_status_flag["count"] == 0
             assert self.reboot_module.reboot_status_flag["method"] == ""
-            assert self.reboot_module.reboot_status_flag["status"] == RebootStatus.STATUS_UNKNOWN
+            assert self.reboot_module.reboot_status_flag["status"] == RebootStatus.STATUS_UNKNOWN.value
 
     def test_validate_reboot_request_success_cold_boot_enum_method(self):
         reboot_request = {"method": REBOOT_METHOD_COLD_BOOT_ENUM, "reason": "test reboot request reason"}
@@ -182,7 +182,7 @@ class TestReboot(object):
             self.reboot_module.execute_reboot("WARM")
             mock_run_command.assert_called_once_with("sudo warm-reboot")
             mock_sleep.assert_called_once_with(260)
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int(time.time()), "Reboot command failed to execute", 'WARM', RebootStatus.STATUS_FAILURE)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int(time.time()), "Reboot command failed to execute", 'WARM', RebootStatus.STATUS_FAILURE.value)
 
     def test_execute_reboot_fail_unknown_reboot(self, caplog):
         with caplog.at_level(logging.ERROR):
@@ -202,7 +202,7 @@ class TestReboot(object):
                     "stdout: ['stdout: execute cold reboot'], stderr: "
                     "['stderror: execute cold reboot']")
             assert caplog.records[0].message == msg
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 1, RebootStatus.STATUS_FAILURE)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 1, RebootStatus.STATUS_FAILURE.value)
 
     def test_execute_reboot_fail_issue_reboot_command_halt(self, caplog):
         with (
@@ -216,7 +216,7 @@ class TestReboot(object):
                    "stdout: ['stdout: execute halt reboot'], stderr: "
                    "['stderror: execute halt reboot']")
             assert caplog.records[0].message == msg
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 3, RebootStatus.STATUS_FAILURE)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 3, RebootStatus.STATUS_FAILURE.value)
 
     def test_execute_reboot_success_halt(self):
         with (
@@ -231,7 +231,7 @@ class TestReboot(object):
             mock_run_command.assert_called_once_with("sudo reboot -p")
             mock_is_halt_command_running.assert_called()
             mock_is_container_running.assert_called_with("pmon")
-            mock_populate_reboot_status_flag.assert_called_once_with(False, 0, 'Halt reboot completed', 3, RebootStatus.STATUS_SUCCESS)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, 0, 'Halt reboot completed', 3, RebootStatus.STATUS_SUCCESS.value)
 
     def test_execute_reboot_fail_halt_timeout(self, caplog):
         with (
@@ -248,7 +248,7 @@ class TestReboot(object):
             mock_sleep.assert_called_with(5)
             mock_is_halt_command_running.assert_called()
             assert any("HALT reboot failed: Services are still running" in record.message for record in caplog.records)
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int(time.time()), 'Halt reboot did not complete', 3, RebootStatus.STATUS_FAILURE)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int(time.time()), 'Halt reboot did not complete', 3, RebootStatus.STATUS_FAILURE.value)
 
     def test_execute_reboot_fail_issue_reboot_command_warm(self, caplog):
         with (
@@ -262,7 +262,7 @@ class TestReboot(object):
                     "stdout: ['stdout: execute WARM reboot'], stderr: "
                     "['stderror: execute WARM reboot']")
             assert caplog.records[0].message == msg
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 'WARM', RebootStatus.STATUS_FAILURE)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 'WARM', RebootStatus.STATUS_FAILURE.value)
 
     def test_issue_reboot_success_cold_boot(self):
         with (

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -64,6 +64,14 @@ class TestReboot(object):
             assert get_reboot_status_flag_data["method"] == ""
             assert get_reboot_status_flag_data["status"] == RebootStatus.STATUS_UNKNOWN.name
 
+    def test_populate_reboot_status_flag_with_status(self):
+        with mock.patch("time.time", return_value=1617811205.25):
+            self.reboot_module.populate_reboot_status_flag(status=RebootStatus.STATUS_SUCCESS.name)
+            return_value, get_reboot_status_flag_data = self.reboot_module.get_reboot_status()
+            assert return_value == 0
+            get_reboot_status_flag_data = json.loads(get_reboot_status_flag_data)
+            assert get_reboot_status_flag_data["status"] == RebootStatus.STATUS_SUCCESS.name
+
     def test_validate_reboot_request_success_cold_boot_enum_method(self):
         reboot_request = {"method": REBOOT_METHOD_COLD_BOOT_ENUM, "reason": "test reboot request reason"}
         result = self.reboot_module.validate_reboot_request(reboot_request)

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -54,12 +54,15 @@ class TestReboot(object):
     def test_populate_reboot_status_flag(self):
         with mock.patch("time.time", return_value=1617811205.25):
             self.reboot_module.populate_reboot_status_flag()
-            assert self.reboot_module.reboot_status_flag["active"] == False
-            assert self.reboot_module.reboot_status_flag["when"] == 0
-            assert self.reboot_module.reboot_status_flag["reason"] == ""
-            assert self.reboot_module.reboot_status_flag["count"] == 0
-            assert self.reboot_module.reboot_status_flag["method"] == ""
-            assert self.reboot_module.reboot_status_flag["status"] == RebootStatus.STATUS_UNKNOWN.value
+            return_value, get_reboot_status_flag_data = self.reboot_module.get_reboot_status_flag()
+            assert return_value == 0
+            get_reboot_status_flag_data = json.loads(get_reboot_status_flag_data)
+            assert get_reboot_status_flag_data["active"] == False
+            assert get_reboot_status_flag_data["when"] == 0
+            assert get_reboot_status_flag_data["reason"] == ""
+            assert get_reboot_status_flag_data["count"] == 0
+            assert get_reboot_status_flag_data["method"] == ""
+            assert get_reboot_status_flag_data["status"] == RebootStatus.STATUS_UNKNOWN.name
 
     def test_validate_reboot_request_success_cold_boot_enum_method(self):
         reboot_request = {"method": REBOOT_METHOD_COLD_BOOT_ENUM, "reason": "test reboot request reason"}

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -182,7 +182,7 @@ class TestReboot(object):
             self.reboot_module.execute_reboot("WARM")
             mock_run_command.assert_called_once_with("sudo warm-reboot")
             mock_sleep.assert_called_once_with(260)
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int(time.time()), "Reboot command failed to execute", 'WARM', RebootStatus.STATUS_FAILURE.value)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int(time.time()), "Reboot command failed to execute", 'WARM', RebootStatus.STATUS_FAILURE)
 
     def test_execute_reboot_fail_unknown_reboot(self, caplog):
         with caplog.at_level(logging.ERROR):
@@ -202,7 +202,7 @@ class TestReboot(object):
                     "stdout: ['stdout: execute cold reboot'], stderr: "
                     "['stderror: execute cold reboot']")
             assert caplog.records[0].message == msg
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 1, RebootStatus.STATUS_FAILURE.value)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 1, RebootStatus.STATUS_FAILURE)
 
     def test_execute_reboot_fail_issue_reboot_command_halt(self, caplog):
         with (
@@ -216,7 +216,7 @@ class TestReboot(object):
                    "stdout: ['stdout: execute halt reboot'], stderr: "
                    "['stderror: execute halt reboot']")
             assert caplog.records[0].message == msg
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 3, RebootStatus.STATUS_FAILURE.value)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 3, RebootStatus.STATUS_FAILURE)
 
     def test_execute_reboot_success_halt(self):
         with (
@@ -231,7 +231,7 @@ class TestReboot(object):
             mock_run_command.assert_called_once_with("sudo reboot -p")
             mock_is_halt_command_running.assert_called()
             mock_is_container_running.assert_called_with("pmon")
-            mock_populate_reboot_status_flag.assert_called_once_with(False, 0, 'Halt reboot completed', 3, RebootStatus.STATUS_SUCCESS.value)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, 0, 'Halt reboot completed', 3, RebootStatus.STATUS_SUCCESS)
 
     def test_execute_reboot_fail_halt_timeout(self, caplog):
         with (
@@ -248,7 +248,7 @@ class TestReboot(object):
             mock_sleep.assert_called_with(5)
             mock_is_halt_command_running.assert_called()
             assert any("HALT reboot failed: Services are still running" in record.message for record in caplog.records)
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int(time.time()), 'Halt reboot did not complete', 3, RebootStatus.STATUS_FAILURE.value)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int(time.time()), 'Halt reboot did not complete', 3, RebootStatus.STATUS_FAILURE)
 
     def test_execute_reboot_fail_issue_reboot_command_warm(self, caplog):
         with (
@@ -262,7 +262,7 @@ class TestReboot(object):
                     "stdout: ['stdout: execute WARM reboot'], stderr: "
                     "['stderror: execute WARM reboot']")
             assert caplog.records[0].message == msg
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 'WARM', RebootStatus.STATUS_FAILURE.value)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 'WARM', RebootStatus.STATUS_FAILURE)
 
     def test_issue_reboot_success_cold_boot(self):
         with (
@@ -361,7 +361,7 @@ class TestReboot(object):
 
     def test_get_reboot_status_active(self):
         MSG="testing reboot response"
-        self.reboot_module.populate_reboot_status_flag(True, TIME, MSG, REBOOT_METHOD_COLD_BOOT_ENUM, RebootStatus.STATUS_SUCCESS.name)
+        self.reboot_module.populate_reboot_status_flag(True, TIME, MSG, REBOOT_METHOD_COLD_BOOT_ENUM, RebootStatus.STATUS_SUCCESS)
         result = self.reboot_module.get_reboot_status()
         assert result[0] == 0
         response_data = json.loads(result[1])
@@ -372,7 +372,7 @@ class TestReboot(object):
         assert response_data["status"] == RebootStatus.STATUS_SUCCESS.name
 
     def test_get_reboot_status_inactive(self):
-        self.reboot_module.populate_reboot_status_flag(False, 0, "", REBOOT_METHOD_COLD_BOOT_ENUM, RebootStatus.STATUS_SUCCESS.name)
+        self.reboot_module.populate_reboot_status_flag(False, 0, "", REBOOT_METHOD_COLD_BOOT_ENUM, RebootStatus.STATUS_SUCCESS)
         result = self.reboot_module.get_reboot_status()
         assert result[0] == 0
         response_data = json.loads(result[1])

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -54,7 +54,7 @@ class TestReboot(object):
     def test_populate_reboot_status_flag(self):
         with mock.patch("time.time", return_value=1617811205.25):
             self.reboot_module.populate_reboot_status_flag()
-            return_value, get_reboot_status_flag_data = self.reboot_module.get_reboot_status_flag()
+            return_value, get_reboot_status_flag_data = self.reboot_module.get_reboot_status()
             assert return_value == 0
             get_reboot_status_flag_data = json.loads(get_reboot_status_flag_data)
             assert get_reboot_status_flag_data["active"] == False

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -62,15 +62,15 @@ class TestReboot(object):
             assert get_reboot_status_flag_data["reason"] == ""
             assert get_reboot_status_flag_data["count"] == 0
             assert get_reboot_status_flag_data["method"] == ""
-            assert get_reboot_status_flag_data["status"] == RebootStatus.STATUS_UNKNOWN.name
+            assert get_reboot_status_flag_data["status"] == RebootStatus.STATUS_UNKNOWN.value
 
     def test_populate_reboot_status_flag_with_status(self):
         with mock.patch("time.time", return_value=1617811205.25):
-            self.reboot_module.populate_reboot_status_flag(status=RebootStatus.STATUS_SUCCESS.name)
+            self.reboot_module.populate_reboot_status_flag(status=RebootStatus.STATUS_SUCCESS)
             return_value, get_reboot_status_flag_data = self.reboot_module.get_reboot_status()
             assert return_value == 0
             get_reboot_status_flag_data = json.loads(get_reboot_status_flag_data)
-            assert get_reboot_status_flag_data["status"] == RebootStatus.STATUS_SUCCESS.name
+            assert get_reboot_status_flag_data["status"] == RebootStatus.STATUS_SUCCESS.value
 
     def test_validate_reboot_request_success_cold_boot_enum_method(self):
         reboot_request = {"method": REBOOT_METHOD_COLD_BOOT_ENUM, "reason": "test reboot request reason"}
@@ -380,7 +380,7 @@ class TestReboot(object):
         assert response_data["when"] == TIME
         assert response_data["reason"] == MSG
         assert response_data["method"] == REBOOT_METHOD_COLD_BOOT_ENUM
-        assert response_data["status"] == RebootStatus.STATUS_SUCCESS.name
+        assert response_data["status"] == RebootStatus.STATUS_SUCCESS.value
 
     def test_get_reboot_status_inactive(self):
         self.reboot_module.populate_reboot_status_flag(False, 0, "", REBOOT_METHOD_COLD_BOOT_ENUM, RebootStatus.STATUS_SUCCESS)
@@ -391,7 +391,7 @@ class TestReboot(object):
         assert response_data["when"] == 0
         assert response_data["reason"] == ""
         assert response_data["method"] == REBOOT_METHOD_COLD_BOOT_ENUM
-        assert response_data["status"] == RebootStatus.STATUS_SUCCESS.name
+        assert response_data["status"] == RebootStatus.STATUS_SUCCESS.value
 
 #        assert result[1] == TEST_INACTIVE_RESPONSE_DATA
 


### PR DESCRIPTION
During smartswitch DPU reboot we query the rebootstatus call to check the current status. This is currently failing on DPU because the RebootStatus enum is not serializable:
```
root@sonic:/home/admin# dbus-send --system --print-reply --dest=org.SONiC.HostService.reboot /org/SONiC/HostService/reboot org.SONiC.HostService.reboot.get_reboot_status
Error org.freedesktop.DBus.Python.TypeError: Traceback (most recent call last):
 File "/usr/lib/python3/dist-packages/dbus/service.py", line 712, in _message_cb
   retval = candidate_method(self, *args, **keywords)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/usr/local/lib/python3.11/dist-packages/host_modules/reboot.py", line 218, in get_reboot_status=
   response_data = json.dumps(self.reboot_status_flag)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/usr/lib/python3.11/json/__init__.py", line 231, in dumps
   return _default_encoder.encode(obj
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/usr/lib/python3.11/json/encoder.py", line 200, in encode
   chunks = self.iterencode(o, _one_shot=True)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/usr/lib/python3.11/json/encoder.py", line 258, in iterencode
   return _iterencode(o, 0)
          ^^^^^^^^^^^^^^^^^
 File "/usr/lib/python3.11/json/encoder.py", line 180, in default
   raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type RebootStatus is not JSON serializable
```
So setting it to value everywhere to fix the issue