### PR TITLE
gNOI: Add backend support for Healthz

### DIFF
--- a/host_modules/debug_info.py
+++ b/host_modules/debug_info.py
@@ -1,0 +1,402 @@
+"""Debug Artifact Collector.
+
+This host service module implements the backend support for 
+collecting host debug artifacts. Depending on the log level 
+and board type input, the relevant log files, DB snapshots, 
+counters, record files, and various command outputs are collected 
+and aggregated under a specified artifact directory and the directory is 
+compressed to a *.tar.gz in the host.
+
+As part of the SONiC Debug artifact collection,below are the list of files.
+core, log, db, counter files, routing.txt and version.txt
+"""
+
+from datetime import datetime
+import json
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+
+from host_modules import host_service
+from utils.sonic_db_utils import SonicDbUtils
+from swsscommon import swsscommon
+
+MOD_NAME = "debug_info"
+ARTIFACT_DIR = "/tmp/dump"
+NONVOLATILE_PARTITION = "/var/log/"
+NONVOLATILE_ARTIFACT_DIR = "/var/log/dump"
+NONVOLATILE_STORAGE_REQUIRED = 5 * 10**8
+NONVOLATILE_TMP_FLAG = "/tmp/nonvolatile_saved"
+ARTIFACT_DIR_HOST = "host"
+DB_ARTIFACT_DIR = ARTIFACT_DIR_HOST + "/db"
+CORE_DIR = "core"
+ARTIFACT_LEVEL_ALERT = "alert"
+ARTIFACT_LEVEL_CRITICAL = "critical"
+ARTIFACT_LEVEL_ALL = "all"
+LOG_LEVEL_KEY = "level"
+PERSISTENT_STORAGE_KEY = "use_persistent_storage"
+
+
+DEBUG_INFO_FLAG = "debug_info"
+
+logger = logging.getLogger(__name__)
+
+class DebugArtifactCollector(host_service.HostModule):
+  """DBus endpoint that collects debug artifacts."""
+
+  def __init__(self, mod_name):
+    self._hostname, self._board_type = DebugArtifactCollector.get_device_metadata()
+    super(DebugArtifactCollector, self).__init__(mod_name)
+
+  @staticmethod
+  def _run_command(cmd: str, timeout: int = 20):
+    """
+    Modified to handle shell redirection logic in Python
+    to avoid shell=True security risks.
+    """
+    # Check if the command has redirection (e.g., 'command > file')
+    if " > " in cmd or " >> " in cmd:
+      append = " >> " in cmd
+      parts = cmd.split(" >> " if append else " > ")
+      actual_cmd = shlex.split(parts[0])
+      out_file = parts[1].strip()
+
+      mode = "a" if append else "w"
+      try:
+        with open(out_file, mode) as f:
+          proc = subprocess.Popen(
+            actual_cmd,
+            stdout=f, # Redirect stdout to file directly
+            stderr=subprocess.PIPE,
+            shell=False, # Semgrep safe
+            text=True,
+            close_fds=True)
+        stdout, stderr = proc.communicate(timeout=timeout)
+        return proc.returncode, "", stderr
+      except Exception as e:
+        return 1, "", str(e)
+
+    # Standard command without redirection
+    proc = subprocess.Popen(
+        shlex.split(cmd),
+        shell=False, # Semgrep safe
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=True)
+    try:
+      stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+      proc.kill()
+      return 1, "command timeout", "command timeout"
+    return proc.returncode, stdout, stderr
+
+  @staticmethod
+  def get_device_metadata() -> str:
+    """
+    Get hostname and board_type from CONFIG_DB
+    using a single swsscommon call.
+    """
+    hostname = "switch"
+    board_type = ""
+    try:
+      # Connect to CONFIG_DB
+      db = swsscommon.SonicV2Connector()
+      db.connect(db.CONFIG_DB)
+      # Get device metadata
+      metadata = db.get_all(db.CONFIG_DB, 'DEVICE_METADATA|localhost')
+      db.close()
+      if not metadata:
+        logger.warning("DEVICE_METADATA|localhost empty or missing")
+        return hostname, board_type
+      hostname = metadata.get('hostname', hostname)
+      board_type = metadata.get('platform', board_type)
+    except Exception as e:
+      logger.warning(f"Failed to read hostname/board_type from CONFIG_DB: {e}")
+    return hostname, board_type
+  
+  @staticmethod
+  def _collect_counter_artifacts(directory: str, prefix: str,
+                                 board_type: str) -> None:
+    COUNTER_CMDS = [
+        "top -b -n 1 -w 500 > {}/top.txt",
+        ('docker exec -i database '
+        'redis-dump -H 127.0.0.1 -p 6379 -d 2 -y > {}/counter_db.json'),
+    ]
+    counter_artifact_dir = os.path.join(
+        directory,
+        datetime.now().strftime(prefix + "counter_%Y%m%d_%H%M%S"))
+    os.makedirs(counter_artifact_dir, exist_ok=True)
+
+    for cmd in COUNTER_CMDS:
+      rc, _, err = DebugArtifactCollector._run_command(cmd.format(counter_artifact_dir), timeout=60)
+      if rc != 0:
+        # Continue the artifact collection in case of error.
+        logger.warning(f"fail to execute command {cmd}, error:{err}")
+
+  @staticmethod
+  def _collect_teamdctl_data(artifact_dir_host):
+    TEAMD_CTL_CMD = 'docker exec -i teamd teamdctl {} state dump'
+    try:
+      portchannels = SonicDbUtils.get_portchannels()
+      if not portchannels:
+        logger.warning("teamdctl: No PortChannels found, skipping teamdctl collection")
+        return
+      for trk in portchannels:
+        teamdctl_cmd = shlex.split(TEAMD_CTL_CMD.format(trk))
+        teamdctl_result = subprocess.run(
+            teamdctl_cmd, shell=False, capture_output=True, text=True)
+        if teamdctl_result.returncode == 0:
+          filepath = os.path.join(artifact_dir_host, f'teamdctl_{trk}.txt')
+          try:
+            with open(filepath, 'w') as f:
+              f.write(teamdctl_result.stdout)
+              # If the filepath is invalid, then just return silently. If the
+              # filepath is valid, the file will be created.
+          except FileNotFoundError:
+            logger.warning(
+                f"teamdctl: Could not write file {filepath},invalid path. Skipping write."
+              )
+        else:
+          logger.warning(
+              f"Error running teamdctl for {trk}: {teamdctl_result.stderr}")
+    except Exception as e:
+      logger.warning(f"Failed to collect Portchannel data: {e}")
+
+  @staticmethod
+  def _save_persistent_storage(artifact_name: str) -> None:
+    if os.path.isfile(NONVOLATILE_TMP_FLAG):
+      logger.warning(
+          f"already exists, skipping saving artifacts to "
+          f"persistent storage {NONVOLATILE_TMP_FLAG}")
+      return
+    try:
+      with open(NONVOLATILE_TMP_FLAG, "w+"):
+        pass
+    except OSError as e:
+      logger.warning(f"error creating flag in tmp: {NONVOLATILE_TMP_FLAG}, Error: {e}")
+      return
+
+    host_artifact_name = ARTIFACT_DIR + "/" + artifact_name
+    shutil.rmtree(NONVOLATILE_ARTIFACT_DIR, ignore_errors=True)
+    try:
+      artifact_size = os.path.getsize(host_artifact_name)
+    except OSError:
+      logger.warning(f"path {host_artifact_name} did not exist")
+      return
+
+    _, _, free = shutil.disk_usage(NONVOLATILE_PARTITION)
+    if free < NONVOLATILE_STORAGE_REQUIRED + artifact_size:
+      logger.warning(
+          f"free space remaining on {NONVOLATILE_PARTITION}, "
+          f"is less than {NONVOLATILE_STORAGE_REQUIRED + artifact_size}:{free}. "
+          f"Not saving artifacts to persistent storage")
+      return
+    
+    os.makedirs(NONVOLATILE_ARTIFACT_DIR, exist_ok=True)
+
+    try:
+      shutil.copy(host_artifact_name, os.path.join(NONVOLATILE_ARTIFACT_DIR, artifact_name))
+    except Exception as e:
+      logger.warning(f"fail to copy artifact to persistent storage: {e}")
+ 
+  @staticmethod
+  def _collect_host_files(artifact_dir_host):
+    """
+    Copy common host files/dirs into the artifact dir using Python APIs.
+    This replaces shell 'cp -r' usage.
+    """
+    # 1) /var/log -> <artifact_dir_host>/var_log
+    try:
+      src = "/var/log"
+      dst = os.path.join(artifact_dir_host, "var_log")
+      if os.path.isdir(src):
+        # copytree errors if dst exists; use copytree into a subdir name that doesn't exist yet
+        if os.path.exists(dst):
+          shutil.rmtree(dst, ignore_errors=True)
+        shutil.copytree(src, dst, dirs_exist_ok=True, ignore_dangling_symlinks=True)
+      else:
+        logger.warning(f"_collect_host_files: {src} does not exist, skipping")
+    except Exception as e:
+      logger.warning(f"_collect_host_files: failed to copy /var/log: {e}")
+ 
+    # 2) /var/core -> <artifact_dir_host>/core (if exists)
+    try:
+      src = "/var/core"
+      dst = os.path.join(artifact_dir_host, "core")
+      if os.path.isdir(src):
+        if os.path.exists(dst):
+          shutil.rmtree(dst, ignore_errors=True)
+        shutil.copytree(src, dst)
+      else:
+        logger.warning(f"_collect_host_files: {src} does not exist, skipping")
+    except Exception as e:
+      logger.warning(f"_collect_host_files: failed to copy /var/core: {e}")
+ 
+  @staticmethod
+  def collect_artifacts(req: str, timestamp: str, board_type: str,
+                        hostname: str):
+    """Collect all artifacts for a given board type.
+
+    Currently only host-level and DB artifacts are collected.
+    Component-level (e.g., gnmi/orch) artifact collection is not supported
+
+    This method can also be called by the CLI.
+
+    Args:
+      req: = string, a single JSON string that contains the log level, 
+        and optional with persistent_storage flag to indicate if the artifacts should
+        be stored in persistent storage, in addition to volatile storage
+      timestamp: = string, a timestamp string that is used in the artifact name.
+      board_type: = string, a string representation of the board type.
+      hostname: = string, the hostname of the device, used to name the output
+        directory.
+
+    Returns:
+      string: a return code and a return string to indicate the output artifact
+      in the host.
+    """
+    COMMON_CMDS = [
+        "show version > {}/version.txt",
+        "ip -6 route > {}/routing.txt",
+        "ip neigh >> {}/routing.txt",
+        "ip route >> {}/routing.txt",
+        "netstat -tplnaW | grep telemetry >> {}/routing.txt",
+        "ip link >> {}/routing.txt",
+    ]
+    DB_CMDS = [
+        ('docker exec -i database '
+        'redis-dump -H 127.0.0.1 -p 6379 -d 0 -y > {}/appl_db.json'),
+        ('docker exec -i database '
+        'redis-dump -H 127.0.0.1 -p 6379 -d 1 -y > {}/asic_db.json'),
+        ('docker exec -i database '
+        'redis-dump -H 127.0.0.1 -p 6379 -d 4 -y > {}/config_db.json'),
+        ('docker exec -i database '
+        'redis-cli -n 1 hgetall VIDTORID > {}/vidtorid.txt'),
+    ]
+    try:
+      request = json.loads(req)
+    except json.JSONDecodeError:
+      return 1, "invalid input: " + req
+    log_level = request.get(LOG_LEVEL_KEY, ARTIFACT_LEVEL_ALERT)
+    use_persistent_storage = request.get(
+        PERSISTENT_STORAGE_KEY) if PERSISTENT_STORAGE_KEY in request else False
+    
+    dir_name = hostname + "_" + timestamp
+    artifact_dir_host = os.path.join(ARTIFACT_DIR, dir_name, ARTIFACT_DIR_HOST)
+    db_artifact_dir = os.path.join(ARTIFACT_DIR, dir_name, DB_ARTIFACT_DIR)
+
+    # Prepare directories
+    try:
+      os.makedirs(artifact_dir_host, exist_ok=True)
+    except Exception as e:
+      logger.warning(f"collect_artifacts: failed to create artifact directory {artifact_dir_host}: {e}")
+      return 1, str(e)
+    
+    # Collect counter artifacts at the beginning of the collection.
+    if log_level == ARTIFACT_LEVEL_CRITICAL or log_level == ARTIFACT_LEVEL_ALL:
+      DebugArtifactCollector._collect_counter_artifacts(artifact_dir_host, "pre_",
+                                           board_type)
+
+    # Collect host files (replaces cp -r /var/log etc.)
+    DebugArtifactCollector._collect_host_files(artifact_dir_host)
+ 
+    # Collect routing/network text info and append outputs to routing.txt
+    for cmd in COMMON_CMDS:
+      rc, _, err = DebugArtifactCollector._run_command(cmd.format(artifact_dir_host))
+      if rc != 0:
+        # Continue the artifact collection in case of error.
+        logger.warning(f"fail to execute command {cmd}, error:{err}")
+
+    # Ensure core dir exists
+    try:
+      os.makedirs(os.path.join(artifact_dir_host, CORE_DIR), exist_ok=True)
+    except Exception as e:
+      logger.warning(f"collect_artifacts: failed to create core dir: {e}")
+
+    DebugArtifactCollector._collect_teamdctl_data(artifact_dir_host)
+
+    # DB commands collection (if requested by log_level)
+    if log_level == ARTIFACT_LEVEL_CRITICAL or log_level == ARTIFACT_LEVEL_ALL:
+      os.makedirs(db_artifact_dir, exist_ok=True)
+      for cmd in DB_CMDS:
+        rc, _, err = DebugArtifactCollector._run_command(cmd.format(db_artifact_dir), timeout=60)
+        if rc != 0:
+          # Continue the artifact collection in case of error.
+          logger.warning(f"fail to execute command {cmd}, error:{err}")
+
+    # Collect counter artifacts at the end of the collection.
+    if log_level == ARTIFACT_LEVEL_CRITICAL or log_level == ARTIFACT_LEVEL_ALL:
+      DebugArtifactCollector._collect_counter_artifacts(artifact_dir_host, "post_",
+                                           board_type)
+
+    artifact_name = dir_name + ".tar.gz"
+    host_artifact_name = ARTIFACT_DIR + "/" + artifact_name
+
+    cmd = ("tar -C " + ARTIFACT_DIR + " -zcvf " + host_artifact_name + " " +
+           dir_name)
+
+    rc, _, err = DebugArtifactCollector._run_command(cmd, timeout=60)
+    shutil.rmtree(os.path.join(ARTIFACT_DIR, dir_name), ignore_errors=True)
+    if rc != 0:
+      return rc, "fail to execute command '" + cmd + "': " + err
+
+    if use_persistent_storage:
+      DebugArtifactCollector._save_persistent_storage(artifact_name)
+    
+    return 0, host_artifact_name
+
+  @host_service.method(
+      host_service.bus_name(MOD_NAME), in_signature="as", out_signature="is")
+  def collect(self, options):
+    """DBus entrypoint to collect debug artifacts from host"""
+    # Converts single string input into a one-element list.
+    if isinstance(options, str):
+        options = [options]
+    try:
+      json.loads(options[0])
+    except json.JSONDecodeError:
+      return 1, "invalid input: " + options[0]
+
+    if not self._board_type or self._hostname == "switch":
+      self._hostname, self._board_type = DebugArtifactCollector.get_device_metadata()
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S%f")
+    try:
+      rc, artifact_path = self.collect_artifacts(options[0], timestamp, self._board_type, self._hostname)
+    except Exception as error:
+      return 1, "Artifact collection failed: " + str(
+          error)
+    if rc != 0:
+      return rc, artifact_path
+    return 0, artifact_path
+
+  @host_service.method(
+      host_service.bus_name(MOD_NAME), in_signature="as", out_signature="is")
+  def check(self, options):
+    """Always ready because artifact collection is synchronous."""
+    return 0, "Artifact ready"
+
+  @host_service.method(
+      host_service.bus_name(MOD_NAME), in_signature="as", out_signature="is")
+  def ack(self, options):
+    # The artifact name in container has a different prefix. Convert it to the
+    # host.
+    if isinstance(options, str):
+        options = [options]
+    artifact = ARTIFACT_DIR + options[0].removeprefix(ARTIFACT_DIR)
+    try:
+      os.remove(artifact)
+    except FileNotFoundError:
+      return 1, "Artifact file not found: " + str(artifact)
+    except PermissionError:
+      return 1, "Artifact file permission denied: " + str(artifact)
+    except OSError as error:
+      return 1, "Failed to delete artifact file with error: " + str(error)
+    return 0, ""
+
+def register():
+  """Return class name."""
+  return DebugArtifactCollector, MOD_NAME

--- a/scripts/sonic-host-server
+++ b/scripts/sonic-host-server
@@ -13,19 +13,19 @@ import dbus.mainloop.glib
 
 from gi.repository import GObject
 from host_modules import (
-    config_engine,
-    gcu,
-    host_service,
-    showtech,
-    systemd_service,
-    file_service,
-    image_service,
-    docker_service,
-    reboot,
-    debug_service,
-    gnoi_reset
+    config_engine, 
+    debug_info, 
+    debug_service, 
+    docker_service, 
+    file_service, 
+    gcu, 
+    gnoi_reset, 
+    host_service, 
+    image_service, 
+    reboot, 
+    showtech, 
+    systemd_service
 )
-
 
 def register_dbus():
     """Register DBus handlers for individual modules"""
@@ -40,6 +40,7 @@ def register_dbus():
         'docker_service': docker_service.DockerService('docker_service'),
         'file_stat': file_service.FileService('file'),
         'debug_service': debug_service.DebugExecutor('DebugExecutor'),
+        'debug_info': debug_info.DebugArtifactCollector('debug_info'),
         'gnoi_reset': gnoi_reset.GnoiReset('gnoi_reset')
         }
     for mod_name, handler_class in mod_dict.items():

--- a/tests/debug_info_test.py
+++ b/tests/debug_info_test.py
@@ -1,0 +1,234 @@
+"""Tests for debug_info."""
+
+import importlib.util
+import importlib.machinery
+import os
+import sys
+import tempfile
+
+if sys.version_info >= (3, 3):
+    from unittest import mock
+else:
+    import mock
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+sonic_host_service_path = os.path.dirname(test_path)
+host_modules_path = os.path.join(sonic_host_service_path, "host_modules")
+sys.path.insert(0, sonic_host_service_path)
+
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
+
+load_source("host_service", host_modules_path + "/host_service.py")
+load_source("debug_info", host_modules_path + "/debug_info.py")
+
+from debug_info import *
+
+class TestDebugArtifactCollector:
+    @classmethod
+    def setup_class(cls):
+        with mock.patch("debug_info.super"):
+            cls.debug_info_module = DebugArtifactCollector(MOD_NAME)
+
+    def setup_method(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.base_path = self.tmpdir.name
+
+    def teardown_method(self):
+        self.tmpdir.cleanup()
+    
+    def test_run_command_success(self):
+        with mock.patch("debug_info.subprocess.Popen") as mp:
+            proc = mock.Mock()
+            proc.communicate.return_value = ("out", "err")
+            proc.returncode = 0
+            mp.return_value = proc
+            rc, out, err = self.debug_info_module._run_command("echo test")
+            assert rc == 0
+            assert out == "out"
+            assert err == "err"
+
+    def test_run_command_timeout(self):
+        with mock.patch("debug_info.subprocess.Popen") as mp:
+            proc = mock.Mock()
+            proc.communicate.side_effect = subprocess.TimeoutExpired(cmd="sleep 5", timeout=1)
+            proc.kill = mock.Mock()
+            mp.return_value = proc
+            rc, out, err = self.debug_info_module._run_command("sleep 5", timeout =1)
+            assert rc == 1
+            assert "timeout" in out
+    
+    def test_get_device_metadata_failure(self):
+        with mock.patch("debug_info.swsscommon.SonicV2Connector") as mock_conn, \
+            mock.patch("debug_info.logger.warning") as mock_warn:
+            instance = mock_conn.return_value
+            instance.get_all.side_effect = Exception("db error")
+            hostname, board_type = self.debug_info_module.get_device_metadata()
+            assert hostname == "switch"
+            assert board_type == ""
+            mock_warn.assert_called_with("Failed to read hostname/board_type from CONFIG_DB: db error")
+
+    def test_get_device_metadata_success(self):
+        with mock.patch("debug_info.swsscommon.SonicV2Connector") as mock_conn:
+            instance = mock_conn.return_value
+            instance.get_all.return_value = {
+                "hostname": "sonic-host",
+                "platform": "x86_64-kvm_x86_64-r0"
+                }
+            hostname, board_type = self.debug_info_module.get_device_metadata()
+            assert hostname == "sonic-host"
+            assert board_type == "x86_64-kvm_x86_64-r0"
+
+    def test_get_device_metadata_missing_fields(self):
+        with mock.patch("debug_info.swsscommon.SonicV2Connector") as mock_conn:
+            instance = mock_conn.return_value
+            instance.get_all.return_value = {}
+            hostname, board_type = self.debug_info_module.get_device_metadata()
+            assert hostname == "switch"
+            assert board_type == ""
+
+    def test_collect_invalid_json(self):
+        rc, msg = self.debug_info_module.collect("not a json")
+        assert rc == 1
+        assert "invalid input" in msg
+
+    def test_collect_success(self):
+        rc, msg = self.debug_info_module.collect("{}")
+        assert rc == 0
+        assert msg.startswith(ARTIFACT_DIR)
+
+    def test_collect_artifact_throw_exception(self):
+        with mock.patch("debug_info.DebugArtifactCollector.collect_artifacts", side_effect=Exception("bad")):
+            rc, msg = self.debug_info_module.collect("[]")
+            assert rc == 1
+            assert "Artifact collection failed" in msg
+
+    def test_check_always_ready(self):
+        rc, msg = self.debug_info_module.check("anything")
+        assert rc == 0
+        assert "ready" in msg.lower()
+    
+    def test_ack_failure(self):
+        with mock.patch("debug_info.os.remove", side_effect=OSError("fail")):
+            rc, msg = self.debug_info_module.ack("/tmp/foo")
+            assert rc == 1
+            assert "Failed to delete" in msg
+    
+    def test_register(self):
+        cls, modname = register()
+        assert cls is DebugArtifactCollector
+        assert modname == "debug_info"
+
+    def test_collect_counter_artifacts_with_errors(self, tmp_path):
+        fake_dir = tmp_path
+        with mock.patch("debug_info.DebugArtifactCollector._run_command", side_effect=[(1, "", "err"), (1, "", "err")]):
+            DebugArtifactCollector._collect_counter_artifacts(str(fake_dir), "ut_", "x86_64")
+
+    def test_save_persistent_storage_flag_exists(self):
+        fake_flag = os.path.join(self.base_path, "nv.tmp")
+        with open(fake_flag, "w") as f:
+            f.write("")
+        with mock.patch("debug_info.NONVOLATILE_TMP_FLAG", fake_flag):
+            DebugArtifactCollector._save_persistent_storage("artifact")
+        assert os.path.exists(fake_flag)
+
+    def test_save_persistent_oserror_creating_flag(self):
+        bad_flag = os.path.join(self.base_path, "bad", "nv.tmp")
+        with mock.patch("debug_info.NONVOLATILE_TMP_FLAG", bad_flag):
+            DebugArtifactCollector._save_persistent_storage("artifact")
+
+    def test_save_persistent_path_not_exists(self):
+        fake_flag = os.path.join(self.base_path, "nv.tmp")
+        with mock.patch("debug_info.NONVOLATILE_TMP_FLAG", fake_flag), \
+             mock.patch("debug_info.ARTIFACT_DIR", self.base_path), \
+             mock.patch("os.path.getsize", side_effect=OSError):
+            DebugArtifactCollector._save_persistent_storage("artifact.tar")
+
+    def test_save_persistent_not_enough_space(self):
+        fake_flag = os.path.join(self.base_path, "nv.tmp")
+        artifact = os.path.join(self.base_path, "artifact.tar")
+        with open(artifact, "w") as f:
+            f.write("data")
+
+        with mock.patch("debug_info.NONVOLATILE_TMP_FLAG", fake_flag), \
+             mock.patch("debug_info.ARTIFACT_DIR", self.base_path), \
+             mock.patch("os.path.getsize", return_value=100), \
+             mock.patch("shutil.disk_usage", return_value=(0, 0, 0)):
+            DebugArtifactCollector._save_persistent_storage("artifact.tar")
+        assert os.path.exists(fake_flag)
+
+    def test_save_persistent_storage_success(self):
+        fake_flag = os.path.join(self.base_path, "nv.tmp")
+        artifact = os.path.join(self.base_path, "artifact.tar")
+        with open(artifact, "w") as f:
+            f.write("data")
+
+        with mock.patch("debug_info.NONVOLATILE_TMP_FLAG", fake_flag), \
+             mock.patch("debug_info.ARTIFACT_DIR", self.base_path), \
+             mock.patch("os.path.getsize", return_value=100), \
+             mock.patch("shutil.disk_usage", return_value=(0, 1000, 1000)), \
+             mock.patch("debug_info.DebugArtifactCollector._run_command", return_value=(0, "", "")):
+            DebugArtifactCollector._save_persistent_storage("artifact.tar")
+        assert os.path.exists(fake_flag)
+
+    def test_collect_teamdctl_get_portchannels_fails(self):
+        with mock.patch("debug_info.SonicDbUtils.get_portchannels",
+                        side_effect=Exception("DB error")), \
+             mock.patch("debug_info.logger.warning") as mock_warn:
+            DebugArtifactCollector._collect_teamdctl_data(self.base_path)
+        mock_warn.assert_called()
+
+    def test_collect_teamdctl_no_portchannels(self):
+        with mock.patch("debug_info.SonicDbUtils.get_portchannels",return_value=[]), \
+             mock.patch("debug_info.logger.warning") as mock_warn:
+            DebugArtifactCollector._collect_teamdctl_data(self.base_path)
+        # No files created
+        assert os.listdir(self.base_path) == []
+        mock_warn.assert_called_with("teamdctl: No PortChannels found, skipping teamdctl collection")
+
+    def test_teamdctl_valid_portchannel_success(self):
+        with mock.patch("debug_info.SonicDbUtils.get_portchannels",return_value=["PortChannel01"]), \
+             mock.patch("debug_info.subprocess.run") as mock_run:
+            mock_run.return_value = mock.Mock(
+                returncode=0,
+                stdout="teamdctl output",
+                stderr=""
+            )
+            DebugArtifactCollector._collect_teamdctl_data(self.base_path)
+        filepath = os.path.join(self.base_path, "teamdctl_PortChannel01.txt")
+        assert os.path.exists(filepath)
+        with open(filepath) as f:
+            assert "teamdctl output" in f.read()
+    
+    def test_teamdctl_valid_portchannel_failure(self):
+        with mock.patch("debug_info.SonicDbUtils.get_portchannels",return_value=["PortChannel02"]), \
+             mock.patch("debug_info.subprocess.run") as mock_run:
+            mock_run.return_value = mock.Mock(
+                returncode=1,
+                stdout="",
+                stderr="some error"
+            )
+            DebugArtifactCollector._collect_teamdctl_data(self.base_path)
+        filepath = os.path.join(self.base_path, "teamdctl_PortChannel02.txt")
+        assert not os.path.exists(filepath)
+
+    def test_teamdctl_file_write_failure(self):
+        with mock.patch("debug_info.SonicDbUtils.get_portchannels",
+                        return_value=["PortChannel03"]), \
+             mock.patch("debug_info.subprocess.run") as mock_run, \
+             mock.patch("builtins.open",side_effect=FileNotFoundError), \
+             mock.patch("debug_info.logger.warning") as mock_warn:
+            mock_run.return_value = mock.Mock(
+                returncode=0,
+                stdout="teamdctl data",
+                stderr=""
+            )
+            DebugArtifactCollector._collect_teamdctl_data(self.base_path)
+        mock_warn.assert_called()

--- a/utils/platform_info.py
+++ b/utils/platform_info.py
@@ -1,0 +1,71 @@
+import logging
+import os
+import yaml
+
+logger = logging.getLogger(__name__)
+
+debian_name = 'Debian GNU/Linux'
+
+debian_version_path = '/etc/os-release'
+sonic_version_paths = [
+  '/etc/sonic/sonic_version.yml',
+]
+
+# Use a global to cache platform info, which does not change at runtime
+_platform = None
+
+def _read_yaml_file(path):
+  with open(path, 'r') as f:
+    try:
+        data = yaml.safe_load(f)
+        return data
+    except yaml.YAMLError as e:
+        logger.error(f"Error parsing {path}: {e}")
+  return {}
+
+def _read_os_version_file(path):
+  with open(path, 'r') as f:
+    reader = csv.reader(f, delimiter='=', quotechar='"')
+    data = dict(reader)
+    return data
+
+def _read_platform_info():
+  global _platform
+  if _platform is not None:
+    return _platform
+
+  platform = {
+    'os': None,
+    'asic_type': None,
+    'is_debian': False,
+    'is_sonic': False,
+  }
+
+  if os.path.isfile(debian_version_path):
+      debian_data = _read_os_version_file(debian_version_path)
+      os_name = debian_data.get('NAME')
+      platform['os'] = os_name
+      if os.name:
+        platform['is_debian'] = debian_name in os_name
+  else:
+    logger.debug('OS version file not found')
+
+  for path in sonic_version_paths:
+    if os.path.isfile(path):
+      sonic_version_data = _read_yaml_file(path)
+      platform['asic_type'] = sonic_version_data.get('asic_type')
+      platform['is_sonic'] = True
+      break
+  if platform.get('asic_type') is None:
+      logger.debug('SONiC version file not found')
+
+  logger.info(f'Platform info: {platform}')
+  # Note: the value of platform is deterministic and simple assignment is threadsafe
+  _platform = platform
+
+def get_platform_info():
+  'Return information about the platform, including OS name and switch ASIC type'
+  return _read_platform_info()
+
+if __name__ == "__main__":
+  print(get_platform_info())

--- a/utils/sonic_db_utils.py
+++ b/utils/sonic_db_utils.py
@@ -1,0 +1,36 @@
+from swsscommon import swsscommon
+import logging
+
+logger = logging.getLogger(__name__)
+
+class SonicDbUtils:
+  """Utility class for fetching information from SONiC Redis DBs using swsscommon."""
+
+  @staticmethod
+  def get_portchannels() -> list[str]:
+    """Fetch PortChannel names from APPL_DB.
+    Returns:
+        List[str]: List of Portchannel names
+    """
+    db = swsscommon.SonicV2Connector()
+    try:
+      db.connect(db.APPL_DB)
+      keys = db.keys(db.APPL_DB, "PORTCHANNEL|*")
+      if not keys:
+        return []
+      portchannels = []
+      for key in keys or []:
+        try:
+          _, name = key.split("|", 1)
+          portchannels.append(name)
+        except ValueError:
+          logger.warning(f"Malformed PORTCHANNEL key: {key}")
+      return portchannels
+    except Exception as e:
+      logger.warning(f"Failed to retrieve the port channels from APPL_DB: {e}")
+      return []
+    finally:
+      try:
+        db.close()
+      except Exception:
+        pass


### PR DESCRIPTION
This PR introduces the backend support for gNOI Healthz. However, since the necessary consumer logic for receiving and executing debug requests is currently absent within the upstream SONiC component containers, the current backend implementation only supports Host-level artifact collection. This involves running common debug commands directly on the host and generating the resulting *.tar.gz file, excluding component-specific debug data.

**NOTE:** All the Functionality testing has been done on SONiC Virtual Switch.

Below is the placeholder for Artifact tar file and the list of files 

```
admin@sonic:/tmp/dump$ ls
sonic_20251106_082724534264  sonic_20251106_082724534264.tar.gz
admin@sonic:/tmp/dump/sonic_20251106_082724534264$ ls
host
admin@sonic:/tmp/dump/sonic_20251106_082724534264/host$ ls
core  log   pre_counter_20251106_082724  version.txt
db    post_counter_20251106_082954  routing.txt
admin@sonic:/tmp/dump/sonic_20251104_132111395021/host/log$ ls
audit	  cron.log	  frr	      lastlog	  swss		 user.log
auth.log   gnmi.log    lost+found  syslog	 user.log.1
btmp	  dpkg.log	  kern.log    private	  sysstat	 wtmp
chrony	  dump		  kern.log.1    telemetry.log
admin@sonic:/tmp/dump/sonic_20251106_082724534264/host$ ls pre_counter_20251106_082724/
counter_db.json  top.txt
admin@sonic:/tmp/dump/sonic_20251106_082724534264/host$ ls post_counter_20251106_082954/
counter_db.json  top.txt
admin@sonic:/tmp/dump/sonic_20251106_082724534264/host$ ls db/
appl_db.json  asic_db.json  config_db.json  vidtorid.txt
```

**Dependent FE PRs**

https://github.com/sonic-net/sonic-gnmi/pull/485
https://github.com/sonic-net/sonic-gnmi/pull/486
https://github.com/sonic-net/sonic-gnmi/pull/507/
https://github.com/sonic-net/sonic-gnmi/pull/487
https://github.com/sonic-net/sonic-gnmi/pull/488/
https://github.com/sonic-net/sonic-gnmi/pull/489
https://github.com/sonic-net/sonic-gnmi/pull/509/


