### PR TITLE
Improve LC reboot cause for supervisor heartbeat (#271)

### DIFF
--- a/scripts/determine-reboot-cause
+++ b/scripts/determine-reboot-cause
@@ -42,6 +42,7 @@ REBOOT_TYPE_KEXEC_PATTERN_FAST = ".*SONIC_BOOT_TYPE=(fast|fast-reboot).*"
 REBOOT_CAUSE_UNKNOWN = "Unknown"
 REBOOT_CAUSE_NON_HARDWARE = "Non-Hardware"
 REBOOT_CAUSE_HARDWARE_OTHER = "Hardware - Other"
+REBOOT_CAUSE_HEARTBEAT_LOSS = "Heartbeat with the Supervisor card lost"
 
 # Global logger class instance
 sonic_logger = syslogger.SysLogger(SYSLOG_IDENTIFIER)
@@ -160,7 +161,9 @@ def get_reboot_cause_dict(previous_reboot_cause, comment, gen_time):
         if match is not None:
             reboot_cause_dict['cause'] = "Kernel Panic"
             reboot_cause_dict['time'] = match.group(1)
- 
+    elif re.search(r'Heartbeat with the Supervisor card lost', previous_reboot_cause):
+        reboot_cause_dict['cause'] = 'Heartbeat with the Supervisor card lost'
+
     return reboot_cause_dict
 
 def determine_reboot_cause():
@@ -180,8 +183,8 @@ def determine_reboot_cause():
     software_reboot_cause = find_software_reboot_cause()
 
     # The main decision logic of the reboot cause:
-    # If there is a valid hardware reboot cause indicated by platform API, 
-    #    check the software reboot cause to add additional rebot cause.
+    # If software reboot cause is not heartbeat loss and there is a valid hardware reboot cause indicated by platform API,
+    #    check the software reboot cause to add additional reboot cause.
     # If there is a reboot cause indicated by /proc/cmdline, and/or warmreboot/fastreboot/softreboot
     #   the software_reboot_cause which is the content of /hosts/reboot-cause/reboot-cause.txt
     #   will be treated as the additional reboot cause
@@ -189,7 +192,7 @@ def determine_reboot_cause():
     #   the software_reboot_cause will be treated as the reboot cause if it's not unknown
     #   otherwise, the cmdline_reboot_cause will be treated as the reboot cause if it's not none
     # Else the software_reboot_cause will be treated as the reboot cause
-    if REBOOT_CAUSE_NON_HARDWARE not in hardware_reboot_cause:
+    if REBOOT_CAUSE_HEARTBEAT_LOSS not in software_reboot_cause and REBOOT_CAUSE_NON_HARDWARE not in hardware_reboot_cause:
         previous_reboot_cause = hardware_reboot_cause
         # Check if any software reboot was issued before this hardware reboot happened
         if software_reboot_cause is not REBOOT_CAUSE_UNKNOWN:

--- a/tests/determine-reboot-cause_test.py
+++ b/tests/determine-reboot-cause_test.py
@@ -53,6 +53,7 @@ REBOOT_CAUSE_USER = "User issued 'reboot' command [User: admin, Time: Thu Oct 22
 GEN_TIME_USER = "2020_10_22_03_14_07"
 REBOOT_CAUSE_KERNEL_PANIC = "Kernel Panic [Time: Sun Mar 28 13:45:12 UTC 2021]"
 GEN_TIME_KERNEL_PANIC = "2021_3_28_13_48_49"
+REBOOT_CAUSE_HEARTBEAT_LOSS = "Heartbeat with the Supervisor card lost"
 
 
 REBOOT_CAUSE_UNKNOWN = "Unknown"
@@ -65,10 +66,12 @@ EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE = "warm-reboot"
 EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER = "User issued 'warm-reboot' command [User: admin, Time: Mon Nov  2 22:37:45 UTC 2020]"
 EXPECTED_FIND_FIRSTBOOT_VERSION = " (First boot of SONiC version 20191130.52)"
 EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_FIRSTBOOT = "Unknown (First boot of SONiC version 20191130.52)"
+EXPECTED_FIND_SOFTWARE_HEATBEAT_LOSS = "Heartbeat with the Supervisor card lost"
 
 EXPECTED_WATCHDOG_REBOOT_CAUSE_DICT = {'comment': '', 'gen_time': '2020_10_22_03_15_08', 'cause': 'Watchdog', 'user': 'N/A', 'time': 'N/A'}
 EXPECTED_USER_REBOOT_CAUSE_DICT = {'comment': '', 'gen_time': '2020_10_22_03_14_07', 'cause': 'reboot', 'user': 'admin', 'time': 'Thu Oct 22 03:11:08 UTC 2020'}
 EXPECTED_KERNEL_PANIC_REBOOT_CAUSE_DICT = {'comment': '', 'gen_time': '2021_3_28_13_48_49', 'cause': 'Kernel Panic', 'user': 'N/A', 'time': 'Sun Mar 28 13:45:12 UTC 2021'}
+EXPECTED_HEATBEAT_LOSS_REBOOT_CAUSE_DICT = {'comment': '', 'gen_time': '2020_10_22_03_14_07', 'cause': 'Heartbeat with the Supervisor card lost', 'user': 'N/A', 'time' : 'N/A' }
 
 REBOOT_CAUSE_DIR="host/reboot-cause/"
 
@@ -130,6 +133,10 @@ class TestDetermineRebootCause(object):
         reboot_cause_dict = determine_reboot_cause.get_reboot_cause_dict(REBOOT_CAUSE_KERNEL_PANIC, "", GEN_TIME_KERNEL_PANIC)
         assert reboot_cause_dict == EXPECTED_KERNEL_PANIC_REBOOT_CAUSE_DICT
 
+    def test_get_reboot_cause_dict_heartbeat_loss(self):
+        reboot_cause_dict = determine_reboot_cause.get_reboot_cause_dict(REBOOT_CAUSE_HEARTBEAT_LOSS, "", GEN_TIME_USER)
+        assert reboot_cause_dict == EXPECTED_HEATBEAT_LOSS_REBOOT_CAUSE_DICT
+
     def test_determine_reboot_cause_hardware(self):
         with mock.patch("determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value=None):
             with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value=REBOOT_CAUSE_UNKNOWN):
@@ -177,6 +184,14 @@ class TestDetermineRebootCause(object):
                     previous_reboot_cause, additional_info = determine_reboot_cause.determine_reboot_cause()
                     assert previous_reboot_cause == EXPECTED_HARDWARE_REBOOT_CAUSE
                     assert additional_info == EXPECTED_FIND_SOFTWARE_REBOOT_CAUSE_USER
+
+    def test_determine_reboot_cause_software_heartbeatloss_hardware_other(self):
+        with mock.patch("determine_reboot_cause.find_proc_cmdline_reboot_cause", return_value=EXPECTED_PARSE_WARMFAST_REBOOT_FROM_PROC_CMDLINE):
+            with mock.patch("determine_reboot_cause.find_software_reboot_cause", return_value=EXPECTED_FIND_SOFTWARE_HEATBEAT_LOSS):
+                with mock.patch("determine_reboot_cause.find_hardware_reboot_cause", return_value=EXPECTED_HARDWARE_REBOOT_CAUSE):
+                    previous_reboot_cause, additional_info = determine_reboot_cause.determine_reboot_cause()
+                    assert previous_reboot_cause == EXPECTED_FIND_SOFTWARE_HEATBEAT_LOSS
+                    assert additional_info == "N/A"
 
     @mock.patch('determine_reboot_cause.REBOOT_CAUSE_DIR', os.path.join(os.getcwd(), REBOOT_CAUSE_DIR))
     @mock.patch('determine_reboot_cause.REBOOT_CAUSE_HISTORY_DIR', os.path.join(os.getcwd(), 'host/reboot-cause/history/'))


### PR DESCRIPTION
When the supervisor reboots ungracefully (e.g., kernel panic), LCs lose connection and are subsequently rebooted. This change adds 'heartbeat loss' as a software reboot cause for LCs.

It also modifies the reboot cause logic to prioritize this software heartbeat loss cause over any hardware triggers that occur during the supervisor-initiated LC reboot. This ensures accurate reporting of the LC's reboot reason.


(Cherry-picked from master)