### PR TITLE
[Smartswitch] Update control plane ACL for smartswitch

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -337,6 +337,10 @@ class ControlPlaneAclManager(logger.Logger):
             allow_internal_chassis_midplane_traffic.append(['iptables', '-A', 'INPUT', '-s', chassis_midplane_ip, '-d', chassis_midplane_ip, '-j', 'ACCEPT'])
             allow_internal_chassis_midplane_traffic.append(['iptables', '-A', 'INPUT', '-i', chassis_midplane_dev_name, '-j', 'ACCEPT'])
 
+        if device_info.is_smartswitch():
+            # Allow traffic to the chassis midplane IP
+            allow_internal_chassis_midplane_traffic.append(['iptables', '-A', 'INPUT', '-d', '169.254.200.254','-j', 'ACCEPT'])
+
         return allow_internal_chassis_midplane_traffic
 
     def generate_allow_internal_docker_ip_traffic_commands(self, namespace):

--- a/tests/caclmgrd/caclmgrd_chassis_midplane_test.py
+++ b/tests/caclmgrd/caclmgrd_chassis_midplane_test.py
@@ -35,9 +35,16 @@ class TestCaclmgrdChassisMidplane(TestCase):
             fs.create_file(DBCONFIG_PATH) # fake database_config.json
 
         with mock.patch("sonic_py_common.device_info.is_chassis", return_value=True):
-            with mock.patch("caclmgrd.ControlPlaneAclManager.run_commands_pipe", side_effect=["eth1-midplane", "1.0.0.33", "eth1-midplane", "1.0.0.33"]):
+            with mock.patch("sonic_py_common.device_info.is_smartswitch", return_value=False):
+                with mock.patch("caclmgrd.ControlPlaneAclManager.run_commands_pipe", side_effect=["eth1-midplane", "1.0.0.33", "eth1-midplane", "1.0.0.33"]):
+                        caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
+                        ret = caclmgrd_daemon.generate_allow_internal_chasis_midplane_traffic('')
+                        self.assertListEqual(test_data["return"], ret)
+                        ret = caclmgrd_daemon.generate_allow_internal_chasis_midplane_traffic('asic0')
+                        self.assertListEqual([], ret)
+        with mock.patch("sonic_py_common.device_info.is_chassis", return_value=False):
+            with mock.patch("sonic_py_common.device_info.is_smartswitch", return_value=True):
                     caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
                     ret = caclmgrd_daemon.generate_allow_internal_chasis_midplane_traffic('')
-                    self.assertListEqual(test_data["return"], ret)
-                    ret = caclmgrd_daemon.generate_allow_internal_chasis_midplane_traffic('asic0')
+                    self.assertListEqual(test_data["return_smartswitch"], ret)
                     self.assertListEqual([], ret)

--- a/tests/caclmgrd/test_chassis_midplane_vectors.py
+++ b/tests/caclmgrd/test_chassis_midplane_vectors.py
@@ -10,6 +10,9 @@ CACLMGRD_CHASSIS_MIDPLANE_TEST_VECTOR = [
             "return": [
                 ['iptables', '-A', 'INPUT', '-s', '1.0.0.33', '-d', '1.0.0.33', '-j', 'ACCEPT'],
                 ['iptables', '-A', 'INPUT', '-i', 'eth1-midplane', '-j', 'ACCEPT']
+            ],
+            "return_smartswitch": [
+                ['iptables', '-A', 'INPUT', '-d', '169.254.200.254','-j', 'ACCEPT']
             ]
         }
     ]


### PR DESCRIPTION
The smartswitch CHASSIS_STATE_DB is hosted on the redis-chassis IP address, which needs to still accept traffic on addition of control plane ACLs (DBs should be accessible at any point of time) this ip is also needed for DPU access as well. So we have a check for smartswitch to allow traffic to the bridge-midplane IP address

##Tests
Manual tests to confirm that addition of control plane ACLs does not render the CHASSIS_STATE_DB inaccesible