### PR TITLE
[BugFix]hostcfgd,mgmt interface IP cannot be deleted IF gw wasn't given during config.

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1585,7 +1585,7 @@ class MgmtIfaceCfg(object):
     def update_mgmt_iface(self, iface, key, data):
         """Handle update management interface config
         """
-        syslog.syslog(syslog.LOG_DEBUG, 'MgmtIfaceCfg: Starting interface update')
+        syslog.syslog(syslog.LOG_DEBUG, 'MgmtIfaceCfg: mgmt iface update')
 
         existing_data = self.iface_config_data.get(key)
 


### PR DESCRIPTION
## Issue
When configuring a static IP on the management interface **without a default gateway address**, the static IP cannot be deleted.  
This issue occurs due to how the data is handled in `update_mgmt_iface()`.  
This function is responsible for configuring and triggering a restart of `interfaces-config.service`.

This issue can occur during different scneraios like 

- when eth0 is configured via openconfig-interfaces.yang model which doesn't even have an option of default gw in the yang model. 
- If someone has an intention just to use static IPv6 without explicit gw as gw can be config by RA.
- If the a wrong config was done, and wants to remove the config.

**config interface ip add <interface_name> <ip_addr> [default_gw]** 

**config interface ip remove <interface_name> <ip_addr> [default_gw]** 

sudo config interface ip add eth0 3002::8/64 

```
root@sonic:/home/admin# ifconfig eth0
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet6 fe80::5054:ff:fe12:3456  prefixlen 64  scopeid 0x20<link>
        inet6 3002::8  prefixlen 64  scopeid 0x0<global>
        ether 52:54:00:12:34:56  txqueuelen 1000  (Ethernet)
        RX packets 9  bytes 1722 (1.6 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 44  bytes 7205 (7.0 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0


sudo config interface ip remove eth0 3002::8/64 

```

## Fix
The fix updates the logic in `update_mgmt_iface()` to properly manage changes to a management interface’s configuration:

- If the configuration has changed, it updates the stored value and logs the update.  
- If the new configuration is empty (`not data`), it removes the existing entry for that key and logs the removal.  
- If there is no change, it does nothing.  


