### PR TITLE
Pin PyGObject to 3.42.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'dbus-python',
         'systemd-python',
         'Jinja2>=2.10',
-        'PyGObject==3.50.0',
+        'PyGObject==3.42.2',
         'pycairo==1.26.1',
         'psutil'
     ] + sonic_dependencies,


### PR DESCRIPTION
PyGObject 3.50.0 has a breaking dependency change, which will cause armhf build failure.
Pin it to 3.42.2