### PR TITLE
[Smartswitch] Update the type of reboot status variable for DPU

### DIFF
--- a/host_modules/reboot.py
+++ b/host_modules/reboot.py
@@ -61,7 +61,11 @@ class Reboot(host_service.HostModule):
         self.reboot_status_flag["reason"] = reason
         self.reboot_status_flag["count"] = self.reboot_count
         self.reboot_status_flag["method"] = method
-        self.reboot_status_flag["status"] = status.value
+        # status value should be of type RebootStatus
+        self.reboot_status_flag["status"] = {
+            "status": status.value,
+            "message": ""
+        }
         self.lock.release()
         return
 

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -73,7 +73,10 @@ class TestReboot(object):
             assert get_reboot_status_flag_data["reason"] == ""
             assert get_reboot_status_flag_data["count"] == 0
             assert get_reboot_status_flag_data["method"] == ""
-            assert get_reboot_status_flag_data["status"] == RebootStatus.STATUS_UNKNOWN.value
+            assert get_reboot_status_flag_data["status"] == {
+                "status": RebootStatus.STATUS_UNKNOWN.value,
+                "message": ""
+            }
 
     def test_populate_reboot_status_flag_with_status(self):
         with mock.patch("time.time", return_value=1617811205.25):
@@ -81,7 +84,10 @@ class TestReboot(object):
             return_value, get_reboot_status_flag_data = self.reboot_module.get_reboot_status()
             assert return_value == 0
             get_reboot_status_flag_data = json.loads(get_reboot_status_flag_data)
-            assert get_reboot_status_flag_data["status"] == RebootStatus.STATUS_SUCCESS.value
+            assert get_reboot_status_flag_data["status"] == {
+                "status": RebootStatus.STATUS_SUCCESS.value,
+                "message": ""
+            }
 
     def test_validate_reboot_request_success_cold_boot_enum_method(self):
         reboot_request = {"method": REBOOT_METHOD_COLD_BOOT_ENUM, "reason": "test reboot request reason"}
@@ -391,7 +397,10 @@ class TestReboot(object):
         assert response_data["when"] == TIME
         assert response_data["reason"] == MSG
         assert response_data["method"] == REBOOT_METHOD_COLD_BOOT_ENUM
-        assert response_data["status"] == RebootStatus.STATUS_SUCCESS.value
+        assert response_data["status"] == {
+            "status": RebootStatus.STATUS_SUCCESS.value,
+            "message": ""
+        }
 
     def test_get_reboot_status_inactive(self):
         self.reboot_module.populate_reboot_status_flag(False, 0, "", REBOOT_METHOD_COLD_BOOT_ENUM, RebootStatus.STATUS_SUCCESS)
@@ -402,7 +411,10 @@ class TestReboot(object):
         assert response_data["when"] == 0
         assert response_data["reason"] == ""
         assert response_data["method"] == REBOOT_METHOD_COLD_BOOT_ENUM
-        assert response_data["status"] == RebootStatus.STATUS_SUCCESS.value
+        assert response_data["status"] == {
+            "status": RebootStatus.STATUS_SUCCESS.value,
+            "message": ""
+        }
 
 #        assert result[1] == TEST_INACTIVE_RESPONSE_DATA
 


### PR DESCRIPTION
The reboot_status variable has to be able to be dumped in json format, and to be converted to the RebootStatus defined in protobuf format, since this is the expectation from the GNMI call. Hence this return type is updated in reboot.py which is called when we perform pre-shutdown for DPUs


This is required to fix the following issue:
```
2025-09-19 19:09:09 - INFO: Rebooting dpu1, ip:169.254.200.2 gnmi_port:8080
panic: rpc error: code = Internal desc = Cannot unmarshal the response: [{"active": true, "when": 1748538762, "reason": "User initiated reboot", "count": 1, "method": "HALT", "status": 0}]; err: [proto: syntax error (line 1:113): unexpected token 0]

goroutine 1 [running]:
github.com/sonic-net/sonic-gnmi/gnoi_client/system.RebootStatus(0xc000101800, {0xb3f778, 0xc000113c80})
        /sonic/src/sonic-gnmi/gnoi_client/system/reboot.go:49 +0x214
main.main()
        /sonic/src/sonic-gnmi/gnoi_client/gnoi_client.go:44 +0x616
```
During the reboot of the DPU

