### PR TITLE
apply_correct_timezone

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -50,6 +50,8 @@ MKHOME_DIR_LIB_REG = r'.*pam_mkhomedir'
 ETC_PAMD_SSHD = "/etc/pam.d/sshd"
 ETC_PAMD_LOGIN = "/etc/pam.d/login"
 ETC_LOGIN_DEF = "/etc/login.defs"
+ETC_LOCALTIME = "/etc/localtime"
+ZONEINFO_DIR = "/usr/share/zoneinfo"
 
 # Linux login.def default values (password hardening disable)
 LINUX_DEFAULT_PASS_MAX_DAYS = 99999
@@ -1474,6 +1476,17 @@ class DeviceMetaCfg(object):
 
         # Load appropriate config
         self.timezone = dev_meta.get('localhost', {}).get('timezone')
+        if self.timezone:
+            try:
+                desired_tz = os.path.realpath(f"{ZONEINFO_DIR}/{self.timezone}")
+                current_tz = os.path.realpath(ETC_LOCALTIME)
+                if desired_tz != current_tz:
+                    run_cmd(['timedatectl', 'set-timezone', self.timezone])
+                    syslog.syslog(syslog.LOG_INFO, f'Applied initial timezone: {self.timezone}')
+                    run_cmd(['systemctl', 'restart', 'rsyslog'])
+                    syslog.syslog(syslog.LOG_INFO, 'DeviceMetaCfg: Restart rsyslog after changing timezone')
+            except Exception as e:
+                syslog.syslog(syslog.LOG_ERR, f"Failed to set initial timezone {self.timezone}: {e}")
         self.syslog_with_osversion = dev_meta.get('localhost', {}).get('syslog_with_osversion')
 
     def hostname_update(self, data):


### PR DESCRIPTION
**Why I did it**
To fix an issue where newly installed SONiC images default /etc/localtime to UTC even when the previous image
was configured with and used a different timezone, and config save was executed before the image update.
This causes a mismatch between the timezone defined in CONFIG_DB and the one defined in the Linux file /etc/localtime, because when the new image comes up with a new filesystem, the Linux file /etc/localtime is created with the default UTC, while the timezone value in CONFIG_DB (DEVICE_METADATA|localhost|timezone) is preserved from the previous image.

**How I did it**
In src/sonic-host-services/scripts/hostcfgd::DeviceMetaCfg:load, we already read the timezone from CONFIG_DB to save it for future events (DeviceMetaCfg:timezone_update observes changes in DEVICE_METADATA).
So at this point, when hostcfgd is up, we can simply update the Linux file /etc/localtime with the initial correct timezone value from CONFIG_DB by executing (only if it differs from the current /etc/localtime):
timedatectl set-timezone <timezone>
(as is already done in timezone_update).
The same pattern exists in hostcfgd::DnsCfg:load.

**How to verify it**
1. Set a non-UTC timezone on the current image: config clock timezone Asia/Jerusalem
2. Run config save
3. Install a new image
4. Reboot and check that hostcfgd is up: systemctl status hostcfgd (~1m)
5. Verify that the timezone is identical in CONFIG_DB and /etc/localtime:
timedatectl
date
cat /etc/localtime
cat /etc/sonic/config_db.json | grep timezone
hget "DEVICE_METADATA|localhost" "timezone"