### PR TITLE
 Fix Kdump SSH Remote Configuration Order

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1252,19 +1252,20 @@ class KdumpCfg(object):
                 num_dumps = data.get("num_dumps")
             run_cmd(["sonic-kdump-config", "--num_dumps", num_dumps])
 
-            # Remote option
-            remote = self.kdump_defaults["remote"]
-            if data.get("remote") is not None:
-                remote = data.get("remote")
-            run_cmd(["sonic-kdump-config", "--remote", remote])
-
+            # ssh_string
             ssh_string = self.kdump_defaults["ssh_string"]
             if data.get("ssh_string") is not None:
-                    run_cmd(["sonic-kdump-config", "--ssh_string", ssh_string])
+                ssh_string = data.get("ssh_string")
+            run_cmd(["sonic-kdump-config", "--ssh_string", ssh_string])
+
             # ssh_path
-            ssh_path= self.kdump_defaults["ssh_path"]
+            ssh_path = self.kdump_defaults["ssh_path"]
             if data.get("ssh_path") is not None:
-                    run_cmd(["sonic-kdump-config", "--ssh_path", ssh_path])
+                ssh_path = data.get("ssh_path")
+            run_cmd(["sonic-kdump-config", "--ssh_path", ssh_path])
+
+            # Remote option
+            run_cmd(["sonic-kdump-config", "--remote"])
 
 class NtpCfg(object):
     """

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -214,7 +214,7 @@ class TestHostcfgdDaemon(TestCase):
                 call(['sonic-kdump-config', '--disable']),
                 call(['sonic-kdump-config', '--num_dumps', '3']),
                 call(['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-16G:448M,16G-32G:768M,32G-:1G']),
-                call(['sonic-kdump-config', '--remote', 'false']),  # Covering remote
+                call(['sonic-kdump-config', '--remote']),  # Covering remote
                 call(['sonic-kdump-config', '--ssh_string', 'user@localhost']),  # Covering ssh_string
                 call(['sonic-kdump-config', '--ssh_path', '/a/b/c'])  # Covering ssh_path
             ]
@@ -235,7 +235,7 @@ class TestHostcfgdDaemon(TestCase):
                 call(['sonic-kdump-config', '--enable']),
                 call(['sonic-kdump-config', '--num_dumps', '3']),
                 call(['sonic-kdump-config', '--memory', '0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-16G:448M,16G-32G:768M,32G-:1G']),
-                call(['sonic-kdump-config', '--remote', 'false']),  # Covering remote
+                call(['sonic-kdump-config', '--remote']),  # Covering remote
                 call(['sonic-kdump-config', '--ssh_string', 'user@localhost']),  # Covering ssh_string
                 call(['sonic-kdump-config', '--ssh_path', '/a/b/c'])  # Covering ssh_path
             ]
@@ -263,7 +263,7 @@ class TestHostcfgdDaemon(TestCase):
                 call(['sonic-kdump-config', '--enable']),
                 call(['sonic-kdump-config', '--num_dumps', '3']),
                 call(['sonic-kdump-config', '--memory', '8G-:1G']),
-                call(['sonic-kdump-config', '--remote', 'false']),  # Covering remote
+                call(['sonic-kdump-config', '--remote']),  # Covering remote
                 call(['sonic-kdump-config', '--ssh_string', 'user@localhost']),  # Covering ssh_string
                 call(['sonic-kdump-config', '--ssh_path', '/a/b/c'])  # Covering ssh_path
             ]


### PR DESCRIPTION
## Description
This PR fixes the ordering issue in kdump remote configuration where `sonic-kdump-config --remote` was being called before `ssh_path` and `ssh_string` were properly set, causing the remote kdump feature to behave incorrectly.

## Related Issue
Fixes #318

## Changes Made
- Reordered configuration commands to set `ssh_string` and `ssh_path` before calling `--remote`
- Fixed variable assignment for `ssh_string` - now properly assigns the value from CONFIG_DB before using it
- Fixed variable assignment for `ssh_path` - now properly assigns the value from CONFIG_DB before using it
- Removed incorrect parameter from `sonic-kdump-config --remote` call (remote state is determined from CONFIG_DB)

## Root Cause
The `sonic-kdump-config --remote` command comments/uncomments `ssh_path` and `ssh_string` in the kdump configuration file based on the remote setting in CONFIG_DB. When called before these values were set, it operated on stale or default values instead of the intended configuration.

## Testing Done
- [x] Verified kdump remote configuration via CONFIG_DB
- [x] Confirmed `ssh_string` and `ssh_path` are properly set before `--remote` is called
- [x] Tested enabling remote kdump feature
- [x] Tested disabling remote kdump feature
- [x] Verified configuration persists across service restarts

## Impact
- **Severity**: Medium
- **Component**: Kdump remote configuration
- **Affected Feature**: SSH-based remote crash dump collection