### PR TITLE
Fix loganalyzer failures on non-smartswitch platforms triggered by #255

### DIFF
--- a/data/debian/sonic-host-services-data.gnoi-shutdown.service
+++ b/data/debian/sonic-host-services-data.gnoi-shutdown.service
@@ -6,10 +6,10 @@ After=network-online.target database.service
 
 [Service]
 Type=simple
-ExecStartPre=/usr/bin/python3 /usr/local/bin/check_platform.py
+ExecCondition=/usr/bin/python3 /usr/local/bin/check_platform.py
 ExecStartPre=/bin/bash /usr/local/bin/wait-for-sonic-core.sh
 ExecStart=/usr/bin/python3 /usr/local/bin/gnoi_shutdown_daemon.py
-Restart=always
+Restart=on-failure
 RestartSec=5
 
 [Install]


### PR DESCRIPTION
Why I did it

The gNOI shutdown daemon service was causing loganalyzer test failures on non-SmartSwitch platforms (e.g., vlab-01). The service attempted to start via ExecStartPre=/usr/local/bin/check_platform.py, which exited with code 1 on incompatible platforms. This caused systemd to log ERROR messages like:
ERR systemd[1]: Failed to start gnoi-shutdown.service - gNOI based DPU Graceful Shutdown Daemon
These errors blocked CI/CD submodule updates due to loganalyzer failures.

How I did it
Changed the service file to use ExecCondition= instead of ExecStartPre= for platform checking:

ExecCondition=/usr/bin/python3 /usr/local/bin/check_platform.py runs before service start
When check_platform.py returns exit code 1 on non-SmartSwitch platforms, systemd treats this as a condition not met rather than a failure
Service is gracefully skipped without error logs on incompatible platforms
Changed Restart=always to Restart=on-failure to avoid unnecessary restart attempts when conditions aren't met

How to verify it
On SmartSwitch NPU platform: Service starts normally and handles DPU graceful shutdown
https://github.com/sonic-net/sonic-buildimage/pull/24609 is run with this change

Which release branch to backport
 [x]202511