### PR TITLE
Parallelize Test Suite Execution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         'wheel'
     ],
     tests_require = [
+        'pytest-xdist',
         'parameterized',
         'pytest',
         'pyfakefs',
@@ -74,6 +75,7 @@ setup(
     ],
     extras_require = {
         "testing": [
+            'pytest-xdist',
             'parameterized',
             'pytest',
             'pyfakefs',

--- a/tests/caclmgrd/caclmgrd_bgp_loopback1_test.py
+++ b/tests/caclmgrd/caclmgrd_bgp_loopback1_test.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import swsscommon
+from swsscommon import swsscommon
 
 from parameterized import parameterized
 from sonic_py_common.general import load_module_from_source
@@ -18,7 +18,7 @@ class TestCaclmgrdLoopback1Drop(TestCase):
         Test caclmgrd soc
     """
     def setUp(self):
-        swsscommon.swsscommon.ConfigDBConnector = MockConfigDb
+        swsscommon.ConfigDBConnector = MockConfigDb
         test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         modules_path = os.path.dirname(test_path)
         scripts_path = os.path.join(modules_path, "scripts")

--- a/tests/caclmgrd/caclmgrd_dhcp_test.py
+++ b/tests/caclmgrd/caclmgrd_dhcp_test.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import swsscommon
+from swsscommon import swsscommon
 
 from parameterized import parameterized
 from sonic_py_common.general import load_module_from_source

--- a/tests/caclmgrd/caclmgrd_feature_test.py
+++ b/tests/caclmgrd/caclmgrd_feature_test.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import swsscommon
+from swsscommon import swsscommon
 
 from parameterized import parameterized
 from sonic_py_common.general import load_module_from_source
@@ -18,7 +18,7 @@ class TestFeature(TestCase):
         Test caclmgrd feature present 
     """
     def setUp(self):
-        swsscommon.swsscommon.ConfigDBConnector = MockConfigDb
+        swsscommon.ConfigDBConnector = MockConfigDb
         test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         modules_path = os.path.dirname(test_path)
         scripts_path = os.path.join(modules_path, "scripts")

--- a/tests/caclmgrd/caclmgrd_generate_allow_internal_docker_ip_traffic_test.py
+++ b/tests/caclmgrd/caclmgrd_generate_allow_internal_docker_ip_traffic_test.py
@@ -2,8 +2,10 @@ import os
 import sys
 
 from parameterized import parameterized
+from swsscommon import swsscommon
 from sonic_py_common.general import load_module_from_source
 from unittest import TestCase, mock
+from tests.common.mock_configdb import MockConfigDb
 from pyfakefs.fake_filesystem_unittest import patchfs
 
 from .test_internal_docker_ip_traffic_vectors import CACLMGRD_INTERNAL_DOCKER_IP_TEST_VECTOR
@@ -20,6 +22,7 @@ class TestCaclmgrdGenerateInternalDockerIp(TestCase):
         sys.path.insert(0, modules_path)
         caclmgrd_path = os.path.join(scripts_path, 'caclmgrd')
         self.caclmgrd = load_module_from_source('caclmgrd', caclmgrd_path)
+        swsscommon.ConfigDBConnector = MockConfigDb
         self.maxDiff = None
 
     @parameterized.expand(CACLMGRD_INTERNAL_DOCKER_IP_TEST_VECTOR)

--- a/tests/caclmgrd/caclmgrd_namespace_docker_ip_test.py
+++ b/tests/caclmgrd/caclmgrd_namespace_docker_ip_test.py
@@ -1,8 +1,10 @@
 import os
 import sys
 
+from swsscommon import swsscommon
 from sonic_py_common.general import load_module_from_source
 from unittest import TestCase, mock
+from tests.common.mock_configdb import MockConfigDb
 
 class TestCaclmgrdNamespaceDockerIP(TestCase):
     """
@@ -15,6 +17,7 @@ class TestCaclmgrdNamespaceDockerIP(TestCase):
         sys.path.insert(0, modules_path)
         caclmgrd_path = os.path.join(scripts_path, 'caclmgrd')
         self.caclmgrd = load_module_from_source('caclmgrd', caclmgrd_path)
+        swsscommon.ConfigDBConnector = MockConfigDb
         self.maxDiff = None
 
     def test_caclmgrd_namespace_docker_ip(self):

--- a/tests/caclmgrd/caclmgrd_scale_test.py
+++ b/tests/caclmgrd/caclmgrd_scale_test.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import swsscommon
+from swsscommon import swsscommon
 
 from parameterized import parameterized
 from sonic_py_common.general import load_module_from_source
@@ -18,7 +18,7 @@ class TestCaclmgrdScale(TestCase):
         Test caclmgrd with scale cacl rules
     """
     def setUp(self):
-        swsscommon.swsscommon.ConfigDBConnector = MockConfigDb
+        swsscommon.ConfigDBConnector = MockConfigDb
         test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         modules_path = os.path.dirname(test_path)
         scripts_path = os.path.join(modules_path, "scripts")

--- a/tests/caclmgrd/caclmgrd_soc_rules_test.py
+++ b/tests/caclmgrd/caclmgrd_soc_rules_test.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import swsscommon
+from swsscommon import swsscommon
 
 from parameterized import parameterized
 from sonic_py_common.general import load_module_from_source
@@ -19,7 +19,7 @@ class TestCaclmgrdSoc(TestCase):
         Test caclmgrd soc
     """
     def setUp(self):
-        swsscommon.swsscommon.ConfigDBConnector = MockConfigDb
+        swsscommon.ConfigDBConnector = MockConfigDb
         test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         modules_path = os.path.dirname(test_path)
         scripts_path = os.path.join(modules_path, "scripts")

--- a/tests/caclmgrd/caclmgrd_test.py
+++ b/tests/caclmgrd/caclmgrd_test.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import swsscommon
+from swsscommon import swsscommon
 from unittest.mock import call, patch, MagicMock
 from unittest import TestCase, mock
 from tests.common.mock_configdb import MockConfigDb
@@ -14,7 +14,7 @@ DBCONFIG_PATH = "/var/run/redis/sonic-db/database_config.json"
 
 class TestCaclmgrd(TestCase):
     def setUp(self):
-        swsscommon.swsscommon.ConfigDBConnector = MockConfigDb
+        swsscommon.ConfigDBConnector = MockConfigDb
         test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         modules_path = os.path.dirname(test_path)
         scripts_path = os.path.join(modules_path, "scripts")

--- a/tests/caclmgrd/conftest.py
+++ b/tests/caclmgrd/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+from tests.common.mock_configdb import MockConfigDb
+
+
+@pytest.fixture(autouse=True)
+def reset_config_db():
+    """Ensure MockConfigDb.CONFIG_DB has minimal required data for caclmgrd."""
+    if not MockConfigDb.CONFIG_DB.get('DEVICE_METADATA'):
+        MockConfigDb.CONFIG_DB['DEVICE_METADATA'] = {
+            'localhost': {}
+        }
+    if not MockConfigDb.CONFIG_DB.get('FEATURE'):
+        MockConfigDb.CONFIG_DB['FEATURE'] = {}
+    yield
+    MockConfigDb.CONFIG_DB = {}

--- a/tests/common/mock_configdb.py
+++ b/tests/common/mock_configdb.py
@@ -3,7 +3,7 @@ class MockConfigDb(object):
         Mock Config DB which responds to data tables requests and store updates to the data table
     """
     STATE_DB = None
-    CONFIG_DB = None
+    CONFIG_DB = {}
     event_queue = []
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
- Add pytest-xdist to testing dependencies
- Change MockConfigDb.CONFIG_DB default from None to {} to prevent TypeError in setUp methods that assign to CONFIG_DB[table]
- Fix caclmgrd test files to use correct swsscommon import: change "import swsscommon" to "from swsscommon import swsscommon" so swsscommon.ConfigDBConnector correctly resolves to the submodule
- Add missing ConfigDBConnector mock in generate_internal_docker_ip and namespace_docker_ip tests
- Add tests/caclmgrd/conftest.py with autouse fixture that initializes DEVICE_METADATA and FEATURE tables in MockConfigDb.CONFIG_DB, required by ControlPlaneAclManager.init

Signed-off-by: Tamer Ahmed tamerahmed@microsoft.com