### PR TITLE
[gnoi-shutdown-daemon] Skip gNOI shutdown for already powered-off DPUs

### DIFF
--- a/scripts/gnoi_shutdown_daemon.py
+++ b/scripts/gnoi_shutdown_daemon.py
@@ -14,6 +14,7 @@ import os
 import redis
 import threading
 import sonic_py_common.daemon_base as daemon_base
+from sonic_platform_base.module_base import ModuleBase
 from sonic_py_common import syslogger
 from swsscommon import swsscommon
 
@@ -135,13 +136,18 @@ class GnoiRebootHandler:
                 module = self._chassis.get_module(module_index)
                 if module is not None:
                     oper_status = module.get_oper_status()
-                    if oper_status != "Online":
+                    if oper_status in (ModuleBase.MODULE_STATUS_OFFLINE,
+                                       ModuleBase.MODULE_STATUS_POWERED_DOWN):
                         logger.log_notice(
                             f"{dpu_name}: DPU is already in '{oper_status}' state, "
                             "skipping gNOI shutdown sequence"
                         )
-                        self._clear_halt_flag(dpu_name)
-                        return True
+                        cleared = self._clear_halt_flag(dpu_name)
+                        if not cleared:
+                            logger.log_warning(
+                                f"{dpu_name}: Failed to clear halt flag while skipping gNOI shutdown"
+                            )
+                        return cleared
         except Exception as e:
             logger.log_warning(
                 f"{dpu_name}: Could not determine operational status ({e}), "

--- a/scripts/gnoi_shutdown_daemon.py
+++ b/scripts/gnoi_shutdown_daemon.py
@@ -126,6 +126,28 @@ class GnoiRebootHandler:
         """
         logger.log_notice(f"{dpu_name}: Starting gNOI shutdown sequence")
 
+        # Check if DPU is already powered off / offline before attempting gNOI shutdown.
+        # This avoids error logs when config reload or reboot is issued while DPUs are
+        # already in the down state (e.g. admin_status was previously set to "down").
+        try:
+            module_index = self._chassis.get_module_index(dpu_name)
+            if module_index >= 0:
+                module = self._chassis.get_module(module_index)
+                if module is not None:
+                    oper_status = module.get_oper_status()
+                    if oper_status != "Online":
+                        logger.log_notice(
+                            f"{dpu_name}: DPU is already in '{oper_status}' state, "
+                            "skipping gNOI shutdown sequence"
+                        )
+                        self._clear_halt_flag(dpu_name)
+                        return True
+        except Exception as e:
+            logger.log_warning(
+                f"{dpu_name}: Could not determine operational status ({e}), "
+                "proceeding with gNOI shutdown"
+            )
+
         # Wait for platform PCI detach completion
         if not self._wait_for_gnoi_halt_in_progress(dpu_name):
             logger.log_warning(f"{dpu_name}: Timeout waiting for PCI detach, proceeding anyway")
@@ -228,12 +250,12 @@ class GnoiRebootHandler:
             if module_index < 0:
                 logger.log_error(f"{dpu_name}: Unable to get module index from chassis")
                 return False
-            
+
             module = self._chassis.get_module(module_index)
             if module is None:
                 logger.log_error(f"{dpu_name}: Module at index {module_index} not found in chassis")
                 return False
-            
+
             module.clear_module_gnoi_halt_in_progress()
             logger.log_info(f"{dpu_name}: Successfully cleared halt_in_progress flag (module index: {module_index})")
             return True

--- a/scripts/gnoi_shutdown_daemon.py
+++ b/scripts/gnoi_shutdown_daemon.py
@@ -120,6 +120,29 @@ class GnoiRebootHandler:
         self._config_db = config_db
         self._chassis = chassis
 
+    def _should_skip_gnoi_shutdown(self, dpu_name: str):
+        """
+        Check whether the DPU is already offline / powered-down.
+
+        Returns:
+            True  - DPU is known to be offline/powered-down; skip gNOI shutdown.
+            False - DPU is known to be in another state; proceed with gNOI shutdown.
+            None  - Cannot determine status; caller should proceed with gNOI shutdown.
+        """
+        module_index = self._chassis.get_module_index(dpu_name)
+        if module_index < 0:
+            return None
+
+        module = self._chassis.get_module(module_index)
+        if module is None:
+            return None
+
+        oper_status = module.get_oper_status()
+        return oper_status in (
+            ModuleBase.MODULE_STATUS_OFFLINE,
+            ModuleBase.MODULE_STATUS_POWERED_DOWN,
+        )
+
     def _handle_transition(self, dpu_name: str, transition_type: str) -> bool:
         """
         Handle a shutdown or reboot transition for a DPU module.
@@ -131,28 +154,25 @@ class GnoiRebootHandler:
         # This avoids error logs when config reload or reboot is issued while DPUs are
         # already in the down state (e.g. admin_status was previously set to "down").
         try:
-            module_index = self._chassis.get_module_index(dpu_name)
-            if module_index >= 0:
-                module = self._chassis.get_module(module_index)
-                if module is not None:
-                    oper_status = module.get_oper_status()
-                    if oper_status in (ModuleBase.MODULE_STATUS_OFFLINE,
-                                       ModuleBase.MODULE_STATUS_POWERED_DOWN):
-                        logger.log_notice(
-                            f"{dpu_name}: DPU is already in '{oper_status}' state, "
-                            "skipping gNOI shutdown sequence"
-                        )
-                        cleared = self._clear_halt_flag(dpu_name)
-                        if not cleared:
-                            logger.log_warning(
-                                f"{dpu_name}: Failed to clear halt flag while skipping gNOI shutdown"
-                            )
-                        return cleared
+            skip = self._should_skip_gnoi_shutdown(dpu_name)
         except Exception as e:
             logger.log_warning(
                 f"{dpu_name}: Could not determine operational status ({e}), "
                 "proceeding with gNOI shutdown"
             )
+            skip = False
+
+        if skip:
+            logger.log_notice(
+                f"{dpu_name}: DPU is already offline/powered-down, "
+                "skipping gNOI shutdown sequence"
+            )
+            cleared = self._clear_halt_flag(dpu_name)
+            if not cleared:
+                logger.log_warning(
+                    f"{dpu_name}: Failed to clear halt flag while skipping gNOI shutdown"
+                )
+            return cleared
 
         # Wait for platform PCI detach completion
         if not self._wait_for_gnoi_halt_in_progress(dpu_name):

--- a/tests/gnoi_shutdown_daemon_test.py
+++ b/tests/gnoi_shutdown_daemon_test.py
@@ -200,6 +200,7 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
         # Mock module for clear operation
         mock_module = MagicMock()
+        mock_module.get_oper_status.return_value = "Online"
         mock_chassis.get_module_index.return_value = 0
         mock_chassis.get_module.return_value = mock_module
 
@@ -208,8 +209,6 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
             result = handler._handle_transition("DPU0", "shutdown")
 
         self.assertTrue(result)
-        mock_chassis.get_module_index.assert_called_with("DPU0")
-        mock_chassis.get_module.assert_called_with(0)
         mock_module.clear_module_gnoi_halt_in_progress.assert_called_once()
         self.assertEqual(mock_execute_command.call_count, 2)
 
@@ -248,6 +247,7 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
         # Mock module for clear operation
         mock_module = MagicMock()
+        mock_module.get_oper_status.return_value = "Online"
         mock_chassis.get_module_index.return_value = 0
         mock_chassis.get_module.return_value = mock_module
 
@@ -257,8 +257,6 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
         # Should still succeed - code proceeds anyway after timeout warning
         self.assertTrue(result)
-        mock_chassis.get_module_index.assert_called_with("DPU0")
-        mock_chassis.get_module.assert_called_with(0)
         mock_module.clear_module_gnoi_halt_in_progress.assert_called_once()
 
     def test_get_dpu_ip_and_port(self):
@@ -296,20 +294,19 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
         # Mock module for clear operation
         mock_module = MagicMock()
+        mock_module.get_oper_status.return_value = "Online"
         mock_chassis.get_module_index.return_value = 0
         mock_chassis.get_module.return_value = mock_module
 
         handler = gnoi_shutdown_daemon.GnoiRebootHandler(mock_db, mock_config_db, mock_chassis)
-        
+
         # Mock _wait_for_gnoi_halt_in_progress to return immediately to prevent hanging
         handler._wait_for_gnoi_halt_in_progress = MagicMock(return_value=True)
-        
+
         result = handler._handle_transition("DPU0", "shutdown")
 
         self.assertFalse(result)
         # Verify that clear_module_gnoi_halt_in_progress was called
-        mock_chassis.get_module_index.assert_called_with("DPU0")
-        mock_chassis.get_module.assert_called_with(0)
         mock_module.clear_module_gnoi_halt_in_progress.assert_called_once()
 
     @patch('gnoi_shutdown_daemon.get_dpu_ip', return_value="10.0.0.1")
@@ -519,21 +516,86 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
         # Mock module for clear operation
         mock_module = MagicMock()
+        mock_module.get_oper_status.return_value = "Online"
         mock_chassis.get_module_index.return_value = 0
         mock_chassis.get_module.return_value = mock_module
 
         handler = gnoi_shutdown_daemon.GnoiRebootHandler(mock_db, mock_config_db, mock_chassis)
-        
+
         # Mock _wait_for_gnoi_halt_in_progress to return immediately to prevent hanging
         handler._wait_for_gnoi_halt_in_progress = MagicMock(return_value=True)
-        
+
         result = handler._handle_transition("DPU0", "shutdown")
 
         self.assertFalse(result)
         # Verify that clear_module_gnoi_halt_in_progress was called
-        mock_chassis.get_module_index.assert_called_with("DPU0")
-        mock_chassis.get_module.assert_called_with(0)
         mock_module.clear_module_gnoi_halt_in_progress.assert_called_once()
+
+    def test_handle_transition_dpu_already_offline(self):
+        """Test that gNOI shutdown is skipped when DPU is already offline."""
+        mock_db = MagicMock()
+        mock_config_db = MagicMock()
+        mock_chassis = MagicMock()
+
+        # Mock module with Offline oper_status
+        mock_module = MagicMock()
+        mock_module.get_oper_status.return_value = "Offline"
+        mock_chassis.get_module_index.return_value = 0
+        mock_chassis.get_module.return_value = mock_module
+
+        handler = gnoi_shutdown_daemon.GnoiRebootHandler(mock_db, mock_config_db, mock_chassis)
+        result = handler._handle_transition("DPU0", "shutdown")
+
+        # Should return True (success) without attempting gNOI reboot
+        self.assertTrue(result)
+        mock_module.get_oper_status.assert_called_once()
+        mock_module.clear_module_gnoi_halt_in_progress.assert_called_once()
+
+    def test_handle_transition_dpu_powered_down(self):
+        """Test that gNOI shutdown is skipped when DPU is in PoweredDown state."""
+        mock_db = MagicMock()
+        mock_config_db = MagicMock()
+        mock_chassis = MagicMock()
+
+        # Mock module with PoweredDown oper_status
+        mock_module = MagicMock()
+        mock_module.get_oper_status.return_value = "PoweredDown"
+        mock_chassis.get_module_index.return_value = 0
+        mock_chassis.get_module.return_value = mock_module
+
+        handler = gnoi_shutdown_daemon.GnoiRebootHandler(mock_db, mock_config_db, mock_chassis)
+        result = handler._handle_transition("DPU0", "shutdown")
+
+        # Should return True (success) without attempting gNOI reboot
+        self.assertTrue(result)
+        mock_module.get_oper_status.assert_called_once()
+        mock_module.clear_module_gnoi_halt_in_progress.assert_called_once()
+
+    def test_handle_transition_oper_status_check_exception(self):
+        """Test that gNOI shutdown proceeds when oper_status check raises exception."""
+        mock_db = MagicMock()
+        mock_config_db = MagicMock()
+        mock_chassis = MagicMock()
+
+        # Mock module to raise exception on get_oper_status
+        mock_chassis.get_module_index.side_effect = Exception("Platform error")
+
+        handler = gnoi_shutdown_daemon.GnoiRebootHandler(mock_db, mock_config_db, mock_chassis)
+
+        # Mock remaining methods to prevent actual gNOI calls
+        handler._wait_for_gnoi_halt_in_progress = MagicMock(return_value=True)
+        handler._send_reboot_command = MagicMock(return_value=True)
+        handler._poll_reboot_status = MagicMock(return_value=True)
+        handler._clear_halt_flag = MagicMock(return_value=True)
+
+        with patch('gnoi_shutdown_daemon.get_dpu_ip', return_value="10.0.0.1"), \
+             patch('gnoi_shutdown_daemon.get_dpu_gnmi_port', return_value="8080"):
+            result = handler._handle_transition("DPU0", "shutdown")
+
+        # Should proceed with shutdown despite oper_status check failure
+        self.assertTrue(result)
+        handler._wait_for_gnoi_halt_in_progress.assert_called_once()
+        handler._send_reboot_command.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/tests/gnoi_shutdown_daemon_test.py
+++ b/tests/gnoi_shutdown_daemon_test.py
@@ -11,6 +11,7 @@ sys.modules['redis'] = MagicMock()
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'scripts')))
 
 import gnoi_shutdown_daemon
+from sonic_platform_base.module_base import ModuleBase
 
 # Common fixtures
 mock_message = {
@@ -200,7 +201,7 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
         # Mock module for clear operation
         mock_module = MagicMock()
-        mock_module.get_oper_status.return_value = "Online"
+        mock_module.get_oper_status.return_value = ModuleBase.MODULE_STATUS_ONLINE
         mock_chassis.get_module_index.return_value = 0
         mock_chassis.get_module.return_value = mock_module
 
@@ -247,7 +248,7 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
         # Mock module for clear operation
         mock_module = MagicMock()
-        mock_module.get_oper_status.return_value = "Online"
+        mock_module.get_oper_status.return_value = ModuleBase.MODULE_STATUS_ONLINE
         mock_chassis.get_module_index.return_value = 0
         mock_chassis.get_module.return_value = mock_module
 
@@ -294,7 +295,7 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
         # Mock module for clear operation
         mock_module = MagicMock()
-        mock_module.get_oper_status.return_value = "Online"
+        mock_module.get_oper_status.return_value = ModuleBase.MODULE_STATUS_ONLINE
         mock_chassis.get_module_index.return_value = 0
         mock_chassis.get_module.return_value = mock_module
 
@@ -516,7 +517,7 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
         # Mock module for clear operation
         mock_module = MagicMock()
-        mock_module.get_oper_status.return_value = "Online"
+        mock_module.get_oper_status.return_value = ModuleBase.MODULE_STATUS_ONLINE
         mock_chassis.get_module_index.return_value = 0
         mock_chassis.get_module.return_value = mock_module
 
@@ -539,7 +540,7 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
         # Mock module with Offline oper_status
         mock_module = MagicMock()
-        mock_module.get_oper_status.return_value = "Offline"
+        mock_module.get_oper_status.return_value = ModuleBase.MODULE_STATUS_OFFLINE
         mock_chassis.get_module_index.return_value = 0
         mock_chassis.get_module.return_value = mock_module
 
@@ -559,7 +560,7 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
         # Mock module with PoweredDown oper_status
         mock_module = MagicMock()
-        mock_module.get_oper_status.return_value = "PoweredDown"
+        mock_module.get_oper_status.return_value = ModuleBase.MODULE_STATUS_POWERED_DOWN
         mock_chassis.get_module_index.return_value = 0
         mock_chassis.get_module.return_value = mock_module
 
@@ -571,13 +572,64 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
         mock_module.get_oper_status.assert_called_once()
         mock_module.clear_module_gnoi_halt_in_progress.assert_called_once()
 
+    def test_handle_transition_dpu_fault_proceeds(self):
+        """Test that gNOI shutdown proceeds when DPU is in Fault state."""
+        mock_db = MagicMock()
+        mock_config_db = MagicMock()
+        mock_chassis = MagicMock()
+
+        # Mock module with Fault oper_status — should NOT skip
+        mock_module = MagicMock()
+        mock_module.get_oper_status.return_value = ModuleBase.MODULE_STATUS_FAULT
+        mock_chassis.get_module_index.return_value = 0
+        mock_chassis.get_module.return_value = mock_module
+
+        handler = gnoi_shutdown_daemon.GnoiRebootHandler(mock_db, mock_config_db, mock_chassis)
+
+        # Mock remaining methods to prevent actual gNOI calls
+        handler._wait_for_gnoi_halt_in_progress = MagicMock(return_value=True)
+        handler._send_reboot_command = MagicMock(return_value=True)
+        handler._poll_reboot_status = MagicMock(return_value=True)
+        handler._clear_halt_flag = MagicMock(return_value=True)
+
+        with patch('gnoi_shutdown_daemon.get_dpu_ip', return_value="10.0.0.1"), \
+             patch('gnoi_shutdown_daemon.get_dpu_gnmi_port', return_value="8080"):
+            result = handler._handle_transition("DPU0", "shutdown")
+
+        # Should proceed with shutdown for Fault state
+        self.assertTrue(result)
+        handler._wait_for_gnoi_halt_in_progress.assert_called_once()
+        handler._send_reboot_command.assert_called_once()
+
+    def test_handle_transition_dpu_offline_clear_halt_failure(self):
+        """Test that _clear_halt_flag failure is propagated when DPU is offline."""
+        mock_db = MagicMock()
+        mock_config_db = MagicMock()
+        mock_chassis = MagicMock()
+
+        # Mock module with Offline oper_status
+        mock_module = MagicMock()
+        mock_module.get_oper_status.return_value = ModuleBase.MODULE_STATUS_OFFLINE
+        mock_chassis.get_module_index.return_value = 0
+        mock_chassis.get_module.return_value = mock_module
+
+        handler = gnoi_shutdown_daemon.GnoiRebootHandler(mock_db, mock_config_db, mock_chassis)
+        # Make _clear_halt_flag fail
+        handler._clear_halt_flag = MagicMock(return_value=False)
+
+        result = handler._handle_transition("DPU0", "shutdown")
+
+        # Should return False since _clear_halt_flag failed
+        self.assertFalse(result)
+        handler._clear_halt_flag.assert_called_once_with("DPU0")
+
     def test_handle_transition_oper_status_check_exception(self):
         """Test that gNOI shutdown proceeds when oper_status check raises exception."""
         mock_db = MagicMock()
         mock_config_db = MagicMock()
         mock_chassis = MagicMock()
 
-        # Mock module to raise exception on get_oper_status
+        # Mock module to raise exception on get_module_index
         mock_chassis.get_module_index.side_effect = Exception("Platform error")
 
         handler = gnoi_shutdown_daemon.GnoiRebootHandler(mock_db, mock_config_db, mock_chassis)

--- a/tests/gnoi_shutdown_daemon_test.py
+++ b/tests/gnoi_shutdown_daemon_test.py
@@ -532,6 +532,67 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
         # Verify that clear_module_gnoi_halt_in_progress was called
         mock_module.clear_module_gnoi_halt_in_progress.assert_called_once()
 
+    def test_should_skip_gnoi_shutdown_offline(self):
+        """Test _should_skip_gnoi_shutdown returns True for Offline DPU."""
+        mock_chassis = MagicMock()
+        mock_module = MagicMock()
+        mock_module.get_oper_status.return_value = ModuleBase.MODULE_STATUS_OFFLINE
+        mock_chassis.get_module_index.return_value = 0
+        mock_chassis.get_module.return_value = mock_module
+
+        handler = gnoi_shutdown_daemon.GnoiRebootHandler(MagicMock(), MagicMock(), mock_chassis)
+        self.assertTrue(handler._should_skip_gnoi_shutdown("DPU0"))
+
+    def test_should_skip_gnoi_shutdown_powered_down(self):
+        """Test _should_skip_gnoi_shutdown returns True for PoweredDown DPU."""
+        mock_chassis = MagicMock()
+        mock_module = MagicMock()
+        mock_module.get_oper_status.return_value = ModuleBase.MODULE_STATUS_POWERED_DOWN
+        mock_chassis.get_module_index.return_value = 0
+        mock_chassis.get_module.return_value = mock_module
+
+        handler = gnoi_shutdown_daemon.GnoiRebootHandler(MagicMock(), MagicMock(), mock_chassis)
+        self.assertTrue(handler._should_skip_gnoi_shutdown("DPU0"))
+
+    def test_should_skip_gnoi_shutdown_online(self):
+        """Test _should_skip_gnoi_shutdown returns False for Online DPU."""
+        mock_chassis = MagicMock()
+        mock_module = MagicMock()
+        mock_module.get_oper_status.return_value = ModuleBase.MODULE_STATUS_ONLINE
+        mock_chassis.get_module_index.return_value = 0
+        mock_chassis.get_module.return_value = mock_module
+
+        handler = gnoi_shutdown_daemon.GnoiRebootHandler(MagicMock(), MagicMock(), mock_chassis)
+        self.assertFalse(handler._should_skip_gnoi_shutdown("DPU0"))
+
+    def test_should_skip_gnoi_shutdown_fault(self):
+        """Test _should_skip_gnoi_shutdown returns False for Fault DPU."""
+        mock_chassis = MagicMock()
+        mock_module = MagicMock()
+        mock_module.get_oper_status.return_value = ModuleBase.MODULE_STATUS_FAULT
+        mock_chassis.get_module_index.return_value = 0
+        mock_chassis.get_module.return_value = mock_module
+
+        handler = gnoi_shutdown_daemon.GnoiRebootHandler(MagicMock(), MagicMock(), mock_chassis)
+        self.assertFalse(handler._should_skip_gnoi_shutdown("DPU0"))
+
+    def test_should_skip_gnoi_shutdown_bad_index(self):
+        """Test _should_skip_gnoi_shutdown returns None when module index is negative."""
+        mock_chassis = MagicMock()
+        mock_chassis.get_module_index.return_value = -1
+
+        handler = gnoi_shutdown_daemon.GnoiRebootHandler(MagicMock(), MagicMock(), mock_chassis)
+        self.assertIsNone(handler._should_skip_gnoi_shutdown("DPU0"))
+
+    def test_should_skip_gnoi_shutdown_no_module(self):
+        """Test _should_skip_gnoi_shutdown returns None when module is None."""
+        mock_chassis = MagicMock()
+        mock_chassis.get_module_index.return_value = 0
+        mock_chassis.get_module.return_value = None
+
+        handler = gnoi_shutdown_daemon.GnoiRebootHandler(MagicMock(), MagicMock(), mock_chassis)
+        self.assertIsNone(handler._should_skip_gnoi_shutdown("DPU0"))
+
     def test_handle_transition_dpu_already_offline(self):
         """Test that gNOI shutdown is skipped when DPU is already offline."""
         mock_db = MagicMock()


### PR DESCRIPTION
**What I did**

Added an operational status check in `gnoi_shutdown_daemon.py` `_handle_transition()` to skip the gNOI Reboot HALT sequence when the DPU is already not Online (e.g. Offline, PoweredDown).

**Why I did it**

Fixes https://github.com/sonic-net/sonic-buildimage/issues/25889

When DPUs are configured with `admin_status: "down"` and are already powered off, a config reload or reboot repopulates CONFIG_DB, which triggers `gnoi-shutdown-daemon` to attempt a gNOI Reboot HALT command on DPUs that are already offline — producing error logs:

```
ERR gnoi-shutdown-daemon[12171]: DPU0: Reboot command failed
ERR gnoi-shutdown-daemon[12171]: DPU0: Failed to send Reboot command
```

**How I verified it**

- Added unit tests for the new behavior:
  - `test_handle_transition_dpu_already_offline` — verifies skip when DPU is in `Offline` state
  - `test_handle_transition_dpu_powered_down` — verifies skip when DPU is in `PoweredDown` state
  - `test_handle_transition_oper_status_check_exception` — verifies graceful fallback when the oper status check raises an exception
- Updated existing tests to mock `get_oper_status()` returning `Online` so they continue testing the normal gNOI shutdown flow
- Manually verified the logic with mock tests

**Details if related**

The fix queries `get_oper_status()` via the platform chassis API at the start of `_handle_transition()`. If the DPU is not `Online`, the method logs a notice, clears the halt flag, and returns success — avoiding any gNOI RPC calls to unreachable DPUs. The check is wrapped in try/except so that if the platform API fails, the daemon falls back to the existing behavior.