### PR TITLE
Fix featured to skip enable/start for static services

### DIFF
--- a/scripts/featured
+++ b/scripts/featured
@@ -420,9 +420,14 @@ class FeatureHandler(object):
 
         feature_names, feature_suffixes = self.get_multiasic_feature_instances(feature)
         for feature_name in feature_names:
-            # Check if it is already enabled, if yes skip the system call
+            # Check if it is already enabled or static, if yes skip the system call.
+            # "static" means the service has no [Install] section — it cannot be enabled
+            # via systemctl enable, and attempting to do so is a no-op. These services
+            # are managed by featured (start/stop) and do not need unmask/enable calls.
+            # Skipping them avoids redundant systemctl start calls that can push services
+            # past their StartLimitBurst during rapid config reloads.
             unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
-            if unit_file_state == "enabled" or not unit_file_state:
+            if unit_file_state in ("enabled", "static") or not unit_file_state:
                 continue
             cmds = []
             for suffix in feature_suffixes:


### PR DESCRIPTION
#### Why I did it

Container services (pmon, lldp, gnmi, snmp, telemetry, sflow, bmp, mgmt-framework) have \\UnitFileState=static\\ because their service templates have no \\[Install]\\ section. In \\nable_feature()\\, the check \\if unit_file_state == 'enabled'\\ fails for these services, so featured proceeds to run:

\\\
systemctl unmask → systemctl enable (fails silently) → systemctl start
\\\

The redundant \\systemctl start\\ adds an extra start attempt on every config reload. After 3+ reloads within \\StartLimitIntervalSec=1200s\\, services like pmon exceed \\StartLimitBurst=3\\ and enter \\start-limit-hit\\.

This regression was introduced by the \\aise_exception=False\\ change for Trixie compatibility ([line 440-452](https://github.com/sonic-net/sonic-host-services/blob/202511/scripts/featured#L440-L452)). On 202505, \\aise_exception=True\\ caused the enable failure to be caught → state set to FAILED → \\systemctl start\\ was never reached. On 202511, the failure is silently ignored → start proceeds → accumulates past the rate limit.

Fixes: sonic-net/sonic-buildimage#25931

##### Work item tracking
- Microsoft ADO: 36811868

#### How I did it

Changed the skip check in \\nable_feature()\\ from:
\\\python
if unit_file_state == 'enabled' or not unit_file_state:
    continue
\\\
to:
\\\python
if unit_file_state in ('enabled', 'static') or not unit_file_state:
    continue
\\\

This skips the unmask/enable/start sequence for static services, since:
- \\systemctl enable\\ is a no-op for static services (no \\[Install]\\ section)
- The redundant \\systemctl start\\ is what causes \\start-limit-hit\\
- These services are already managed by featured's start/stop logic elsewhere

#### How to verify it

1. On a 202511 DUT, run \\	est_load_minigraph_with_golden_config\\ which performs 4 consecutive config reloads
2. pmon should NOT hit \\start-limit-hit\\ on the 4th reload
3. Verify pmon is running: \\docker ps | grep pmon\\

#### Related PRs
- sonic-net/sonic-utilities#4314 — complementary fix for \\_reset_failed_services()\\ (defense-in-depth)
- sonic-net/sonic-mgmt#22775 — conditional skip for the affected test

#### Description for the changelog

Fix featured to skip redundant enable/start for static services, preventing start-limit-hit after multiple config reloads.