### PR TITLE
[pipeline] Use sonic-slave-trixie build container image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,15 +82,15 @@ stages:
         sudo apt-get update
         sudo apt-get -y install apt-transport-https ca-certificates curl gnupg lsb-release
 
-        # Download and import key
-        curl -sLS https://packages.microsoft.com/keys/microsoft.asc | \
-          gpg --dearmor | sudo tee /usr/share/keyrings/microsoft.gpg > /dev/null
+        # Download Microsoft signing key
+        sudo mkdir -p /etc/apt/keyrings
+        curl -sSL https://packages.microsoft.com/keys/microsoft.asc | \
+          gpg --dearmor | sudo tee /usr/share/keyrings/microsoft-keyring.gpg > /dev/null
         
-        # Also add to trusted.gpg.d for sqv
-        sudo cp /usr/share/keyrings/microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
-        
-        echo "deb [arch=amd64] https://packages.microsoft.com/debian/13/prod trixie main" | \
+        # Add repo with signed-by pointing to the keyring
+        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-keyring.gpg] https://packages.microsoft.com/debian/13/prod trixie main" | \
           sudo tee /etc/apt/sources.list.d/microsoft.list
+        
         sudo apt-get update
         sudo apt-get install -y dotnet-sdk-8.0
       displayName: "Install .NET CORE"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,19 +75,12 @@ stages:
         sudo pip3 install sonic_utilities-1.2-py3-none-any.whl
       workingDirectory: $(Pipeline.Workspace)/target/python-wheels/trixie/
       displayName: 'Install Python dependencies'
-    
-    - script: |
-        set -ex
-        cat /etc/os-release || true
-        uname -a || true
-        cat /etc/debian_version || true
-      displayName: "Debug: container OS info"
 
     - script: |
         set -ex
         # Install .NET CORE
         curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-        sudo apt-add-repository https://packages.microsoft.com/debian/12/prod
+        sudo apt-add-repository https://packages.microsoft.com/debian/13/prod
         sudo apt-get update
         sudo apt-get install -y dotnet-sdk-8.0
       displayName: "Install .NET CORE"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ stages:
           gpg --dearmor | sudo tee /usr/share/keyrings/microsoft-keyring.gpg > /dev/null
         
         # Add repo with signed-by pointing to the keyring
-        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-keyring.gpg] https://packages.microsoft.com/debian/13/prod trixie main" | \
+        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-keyring.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" | \
           sudo tee /etc/apt/sources.list.d/microsoft.list
         
         sudo apt-get update

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,6 +75,13 @@ stages:
         sudo pip3 install sonic_utilities-1.2-py3-none-any.whl
       workingDirectory: $(Pipeline.Workspace)/target/python-wheels/trixie/
       displayName: 'Install Python dependencies'
+    
+    - script: |
+        set -ex
+        cat /etc/os-release || true
+        uname -a || true
+        cat /etc/debian_version || true
+      displayName: "Debug: container OS info"
 
     - script: |
         set -ex

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,14 +79,15 @@ stages:
     - script: |
         set -ex
         # Install .NET CORE
-        if ! command -v gpg &> /dev/null; then
-          sudo apt-get update
-          sudo apt-get install -y gnupg
-        fi
+        sudo apt-get update
+        sudo apt-get -y install apt-transport-https ca-certificates curl gnupg lsb-release
+
+        # Download and import key
         sudo mkdir -p /etc/apt/keyrings
         curl -sLS https://packages.microsoft.com/keys/microsoft.asc | \
           gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
         sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
+        
         echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/debian/13/prod trixie main" | \
           sudo tee /etc/apt/sources.list.d/microsoft.list
         sudo apt-get update

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ stages:
       vmImage: ubuntu-24.04
 
     container:
-      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm-amd64:$(BUILD_BRANCH)
+      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-trixie-amd64:$(BUILD_BRANCH)
 
     steps:
     - checkout: self

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ stages:
       vmImage: ubuntu-24.04
 
     container:
-      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-trixie-amd64:$(BUILD_BRANCH)
+      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-trixie:$(BUILD_BRANCH)-amd64
 
     steps:
     - checkout: self

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,10 +85,10 @@ stages:
         # Download and import key
         sudo mkdir -p /etc/apt/keyrings
         curl -sLS https://packages.microsoft.com/keys/microsoft.asc | \
-          gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
-        sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
+          sudo tee /etc/apt/keyrings/microsoft.asc > /dev/null
+        sudo chmod go+r /etc/apt/keyrings/microsoft.asc
         
-        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/debian/13/prod trixie main" | \
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.asc] https://packages.microsoft.com/debian/13/prod trixie main" | \
           sudo tee /etc/apt/sources.list.d/microsoft.list
         sudo apt-get update
         sudo apt-get install -y dotnet-sdk-8.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,11 +55,12 @@ stages:
         sudo dpkg -i libnl-genl-3-200_*.deb
         sudo dpkg -i libnl-route-3-200_*.deb
         sudo dpkg -i libnl-nf-3-200_*.deb
+        sudo dpkg -i libpcre3_*.deb
         sudo dpkg -i libyang_1.0.73_*.deb
         sudo dpkg -i libswsscommon_1.0.0_amd64.deb
         sudo dpkg -i libswsscommon-dev_1.0.0_amd64.deb
         sudo dpkg -i python3-swsscommon_1.0.0_amd64.deb
-      workingDirectory: $(Pipeline.Workspace)/target/debs/bookworm/
+      workingDirectory: $(Pipeline.Workspace)/target/debs/trixie/
       displayName: 'Install Debian dependencies'
 
     - script: |
@@ -72,7 +73,7 @@ stages:
         sudo pip3 install sonic_config_engine-1.0-py3-none-any.whl
         sudo pip3 install sonic_platform_common-1.0-py3-none-any.whl
         sudo pip3 install sonic_utilities-1.2-py3-none-any.whl
-      workingDirectory: $(Pipeline.Workspace)/target/python-wheels/bookworm/
+      workingDirectory: $(Pipeline.Workspace)/target/python-wheels/trixie/
       displayName: 'Install Python dependencies'
 
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,12 +83,13 @@ stages:
         sudo apt-get -y install apt-transport-https ca-certificates curl gnupg lsb-release
 
         # Download and import key
-        sudo mkdir -p /etc/apt/keyrings
         curl -sLS https://packages.microsoft.com/keys/microsoft.asc | \
-          sudo tee /etc/apt/keyrings/microsoft.asc > /dev/null
-        sudo chmod go+r /etc/apt/keyrings/microsoft.asc
+          gpg --dearmor | sudo tee /usr/share/keyrings/microsoft.gpg > /dev/null
         
-        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.asc] https://packages.microsoft.com/debian/13/prod trixie main" | \
+        # Also add to trusted.gpg.d for sqv
+        sudo cp /usr/share/keyrings/microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
+        
+        echo "deb [arch=amd64] https://packages.microsoft.com/debian/13/prod trixie main" | \
           sudo tee /etc/apt/sources.list.d/microsoft.list
         sudo apt-get update
         sudo apt-get install -y dotnet-sdk-8.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,8 +79,16 @@ stages:
     - script: |
         set -ex
         # Install .NET CORE
-        curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-        sudo apt-add-repository https://packages.microsoft.com/debian/13/prod
+        if ! command -v gpg &> /dev/null; then
+          sudo apt-get update
+          sudo apt-get install -y gnupg
+        fi
+        sudo mkdir -p /etc/apt/keyrings
+        curl -sLS https://packages.microsoft.com/keys/microsoft.asc | \
+          gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
+        sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/debian/13/prod trixie main" | \
+          sudo tee /etc/apt/sources.list.d/microsoft.list
         sudo apt-get update
         sudo apt-get install -y dotnet-sdk-8.0
       displayName: "Install .NET CORE"


### PR DESCRIPTION
## Summary
Update the Azure Pipelines build container image used by `sonic-host-services` from the Bookworm-based slave image to the Trixie-based slave image.

## Motivation / Background
The current pipeline runs in a Bookworm slave container. Moving to the updated Trixie slave image aligns the build environment with the newer Boost version expected by the downloaded artifacts and matches the newer slave image naming convention (arch encoded in the tag).

## Changes
- **azure-pipelines.yml**
  - Container image updated:
    - from: `sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm-amd64:$(BUILD_BRANCH)`
    - to:   `sonicdev-microsoft.azurecr.io:443/sonic-slave-trixie:$(BUILD_BRANCH)-amd64`

## Testing
- CI pipeline run for this PR (Azure Pipelines).