### PR TITLE
Fix test flakiness due to time.time() calls

### DIFF
--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -204,13 +204,14 @@ class TestReboot(object):
         with (
             mock.patch("reboot._run_command") as mock_run_command,
             mock.patch("time.sleep") as mock_sleep,
+            mock.patch("time.time", return_value=TEST_TIMESTAMP),
             mock.patch("reboot.Reboot.populate_reboot_status_flag") as mock_populate_reboot_status_flag,
         ):
             mock_run_command.return_value = (0, ["stdout: execute WARM reboot"], ["stderror: execute WARM reboot"])
             self.reboot_module.execute_reboot("WARM")
             mock_run_command.assert_called_once_with("sudo warm-reboot")
             mock_sleep.assert_called_once_with(260)
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int(time.time()), "Reboot command failed to execute", 'WARM', RebootStatus.STATUS_FAILURE)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int(TEST_TIMESTAMP), "Reboot command failed to execute", 'WARM', RebootStatus.STATUS_FAILURE)
 
     def test_execute_reboot_fail_unknown_reboot(self, caplog):
         with caplog.at_level(logging.ERROR):
@@ -221,6 +222,7 @@ class TestReboot(object):
     def test_execute_reboot_fail_issue_reboot_command_cold_boot(self, caplog):
         with (
             mock.patch("reboot._run_command") as mock_run_command,
+            mock.patch("time.time", return_value=TEST_TIMESTAMP),
             mock.patch("reboot.Reboot.populate_reboot_status_flag") as mock_populate_reboot_status_flag,
             caplog.at_level(logging.ERROR),
         ):
@@ -230,11 +232,12 @@ class TestReboot(object):
                     "stdout: ['stdout: execute cold reboot'], stderr: "
                     "['stderror: execute cold reboot']")
             assert caplog.records[0].message == msg
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 1, RebootStatus.STATUS_FAILURE)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int(TEST_TIMESTAMP), "Failed to execute reboot command", 1, RebootStatus.STATUS_FAILURE)
 
     def test_execute_reboot_fail_issue_reboot_command_halt(self, caplog):
         with (
             mock.patch("reboot._run_command") as mock_run_command,
+            mock.patch("time.time", return_value=TEST_TIMESTAMP),
             mock.patch("reboot.Reboot.populate_reboot_status_flag") as mock_populate_reboot_status_flag,
             caplog.at_level(logging.ERROR),
         ):
@@ -244,7 +247,7 @@ class TestReboot(object):
                    "stdout: ['stdout: execute halt reboot'], stderr: "
                    "['stderror: execute halt reboot']")
             assert caplog.records[0].message == msg
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 3, RebootStatus.STATUS_FAILURE)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int(TEST_TIMESTAMP), "Failed to execute reboot command", 3, RebootStatus.STATUS_FAILURE)
 
     def test_execute_reboot_success_halt(self):
         with (
@@ -265,6 +268,7 @@ class TestReboot(object):
         with (
             mock.patch("reboot._run_command") as mock_run_command,
             mock.patch("time.sleep") as mock_sleep,
+            mock.patch("time.time", return_value=TEST_TIMESTAMP),
             mock.patch("reboot.Reboot.is_halt_command_running", return_value=True) as mock_is_halt_command_running,
             mock.patch("reboot.Reboot.is_container_running", return_value=True) as mock_is_container_running,
             mock.patch("reboot.Reboot.populate_reboot_status_flag") as mock_populate_reboot_status_flag,
@@ -276,11 +280,12 @@ class TestReboot(object):
             mock_sleep.assert_called_with(5)
             mock_is_halt_command_running.assert_called()
             assert any("HALT reboot failed: Services are still running" in record.message for record in caplog.records)
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int(time.time()), 'Halt reboot did not complete', 3, RebootStatus.STATUS_FAILURE)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int(TEST_TIMESTAMP), 'Halt reboot did not complete', 3, RebootStatus.STATUS_FAILURE)
 
     def test_execute_reboot_fail_issue_reboot_command_warm(self, caplog):
         with (
             mock.patch("reboot._run_command") as mock_run_command,
+            mock.patch("time.time", return_value=TEST_TIMESTAMP),
             mock.patch("reboot.Reboot.populate_reboot_status_flag") as mock_populate_reboot_status_flag,
             caplog.at_level(logging.ERROR),
         ):
@@ -290,7 +295,7 @@ class TestReboot(object):
                     "stdout: ['stdout: execute WARM reboot'], stderr: "
                     "['stderror: execute WARM reboot']")
             assert caplog.records[0].message == msg
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 'WARM', RebootStatus.STATUS_FAILURE)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, int(TEST_TIMESTAMP), "Failed to execute reboot command", 'WARM', RebootStatus.STATUS_FAILURE)
 
     def test_issue_reboot_success_cold_boot(self):
         with (


### PR DESCRIPTION
Fixes: https://github.com/sonic-net/sonic-mgmt/issues/23745

In the reboot_test.py, the assert calls check for the exact timestamp to match. However sometimes there is a delay between when the call is made and when the assert is checked. If this delay is greater than 1 second, the timestamps diverge and the assert fails. This is a flakiness introduced by the test framework and hence we should mock it and make it more robust.