### PR TITLE
Fix race condition leaving orphaned BGP containers on chassis supervisor

### DIFF
--- a/scripts/featured
+++ b/scripts/featured
@@ -398,6 +398,31 @@ class FeatureHandler(object):
 
         return feature_names, feature_suffixes
 
+    WAIT_FOR_STABLE_TIMEOUT = 60
+    WAIT_FOR_STABLE_POLL_INTERVAL = 1
+
+    def wait_for_service_stable(self, unit):
+        """Wait for a systemd service to leave 'activating' state before stopping it.
+
+        Sending systemctl stop while a service is in 'activating' (ExecStartPre) kills the
+        startup script via SIGTERM without running ExecStop, which can leave Docker containers
+        orphaned. Waiting for a stable state ensures ExecStop runs on stop.
+        """
+        deadline = time.time() + self.WAIT_FOR_STABLE_TIMEOUT
+        while time.time() < deadline:
+            cmd = ["systemctl", "is-active", unit]
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, _ = proc.communicate()
+            state = stdout.decode().strip() if isinstance(stdout, bytes) else stdout.strip()
+            if state != "activating":
+                return state
+            syslog.syslog(syslog.LOG_INFO,
+                          "Waiting for '{}' to leave activating state".format(unit))
+            time.sleep(self.WAIT_FOR_STABLE_POLL_INTERVAL)
+        syslog.syslog(syslog.LOG_WARNING,
+                      "Timed out waiting for '{}' to leave activating state".format(unit))
+        return "activating"
+
     def get_systemd_unit_state(self, unit):
         """ Returns service configuration """
 
@@ -474,6 +499,11 @@ class FeatureHandler(object):
             unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
             if unit_file_state in ("disabled", "masked"):
                 continue
+            # Wait for the service to leave 'activating' state before stopping it.
+            # Stopping during ExecStartPre kills the startup script without running
+            # ExecStop, leaving Docker containers orphaned (see issue #24875).
+            service_unit = "{}.{}".format(feature_name, feature_suffixes[-1])
+            self.wait_for_service_stable(service_unit)
             cmds = []
             for suffix in reversed(feature_suffixes):
                 cmds.append(["sudo", "systemctl", "stop", "{}.{}".format(feature_name, suffix)])

--- a/tests/featured/featured_test.py
+++ b/tests/featured/featured_test.py
@@ -565,3 +565,129 @@ class TestFeatureDaemon(TestCase):
 
                 # Verify the feature state was not enabled in the cache
                 assert feature_handler._cached_config[feature.name].state != 'enabled'
+
+
+class TestWaitForServiceStable(TestCase):
+    """Tests for wait_for_service_stable method that prevents orphaned containers."""
+
+    def _create_handler(self):
+        feature_state_table_mock = mock.Mock()
+        device_cfg = {"DEVICE_METADATA": {"localhost": {"type": "ToRRouter"}}}
+        handler = featured.FeatureHandler(MockConfigDb(), feature_state_table_mock, device_cfg, False)
+        return handler
+
+    @mock.patch("featured.subprocess")
+    @mock.patch("featured.time.sleep")
+    def test_service_already_active(self, mock_sleep, mock_subprocess):
+        """Service is already 'active' — should return immediately without polling."""
+        handler = self._create_handler()
+        popen_mock = mock.Mock()
+        popen_mock.communicate.return_value = (b"active\n", b"")
+        popen_mock.returncode = 0
+        mock_subprocess.Popen.return_value = popen_mock
+
+        result = handler.wait_for_service_stable("bgp@3.service")
+
+        assert result == "active"
+        mock_sleep.assert_not_called()
+
+    @mock.patch("featured.subprocess")
+    @mock.patch("featured.time.sleep")
+    def test_service_inactive(self, mock_sleep, mock_subprocess):
+        """Service is 'inactive' — should return immediately."""
+        handler = self._create_handler()
+        popen_mock = mock.Mock()
+        popen_mock.communicate.return_value = (b"inactive\n", b"")
+        popen_mock.returncode = 0
+        mock_subprocess.Popen.return_value = popen_mock
+
+        result = handler.wait_for_service_stable("bgp@3.service")
+
+        assert result == "inactive"
+        mock_sleep.assert_not_called()
+
+    @mock.patch("featured.subprocess")
+    @mock.patch("featured.time.sleep")
+    def test_service_transitions_from_activating_to_active(self, mock_sleep, mock_subprocess):
+        """Service starts in 'activating' then transitions to 'active' — should poll and return."""
+        handler = self._create_handler()
+
+        popen_mocks = []
+        for state in [b"activating\n", b"activating\n", b"active\n"]:
+            m = mock.Mock()
+            m.communicate.return_value = (state, b"")
+            m.returncode = 0
+            popen_mocks.append(m)
+
+        mock_subprocess.Popen.side_effect = popen_mocks
+
+        result = handler.wait_for_service_stable("bgp@3.service")
+
+        assert result == "active"
+        assert mock_sleep.call_count == 2
+
+    @mock.patch("featured.subprocess")
+    @mock.patch("featured.time.sleep")
+    @mock.patch("featured.time.time")
+    def test_service_activating_timeout(self, mock_time, mock_sleep, mock_subprocess):
+        """Service stays 'activating' past timeout — should return 'activating'."""
+        handler = self._create_handler()
+
+        # Simulate time progressing past the timeout
+        mock_time.side_effect = [0.0, 1.0, 2.0, 61.0]
+
+        popen_mock = mock.Mock()
+        popen_mock.communicate.return_value = (b"activating\n", b"")
+        popen_mock.returncode = 0
+        mock_subprocess.Popen.return_value = popen_mock
+
+        result = handler.wait_for_service_stable("bgp@3.service")
+
+        assert result == "activating"
+
+    @mock.patch("featured.subprocess")
+    @mock.patch("featured.time.sleep")
+    def test_service_failed(self, mock_sleep, mock_subprocess):
+        """Service is 'failed' — should return immediately."""
+        handler = self._create_handler()
+        popen_mock = mock.Mock()
+        popen_mock.communicate.return_value = (b"failed\n", b"")
+        popen_mock.returncode = 0
+        mock_subprocess.Popen.return_value = popen_mock
+
+        result = handler.wait_for_service_stable("bgp@3.service")
+
+        assert result == "failed"
+        mock_sleep.assert_not_called()
+
+    @mock.patch("syslog.syslog", side_effect=syslog_side_effect)
+    def test_disable_feature_calls_wait_for_service_stable(self, mock_syslog):
+        """Verify disable_feature calls wait_for_service_stable before systemctl stop."""
+        handler = self._create_handler()
+
+        feat_cfg = {"state": "disabled", "auto_restart": "enabled"}
+        feature = featured.Feature("bgp", feat_cfg)
+
+        call_order = []
+
+        def track_wait(unit):
+            call_order.append(("wait", unit))
+            return "active"
+
+        def track_run_cmd(cmd, **kwargs):
+            call_order.append(("cmd", cmd))
+
+        with mock.patch.object(handler, "get_multiasic_feature_instances",
+                               return_value=(["bgp@3"], ["service"])), \
+             mock.patch.object(handler, "get_systemd_unit_state", return_value="enabled"), \
+             mock.patch.object(handler, "wait_for_service_stable", side_effect=track_wait), \
+             mock.patch("featured.run_cmd", side_effect=track_run_cmd), \
+             mock.patch.object(handler, "set_feature_state"):
+
+            handler.disable_feature(feature)
+
+            # Verify wait was called before stop
+            assert len(call_order) >= 2
+            assert call_order[0] == ("wait", "bgp@3.service")
+            assert call_order[1][0] == "cmd"
+            assert "stop" in call_order[1][1]


### PR DESCRIPTION
#### What I did

Fix race condition that leaves orphaned BGP Docker containers on T2 Chassis Supervisor during first boot.

#### How I did it

Added `wait_for_service_stable()` method to `FeatureHandler` that polls `systemctl is-active` until the service leaves `activating` state before sending `systemctl stop`. This ensures ExecStop runs properly, which tears down Docker containers cleanly.

**Root cause:** On T2 chassis boot, `sonic.target` starts BGP services via systemd while `featured` daemon concurrently reads FEATURE table and sees BGP `state: disabled` on Supervisor. `featured` calls `systemctl stop` while the service is still in `activating` (ExecStartPre) phase. Systemd sends SIGTERM to the startup script without running ExecStop, leaving Docker containers running without any systemd service managing them.

**Fix:** Before calling `systemctl stop` in `disable_feature()`, wait for the service to leave `activating` state (60s timeout, 1s poll). Once the service reaches `active`, `inactive`, or `failed` state, `systemctl stop` will properly execute ExecStop and clean up Docker containers.

#### How to verify it

1. On T2 chassis supervisor with multi-ASIC, configure BGP as disabled on supervisor
2. Reboot the system
3. Verify no orphaned BGP Docker containers remain after featured processes the config
4. Previously, `docker ps` would show bgp containers running without corresponding systemd services

#### Which release branch to backport

202405

#### Unit test results

All 38 tests pass (32 existing + 6 new):

```
tests/featured/featured_test.py::TestWaitForServiceStable::test_service_already_active PASSED
tests/featured/featured_test.py::TestWaitForServiceStable::test_service_inactive PASSED
tests/featured/featured_test.py::TestWaitForServiceStable::test_service_failed PASSED
tests/featured/featured_test.py::TestWaitForServiceStable::test_service_transitions_from_activating_to_active PASSED
tests/featured/featured_test.py::TestWaitForServiceStable::test_service_activating_timeout PASSED
tests/featured/featured_test.py::TestWaitForServiceStable::test_disable_feature_calls_wait_for_service_stable PASSED

============================== 38 passed in 0.69s ==============================
```

Fixes https://github.com/sonic-net/sonic-buildimage/issues/24875

Signed-off-by: Deepak Singhal <deepsinghal@microsoft.com>