### PR TITLE
Fix for PMON restart fails with Error "All critical services should be fully started!"

### DIFF
--- a/scripts/featured
+++ b/scripts/featured
@@ -434,6 +434,12 @@ class FeatureHandler(object):
             # otherwise, start/enable corresponding systemd .service unit
 
             cmds.append(["sudo", "systemctl", "enable", "{}.{}".format(feature_name, feature_suffixes[-1])])
+            # Reset any accumulated start-limit-hit counter before starting. featured issues
+            # deliberate, externally-triggered starts (e.g. after PortInitDone), so it is safe
+            # to clear the rate-limit state even if systemd's own Restart= loop would normally
+            # be subject to StartLimitBurst. reset-failed is idempotent and returns 0 when the
+            # service is not in a failed state.
+            cmds.append(["sudo", "systemctl", "reset-failed", "{}.{}".format(feature_name, feature_suffixes[-1])])
             cmds.append(["sudo", "systemctl", "start", "{}.{}".format(feature_name, feature_suffixes[-1])])
 
             for cmd in cmds:

--- a/scripts/featured
+++ b/scripts/featured
@@ -435,10 +435,10 @@ class FeatureHandler(object):
 
             cmds.append(["sudo", "systemctl", "enable", "{}.{}".format(feature_name, feature_suffixes[-1])])
             # Reset any accumulated start-limit-hit counter before starting. featured issues
-            # deliberate, externally-triggered starts (e.g. after PortInitDone), so it is safe
-            # to clear the rate-limit state even if systemd's own Restart= loop would normally
-            # be subject to StartLimitBurst. reset-failed is idempotent and returns 0 when the
-            # service is not in a failed state.
+            # deliberate, externally-triggered starts, so it is safe to clear the rate-limit
+            # state even if systemd's own Restart= loop would normally be subject to
+            # StartLimitBurst. reset-failed is idempotent and returns 0 when the service is
+            # not in a failed state.
             cmds.append(["sudo", "systemctl", "reset-failed", "{}.{}".format(feature_name, feature_suffixes[-1])])
             cmds.append(["sudo", "systemctl", "start", "{}.{}".format(feature_name, feature_suffixes[-1])])
 

--- a/tests/featured/featured_test.py
+++ b/tests/featured/featured_test.py
@@ -414,10 +414,12 @@ class TestFeatureDaemon(TestCase):
             expected = [call(['sudo', 'systemctl', 'daemon-reload'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'unmask', 'dhcp_relay.service'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'enable', 'dhcp_relay.service'], capture_output=True, check=True, text=True),
+                        call(['sudo', 'systemctl', 'reset-failed', 'dhcp_relay.service'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'start', 'dhcp_relay.service'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'daemon-reload'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'unmask', 'mux.service'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'enable', 'mux.service'], capture_output=True, check=True, text=True),
+                        call(['sudo', 'systemctl', 'reset-failed', 'mux.service'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'start', 'mux.service'], capture_output=True, check=True, text=True)]
             mocked_subprocess.run.assert_has_calls(expected, any_order=True)
 
@@ -455,10 +457,12 @@ class TestFeatureDaemon(TestCase):
             expected = [call(['sudo', 'systemctl', 'daemon-reload'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'unmask', 'dhcp_relay.service'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'enable', 'dhcp_relay.service'], capture_output=True, check=True, text=True),
+                        call(['sudo', 'systemctl', 'reset-failed', 'dhcp_relay.service'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'start', 'dhcp_relay.service'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'daemon-reload'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'unmask', 'mux.service'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'enable', 'mux.service'], capture_output=True, check=True, text=True),
+                        call(['sudo', 'systemctl', 'reset-failed', 'mux.service'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'start', 'mux.service'], capture_output=True, check=True, text=True)]
 
             mocked_subprocess.run.assert_has_calls(expected, any_order=True)
@@ -481,10 +485,12 @@ class TestFeatureDaemon(TestCase):
                 call(['sudo', 'systemctl', 'daemon-reload'], capture_output=True, check=True, text=True),
                 call(['sudo', 'systemctl', 'unmask', 'dhcp_relay.service'], capture_output=True, check=True, text=True),
                 call(['sudo', 'systemctl', 'enable', 'dhcp_relay.service'], capture_output=True, check=True, text=True),
+                call(['sudo', 'systemctl', 'reset-failed', 'dhcp_relay.service'], capture_output=True, check=True, text=True),
                 call(['sudo', 'systemctl', 'start', 'dhcp_relay.service'], capture_output=True, check=True, text=True),
                 call(['sudo', 'systemctl', 'daemon-reload'], capture_output=True, check=True, text=True),
                 call(['sudo', 'systemctl', 'unmask', 'mux.service'], capture_output=True, check=True, text=True),
                 call(['sudo', 'systemctl', 'enable', 'mux.service'], capture_output=True, check=True, text=True),
+                call(['sudo', 'systemctl', 'reset-failed', 'mux.service'], capture_output=True, check=True, text=True),
                 call(['sudo', 'systemctl', 'start', 'mux.service'], capture_output=True, check=True, text=True)]               
         
             mocked_subprocess.run.assert_has_calls(expected, any_order=True)
@@ -509,10 +515,12 @@ class TestFeatureDaemon(TestCase):
             expected = [call(['sudo', 'systemctl', 'daemon-reload'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'unmask', 'dhcp_relay.service'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'enable', 'dhcp_relay.service'], capture_output=True, check=True, text=True),
+                        call(['sudo', 'systemctl', 'reset-failed', 'dhcp_relay.service'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'start', 'dhcp_relay.service'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'daemon-reload'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'unmask', 'mux.service'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'enable', 'mux.service'], capture_output=True, check=True, text=True),
+                        call(['sudo', 'systemctl', 'reset-failed', 'mux.service'], capture_output=True, check=True, text=True),
                         call(['sudo', 'systemctl', 'start', 'mux.service'], capture_output=True, check=True, text=True)]
             mocked_subprocess.run.assert_has_calls(expected, any_order=True)
 


### PR DESCRIPTION
Why I did it:

On 202511 when running override_config_table.test_override_config_table#test_load_minigraph_with_golden_config sonic-mgmt test, the test fails with Error "All critical services should be fully started!". This is because pmon service hits start-limit-hit and doesn't come back for 420 seconds. This can also be reproduced by doing config reload continuously (immediately 3 in a row).
pmon has StartLimitBurst set to 3 within 20min (which is sonic common). This service is controlled by featured as a delay start process. Config reload bumps up the restart count by 1. When config reload starts the process again, featured kicks in to stop the process and start again as delayed. That again bumps the restart count. If the restart count reach max before featured starts the process, it fails due to start-limit.
18:52:43 — pmon restarts (1st time, success)
18:54:32 — pmon receives SIGTERM (~2 min after start), deliberate shutdown
18:55:14 — featured detects pmon is down, holds restart
18:55:46 — featured attempts restart → FAILS with start-limit-hit

How I did it:

Reset accumulated start-limit-hit counter before starting a service in featured. Featured Issues a deliberate, externally-triggered start for pmon service. It is safe to clear the rate-limit state even if systemd's own Restart= loop would normally be subject to StartLimitBurst. reset-failed is idempotent and returns 0 when the service is not in a failed state.

How to verify it:

This can be manually tested by continuously running "config reload" command 3 or more times and check pmon is able to come up. This can also be tested by running the aforementioned sonic-mgmt test.