### PR TITLE
[featured] Fix namespace CONFIG_DBs rendering and cleanup

### DIFF
--- a/scripts/featured
+++ b/scripts/featured
@@ -188,6 +188,13 @@ class FeatureHandler(object):
             syslog.syslog(syslog.LOG_INFO, "Deregistering feature {}".format(feature_name))
             self._cached_config.pop(feature_name, None)
             self._feature_state_table._del(feature_name)
+
+            # Clean up feature from namespace CONFIG_DBs and STATE_DBs
+            for ns, db in self.ns_cfg_db.items():
+                db.set_entry(FEATURE_TBL, feature_name, None)
+            for ns, tbl in self.ns_feature_state_tbl.items():
+                tbl._del(feature_name)
+
             return
 
         device_config = {}
@@ -526,9 +533,6 @@ class FeatureHandler(object):
         current_entry = self._config_db.get_entry('FEATURE', feature.name)
         current_feature_state = current_entry.get('state') if current_entry else None
 
-        if feature.state == current_feature_state:
-            return
-
         # feature.state might be rendered from a template, so that it should resync CONFIG DB
         # FEATURE table to override the template value to valid state value
         # ('always_enabled', 'always_disabled', 'disabled', 'enabled'). However, we should only
@@ -539,11 +543,15 @@ class FeatureHandler(object):
         #     2. the current feature state in DB is a template which should be replaced by rendered feature
         #        state
         # For other cases, we should not resync feature.state to CONFIG DB to avoid overriding user configuration.
-        if self._feature_state_is_immutable(feature.state) or self._feature_state_is_template(current_feature_state):
-            self._config_db.mod_entry('FEATURE', feature.name, {'state': feature.state})
+        if feature.state != current_feature_state:
+            if self._feature_state_is_immutable(feature.state) or self._feature_state_is_template(current_feature_state):
+                self._config_db.mod_entry('FEATURE', feature.name, {'state': feature.state})
 
-            # resync the feature state to CONFIG_DB in namespaces in multi-asic platform
-            for ns, db in self.ns_cfg_db.items():
+        # Resync namespace CONFIG_DBs independently.
+        for ns, db in self.ns_cfg_db.items():
+            ns_entry = db.get_entry('FEATURE', feature.name)
+            ns_state = ns_entry.get('state') if ns_entry else None
+            if ns_state is not None and self._feature_state_is_template(ns_state):
                 db.mod_entry('FEATURE', feature.name, {'state': feature.state})
 
     def sync_feature_delay_state(self, feature):

--- a/scripts/featured
+++ b/scripts/featured
@@ -219,6 +219,8 @@ class FeatureHandler(object):
         if self._cached_config[feature_name].state != feature.state:
             if self.update_feature_state(feature):
                 self.sync_feature_scope(feature)
+                # Resync namespaces on (re-)registration.
+                self.resync_feature_state(feature)
                 self._cached_config[feature_name] = feature
             else:
                 self.resync_feature_state(self._cached_config[feature_name])
@@ -530,7 +532,7 @@ class FeatureHandler(object):
         return True
 
     def resync_feature_state(self, feature):
-        current_entry = self._config_db.get_entry('FEATURE', feature.name)
+        current_entry = self._config_db.get_entry(FEATURE_TBL, feature.name)
         current_feature_state = current_entry.get('state') if current_entry else None
 
         # feature.state might be rendered from a template, so that it should resync CONFIG DB
@@ -545,14 +547,16 @@ class FeatureHandler(object):
         # For other cases, we should not resync feature.state to CONFIG DB to avoid overriding user configuration.
         if feature.state != current_feature_state:
             if self._feature_state_is_immutable(feature.state) or self._feature_state_is_template(current_feature_state):
-                self._config_db.mod_entry('FEATURE', feature.name, {'state': feature.state})
+                self._config_db.mod_entry(FEATURE_TBL, feature.name, {'state': feature.state})
 
-        # Resync namespace CONFIG_DBs independently.
+        # Resync namespaces like the host above: render templates, enforce immutable
+        # states, and restore a missing 'state'.
         for ns, db in self.ns_cfg_db.items():
-            ns_entry = db.get_entry('FEATURE', feature.name)
+            ns_entry = db.get_entry(FEATURE_TBL, feature.name)
             ns_state = ns_entry.get('state') if ns_entry else None
-            if ns_state is not None and self._feature_state_is_template(ns_state):
-                db.mod_entry('FEATURE', feature.name, {'state': feature.state})
+            if ns_state != feature.state and \
+               (self._feature_state_is_immutable(feature.state) or self._feature_state_is_template(ns_state)):
+                db.mod_entry(FEATURE_TBL, feature.name, {'state': feature.state})
 
     def sync_feature_delay_state(self, feature):
         current_entry = self._config_db.get_entry('FEATURE', feature.name)

--- a/tests/featured/featured_test.py
+++ b/tests/featured/featured_test.py
@@ -377,6 +377,86 @@ class TestFeatureHandler(TestCase):
             assert any("ExclusionList: skip disabling 'frr_bmp'" in str(c.args[1]) for c in mock_syslog.call_args_list)
 
 
+class TestHandlerDeregistration(TestCase):
+
+    def test_handler_deregister_cleans_namespace_dbs(self):
+        mock_db = mock.MagicMock()
+        mock_feature_state_table = mock.MagicMock()
+
+        feature_handler = featured.FeatureHandler(mock_db, mock_feature_state_table, {}, False)
+
+        mock_ns_cfg_db = mock.MagicMock()
+        mock_ns_state_tbl = mock.MagicMock()
+        feature_handler.ns_cfg_db = {'asic0': mock_ns_cfg_db}
+        feature_handler.ns_feature_state_tbl = {'asic0': mock_ns_state_tbl}
+
+        feature_handler._cached_config['sflow'] = featured.Feature('sflow', {'state': 'enabled'})
+
+        feature_handler.handler('sflow', 'DEL', {})
+
+        mock_feature_state_table._del.assert_called_once_with('sflow')
+        mock_ns_cfg_db.set_entry.assert_called_once_with('FEATURE', 'sflow', None)
+        mock_ns_state_tbl._del.assert_called_once_with('sflow')
+        assert 'sflow' not in feature_handler._cached_config
+
+
+class TestResyncFeatureStateNamespace(TestCase):
+
+    @mock.patch('featured.FeatureHandler.update_systemd_config', mock.MagicMock())
+    @mock.patch('featured.FeatureHandler.update_feature_state', mock.MagicMock())
+    @mock.patch('featured.FeatureHandler.sync_feature_scope', mock.MagicMock())
+    @mock.patch('featured.FeatureHandler.sync_feature_delay_state', mock.MagicMock())
+    def test_namespace_template_rendered_when_host_matches(self):
+        mock_db = mock.MagicMock()
+        mock_feature_state_table = mock.MagicMock()
+
+        feature_handler = featured.FeatureHandler(mock_db, mock_feature_state_table, {}, False)
+
+        mock_db.get_entry.return_value = {'state': 'enabled'}
+
+        mock_ns_db = mock.MagicMock()
+        mock_ns_db.get_entry.return_value = {'state': '{{ some_template }}'}
+        feature_handler.ns_cfg_db = {'asic0': mock_ns_db}
+
+        feature = featured.Feature('sflow', {
+            'state': 'enabled',
+            'auto_restart': 'enabled',
+        })
+        feature_handler._cached_config['sflow'] = feature
+
+        feature_handler.resync_feature_state(feature)
+
+        mock_db.mod_entry.assert_not_called()
+        mock_ns_db.mod_entry.assert_called_once_with('FEATURE', 'sflow', {'state': 'enabled'})
+
+    @mock.patch('featured.FeatureHandler.update_systemd_config', mock.MagicMock())
+    @mock.patch('featured.FeatureHandler.update_feature_state', mock.MagicMock())
+    @mock.patch('featured.FeatureHandler.sync_feature_scope', mock.MagicMock())
+    @mock.patch('featured.FeatureHandler.sync_feature_delay_state', mock.MagicMock())
+    def test_namespace_valid_state_not_overwritten(self):
+        mock_db = mock.MagicMock()
+        mock_feature_state_table = mock.MagicMock()
+
+        feature_handler = featured.FeatureHandler(mock_db, mock_feature_state_table, {}, False)
+
+        mock_db.get_entry.return_value = {'state': 'enabled'}
+
+        mock_ns_db = mock.MagicMock()
+        mock_ns_db.get_entry.return_value = {'state': 'enabled'}
+        feature_handler.ns_cfg_db = {'asic0': mock_ns_db}
+
+        feature = featured.Feature('sflow', {
+            'state': 'enabled',
+            'auto_restart': 'enabled',
+        })
+        feature_handler._cached_config['sflow'] = feature
+
+        feature_handler.resync_feature_state(feature)
+
+        mock_db.mod_entry.assert_not_called()
+        mock_ns_db.mod_entry.assert_not_called()
+
+
 @mock.patch("syslog.syslog", side_effect=syslog_side_effect)
 @mock.patch('sonic_py_common.device_info.get_device_runtime_metadata')
 class TestFeatureDaemon(TestCase):

--- a/tests/featured/featured_test.py
+++ b/tests/featured/featured_test.py
@@ -395,66 +395,118 @@ class TestHandlerDeregistration(TestCase):
         feature_handler.handler('sflow', 'DEL', {})
 
         mock_feature_state_table._del.assert_called_once_with('sflow')
-        mock_ns_cfg_db.set_entry.assert_called_once_with('FEATURE', 'sflow', None)
+        mock_ns_cfg_db.set_entry.assert_called_once_with(featured.FEATURE_TBL, 'sflow', None)
         mock_ns_state_tbl._del.assert_called_once_with('sflow')
         assert 'sflow' not in feature_handler._cached_config
 
 
 class TestResyncFeatureStateNamespace(TestCase):
 
-    @mock.patch('featured.FeatureHandler.update_systemd_config', mock.MagicMock())
-    @mock.patch('featured.FeatureHandler.update_feature_state', mock.MagicMock())
-    @mock.patch('featured.FeatureHandler.sync_feature_scope', mock.MagicMock())
-    @mock.patch('featured.FeatureHandler.sync_feature_delay_state', mock.MagicMock())
-    def test_namespace_template_rendered_when_host_matches(self):
+    def _make_handler(self, host_state, ns_get_entry):
+        """Build a FeatureHandler with a mocked host DB and a single mocked namespace DB."""
         mock_db = mock.MagicMock()
+        mock_db.get_entry.return_value = {'state': host_state} if host_state is not None else None
         mock_feature_state_table = mock.MagicMock()
 
         feature_handler = featured.FeatureHandler(mock_db, mock_feature_state_table, {}, False)
 
-        mock_db.get_entry.return_value = {'state': 'enabled'}
-
         mock_ns_db = mock.MagicMock()
-        mock_ns_db.get_entry.return_value = {'state': '{{ some_template }}'}
+        mock_ns_db.get_entry.return_value = ns_get_entry
         feature_handler.ns_cfg_db = {'asic0': mock_ns_db}
+        return feature_handler, mock_db, mock_ns_db
 
-        feature = featured.Feature('sflow', {
-            'state': 'enabled',
-            'auto_restart': 'enabled',
-        })
+    def _feature(self, state):
+        return featured.Feature('sflow', {'state': state, 'auto_restart': 'enabled'})
+
+    def test_namespace_template_rendered_when_host_matches(self):
+        # Host already 'enabled' (no host write), namespace still holds a template -> render it.
+        feature_handler, mock_db, mock_ns_db = self._make_handler('enabled', {'state': '{{ some_template }}'})
+        feature = self._feature('enabled')
         feature_handler._cached_config['sflow'] = feature
 
         feature_handler.resync_feature_state(feature)
 
         mock_db.mod_entry.assert_not_called()
-        mock_ns_db.mod_entry.assert_called_once_with('FEATURE', 'sflow', {'state': 'enabled'})
+        mock_ns_db.mod_entry.assert_called_once_with(featured.FEATURE_TBL, 'sflow', {'state': 'enabled'})
 
-    @mock.patch('featured.FeatureHandler.update_systemd_config', mock.MagicMock())
-    @mock.patch('featured.FeatureHandler.update_feature_state', mock.MagicMock())
-    @mock.patch('featured.FeatureHandler.sync_feature_scope', mock.MagicMock())
-    @mock.patch('featured.FeatureHandler.sync_feature_delay_state', mock.MagicMock())
     def test_namespace_valid_state_not_overwritten(self):
-        mock_db = mock.MagicMock()
-        mock_feature_state_table = mock.MagicMock()
-
-        feature_handler = featured.FeatureHandler(mock_db, mock_feature_state_table, {}, False)
-
-        mock_db.get_entry.return_value = {'state': 'enabled'}
-
-        mock_ns_db = mock.MagicMock()
-        mock_ns_db.get_entry.return_value = {'state': 'enabled'}
-        feature_handler.ns_cfg_db = {'asic0': mock_ns_db}
-
-        feature = featured.Feature('sflow', {
-            'state': 'enabled',
-            'auto_restart': 'enabled',
-        })
+        # Namespace already matches the rendered state -> idempotent, no write.
+        feature_handler, mock_db, mock_ns_db = self._make_handler('enabled', {'state': 'enabled'})
+        feature = self._feature('enabled')
         feature_handler._cached_config['sflow'] = feature
 
         feature_handler.resync_feature_state(feature)
 
         mock_db.mod_entry.assert_not_called()
         mock_ns_db.mod_entry.assert_not_called()
+
+    def test_namespace_immutable_state_forced(self):
+        # Immutable rendered state must be enforced in the namespace even if it holds a
+        # concrete (non-template) differing value.
+        feature_handler, mock_db, mock_ns_db = self._make_handler('always_enabled', {'state': 'disabled'})
+        feature = self._feature('always_enabled')
+        feature_handler._cached_config['sflow'] = feature
+
+        feature_handler.resync_feature_state(feature)
+
+        mock_ns_db.mod_entry.assert_called_once_with(featured.FEATURE_TBL, 'sflow', {'state': 'always_enabled'})
+
+    def test_namespace_missing_state_repopulated(self):
+        # Namespace entry exists but has no 'state' (e.g. only has_* written by
+        # sync_feature_scope after a deregister/re-register) -> state must be repopulated.
+        feature_handler, mock_db, mock_ns_db = self._make_handler('enabled', {'has_global_scope': 'True'})
+        feature = self._feature('enabled')
+        feature_handler._cached_config['sflow'] = feature
+
+        feature_handler.resync_feature_state(feature)
+
+        mock_ns_db.mod_entry.assert_called_once_with(featured.FEATURE_TBL, 'sflow', {'state': 'enabled'})
+
+    def test_namespace_concrete_user_state_preserved(self):
+        # Non-immutable rendered state: a concrete user-set namespace value that differs
+        # must NOT be overwritten.
+        feature_handler, mock_db, mock_ns_db = self._make_handler('disabled', {'state': 'enabled'})
+        feature = self._feature('disabled')
+        feature_handler._cached_config['sflow'] = feature
+
+        feature_handler.resync_feature_state(feature)
+
+        mock_db.mod_entry.assert_not_called()
+        mock_ns_db.mod_entry.assert_not_called()
+
+
+class TestHandlerReregistration(TestCase):
+
+    def test_deregister_then_register_restores_namespace_state(self):
+        # DEL removes the namespace entry; on the subsequent SET, sync_feature_scope is
+        # stubbed and the namespace is simulated as a partial row (has_* only, no 'state'),
+        # so this asserts that the SET-success resync_feature_state writes the namespace
+        # 'state' back. (Handler-level test; sync_feature_scope itself is mocked out.)
+        mock_db = mock.MagicMock()
+        feature_handler = featured.FeatureHandler(mock_db, mock.MagicMock(), {}, False)
+        # Make Feature() rendering deterministic regardless of the host's runtime metadata.
+        feature_handler._device_running_config = {}
+
+        mock_ns_cfg_db = mock.MagicMock()
+        mock_ns_state_tbl = mock.MagicMock()
+        feature_handler.ns_cfg_db = {'asic0': mock_ns_cfg_db}
+        feature_handler.ns_feature_state_tbl = {'asic0': mock_ns_state_tbl}
+
+        # 1) Deregister -> namespace entry deleted.
+        feature_handler.handler('sflow', 'DEL', {})
+        mock_ns_cfg_db.set_entry.assert_called_once_with(featured.FEATURE_TBL, 'sflow', None)
+
+        # 2) Re-register. Host already carries the state; the namespace was rebuilt partial
+        #    (only has_* from sync_feature_scope) so it lacks 'state'.
+        mock_db.get_entry.return_value = {'state': 'enabled'}
+        mock_ns_cfg_db.get_entry.return_value = {'has_global_scope': 'True'}
+
+        with mock.patch.object(feature_handler, 'update_systemd_config'), \
+             mock.patch.object(feature_handler, 'update_feature_state', return_value=True), \
+             mock.patch.object(feature_handler, 'sync_feature_scope'):
+            feature_handler.handler('sflow', 'SET', {'state': 'enabled', 'auto_restart': 'enabled'})
+
+        mock_ns_cfg_db.mod_entry.assert_any_call(featured.FEATURE_TBL, 'sflow', {'state': 'enabled'})
 
 
 @mock.patch("syslog.syslog", side_effect=syslog_side_effect)


### PR DESCRIPTION
## What I did

Fixed two issues in `featured` daemon for multi-ASIC platforms:

1. Feature deregistration now cleans up FEATURE entries from all per-ASIC namespace CONFIG_DBs and STATE_DBs.
2. `resync_feature_state()` now independently checks each namespace CONFIG_DB for unrendered Jinja2 templates, instead of assuming all namespaces match the host.

## How I did it

Deregistration cleanup: In `FeatureHandler.handler()`, when a feature is deregistered (`feature_cfg` is empty), added cleanup of the FEATURE entry from all namespace CONFIG_DBs via `set_entry(None)` and from all namespace STATE_DBs via `_del()`.

Independent namespace rendering: In `resync_feature_state()`, removed the early return when host state matches the rendered state. The host CONFIG_DB update still only happens for immutable or template states. Added a new loop that independently checks each namespace CONFIG_DB — if a namespace entry still contains a Jinja2 template, it gets rendered to the correct state value regardless of host CONFIG_DB state.

## How to verify it

On a multi-ASIC system:

```bash
# Test deregistration cleanup
sudo sonic-package-manager install xxx -y
sudo sonic-package-manager uninstall xxx -y --force
# Verify per-ASIC entries are removed
sonic-db-cli -n asic0 CONFIG_DB HGETALL "FEATURE|xxx"
# Should return {}

# Test template rendering
# After boot, check that per-ASIC FEATURE entries have rendered state values
sonic-db-cli -n asic0 CONFIG_DB HGET "FEATURE|xxx" state
```