### PR TITLE
Add back PROC_CMDLINE path used while reading fips config

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -105,7 +105,7 @@ DEFAULT_FIPS_RESTART_SERVICES = ['ssh', 'telemetry.service', 'restapi']
 # MISC Constants
 CFG_DB = "CONFIG_DB"
 STATE_DB = "STATE_DB"
-
+PROC_CMDLINE = '/proc/cmdline'
 
 def signal_handler(sig, frame):
     if sig == signal.SIGHUP:


### PR DESCRIPTION
When FIPS config is added to CONFIG_DB, hostcfgd crashes with the below backtrace

```
2026 Apr 14 21:59:24.220203 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]: Traceback (most recent call last):
2026 Apr 14 21:59:24.220865 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:   File "/usr/local/bin/hostcfgd", line 2540, in <module>
2026 Apr 14 21:59:24.220923 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:     main()
2026 Apr 14 21:59:24.220967 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:     ~~~~^^
2026 Apr 14 21:59:24.220999 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:   File "/usr/local/bin/hostcfgd", line 2537, in main
2026 Apr 14 21:59:24.221028 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:     daemon.start()
2026 Apr 14 21:59:24.221056 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:     ~~~~~~~~~~~~^^
2026 Apr 14 21:59:24.221085 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:   File "/usr/local/bin/hostcfgd", line 2529, in start
2026 Apr 14 21:59:24.221113 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:     self.config_db.listen(init_data_handler=self.load)
2026 Apr 14 21:59:24.221142 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:     ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026 Apr 14 21:59:24.221171 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:   File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 2743, in listen
2026 Apr 14 21:59:24.221199 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:     init_data_handler(init_callback_data)
2026 Apr 14 21:59:24.221228 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:     ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
2026 Apr 14 21:59:24.221256 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:   File "/usr/local/bin/hostcfgd", line 2272, in load
2026 Apr 14 21:59:24.221285 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:     self.fipscfg.load(fips_cfg)
2026 Apr 14 21:59:24.221313 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:     ~~~~~~~~~~~~~~~~~^^^^^^^^^^
2026 Apr 14 21:59:24.221341 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:   File "/usr/local/bin/hostcfgd", line 1781, in load
2026 Apr 14 21:59:24.221369 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:     self.read_config()
2026 Apr 14 21:59:24.221397 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:     ~~~~~~~~~~~~~~~~^^
2026 Apr 14 21:59:24.221425 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:   File "/usr/local/bin/hostcfgd", line 1772, in read_config
2026 Apr 14 21:59:24.221454 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:     with open(PROC_CMDLINE) as f:
2026 Apr 14 21:59:24.221482 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]:               ^^^^^^^^^^^^
2026 Apr 14 21:59:24.221526 svcstr-nh5010-ut2-3 INFO hostcfgd[133384]: NameError: name 'PROC_CMDLINE' is not defined
2026 Apr 14 21:59:24.256218 svcstr-nh5010-ut2-3 NOTICE systemd[1]: hostcfgd.service: Main process exited, code=exited, status=1/FAILURE
```

Adding back PROC_CMDLINE definition to prevent the crash