### PR TITLE
[smartswitch] Use dpu_halt_services_timeout from platform.json, fallback to HALT_TIMEOUT=60

### DIFF
--- a/host_modules/reboot.py
+++ b/host_modules/reboot.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import threading
 import time
 import docker
@@ -9,6 +10,7 @@ import psutil
 from host_modules import host_service
 from utils.run_cmd import _run_command
 from enum import Enum
+from sonic_py_common import device_info
 
 MOD_NAME = 'reboot'
 # Reboot method in reboot request
@@ -33,6 +35,26 @@ class RebootStatus(Enum):
     STATUS_FAILURE = 3
 
 logger = logging.getLogger(__name__)
+
+
+def get_dpu_halt_services_timeout():
+    """Read dpu_halt_services_timeout from platform.json.
+       Fall back to HALT_TIMEOUT if missing/null/invalid/unreadable.
+    """
+    try:
+        platform_json_path = os.path.join(
+            device_info.get_path_to_platform_dir(), "platform.json"
+        )
+        with open(platform_json_path, "r") as f:
+            data = json.load(f)
+
+        timeout = data.get("dpu_halt_services_timeout")
+        if timeout is None:
+            return HALT_TIMEOUT
+
+        return int(timeout)
+    except (OSError, ValueError, TypeError, AttributeError, json.JSONDecodeError):
+        return HALT_TIMEOUT
 
 
 class Reboot(host_service.HostModule):
@@ -139,12 +161,12 @@ class Reboot(host_service.HostModule):
            is still alive after the below waiting period, we can conclude that the reboot has failed.
            Each container can take up to 20 seconds to get killed. In total, there are 10 containers,
            and adding a buffer of 1 minute brings up the delay value.
-           For Halt reboot_method, wait for 60 secs timeout. we expect pmon, syncd containers are killed, 
+           For Halt reboot_method, wait for configured timeout or fallback timeout. we expect pmon, syncd containers are killed,
            if Halt reboot is Successful."""
         if reboot_method in REBOOT_METHOD_HALT_BOOT_VALUES:
             # Periodically check every 5 seconds until PMON container is stopped or timeout occurs
             logger.info("%s: Waiting until services are halted or timeout occurs", MOD_NAME)
-            timeout = HALT_TIMEOUT
+            timeout = get_dpu_halt_services_timeout()
             start_time = time.monotonic()
 
             while time.monotonic() - start_time < timeout:

--- a/host_modules/reboot.py
+++ b/host_modules/reboot.py
@@ -52,8 +52,13 @@ def get_dpu_halt_services_timeout():
         if timeout is None:
             return HALT_TIMEOUT
 
-        return int(timeout)
-    except (OSError, ValueError, TypeError, AttributeError, json.JSONDecodeError):
+        timeout = int(timeout)
+        return timeout if timeout > 0 else HALT_TIMEOUT
+    except (OSError, ValueError, TypeError, AttributeError, json.JSONDecodeError) as e:
+        logger.info(
+            "%s: Failed to read dpu_halt_services_timeout from platform.json: %s. Using default %d",
+            MOD_NAME, e, HALT_TIMEOUT
+        )
         return HALT_TIMEOUT
 
 

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -97,7 +97,7 @@ class TestReboot(object):
             mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_data))),
             mock.patch("reboot.json.load", return_value=mock_data),
         ):
-            assert reboot.get_halt_timeout_from_platform_json() == 120
+            assert sys.modules["reboot"].get_halt_timeout_from_platform_json() == 120
 
     def test_get_halt_timeout_from_platform_json_none(self):
         mock_data = {"dpu_halt_services_timeout": None}
@@ -107,7 +107,7 @@ class TestReboot(object):
             mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_data))),
             mock.patch("reboot.json.load", return_value=mock_data),
         ):
-            assert reboot.get_halt_timeout_from_platform_json() == HALT_TIMEOUT
+            assert sys.modules["reboot"].get_halt_timeout_from_platform_json() == HALT_TIMEOUT
 
     @pytest.mark.parametrize(
         "side_effect",
@@ -125,7 +125,7 @@ class TestReboot(object):
             mock.patch("builtins.open", mock.mock_open(read_data="{}")),
             mock.patch("reboot.json.load", side_effect=side_effect),
         ):
-            assert reboot.get_halt_timeout_from_platform_json() == HALT_TIMEOUT
+            assert sys.modules["reboot"].get_halt_timeout_from_platform_json() == HALT_TIMEOUT
 
     def test_validate_reboot_request_success_cold_boot_enum_method(self):
         reboot_request = {"method": REBOOT_METHOD_COLD_BOOT_ENUM, "reason": "test reboot request reason"}

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -90,7 +90,7 @@ class TestReboot(object):
                 "message": ""
             }
 
-    def test_get_halt_timeout_from_platform_json_value(self):
+    def test_get_dpu_halt_services_timeout_value(self):
         mock_data = {"dpu_halt_services_timeout": 120}
 
         with (
@@ -98,9 +98,9 @@ class TestReboot(object):
             mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_data))),
             mock.patch("host_modules.reboot.json.load", return_value=mock_data),
         ):
-            assert host_reboot.get_halt_timeout_from_platform_json() == 120
+            assert host_reboot.get_dpu_halt_services_timeout() == 120
 
-    def test_get_halt_timeout_from_platform_json_none(self):
+    def test_get_dpu_halt_services_timeout_none(self):
         mock_data = {"dpu_halt_services_timeout": None}
 
         with (
@@ -108,7 +108,7 @@ class TestReboot(object):
             mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_data))),
             mock.patch("host_modules.reboot.json.load", return_value=mock_data),
         ):
-            assert host_reboot.get_halt_timeout_from_platform_json() == HALT_TIMEOUT
+            assert host_reboot.get_dpu_halt_services_timeout() == HALT_TIMEOUT
 
     @pytest.mark.parametrize(
         "side_effect",
@@ -120,13 +120,13 @@ class TestReboot(object):
             json.JSONDecodeError("Expecting value", "doc", 0),
         ],
     )
-    def test_get_halt_timeout_from_platform_json_exceptions(self, side_effect):
+    def test_get_dpu_halt_services_timeout_exceptions(self, side_effect):
         with (
             mock.patch("host_modules.reboot.device_info.get_path_to_platform_dir", return_value="/tmp/platform"),
             mock.patch("builtins.open", mock.mock_open(read_data="{}")),
             mock.patch("host_modules.reboot.json.load", side_effect=side_effect),
         ):
-            assert host_reboot.get_halt_timeout_from_platform_json() == HALT_TIMEOUT
+            assert host_reboot.get_dpu_halt_services_timeout() == HALT_TIMEOUT
 
     def test_validate_reboot_request_success_cold_boot_enum_method(self):
         reboot_request = {"method": REBOOT_METHOD_COLD_BOOT_ENUM, "reason": "test reboot request reason"}

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -21,6 +21,7 @@ sonic_host_service_path = os.path.dirname(test_path)
 host_modules_path = os.path.join(sonic_host_service_path, "../host_modules")
 sys.path.insert(0, sonic_host_service_path)
 
+import host_modules.reboot as host_reboot
 from host_modules.reboot import RebootStatus
 
 TIME = 1617811205
@@ -93,21 +94,21 @@ class TestReboot(object):
         mock_data = {"dpu_halt_services_timeout": 120}
 
         with (
-            mock.patch("reboot.device_info.get_path_to_platform_dir", return_value="/tmp/platform"),
+            mock.patch("host_modules.reboot.device_info.get_path_to_platform_dir", return_value="/tmp/platform"),
             mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_data))),
-            mock.patch("reboot.json.load", return_value=mock_data),
+            mock.patch("host_modules.reboot.json.load", return_value=mock_data),
         ):
-            assert sys.modules["reboot"].get_halt_timeout_from_platform_json() == 120
+            assert host_reboot.get_halt_timeout_from_platform_json() == 120
 
     def test_get_halt_timeout_from_platform_json_none(self):
         mock_data = {"dpu_halt_services_timeout": None}
 
         with (
-            mock.patch("reboot.device_info.get_path_to_platform_dir", return_value="/tmp/platform"),
+            mock.patch("host_modules.reboot.device_info.get_path_to_platform_dir", return_value="/tmp/platform"),
             mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_data))),
-            mock.patch("reboot.json.load", return_value=mock_data),
+            mock.patch("host_modules.reboot.json.load", return_value=mock_data),
         ):
-            assert sys.modules["reboot"].get_halt_timeout_from_platform_json() == HALT_TIMEOUT
+            assert host_reboot.get_halt_timeout_from_platform_json() == HALT_TIMEOUT
 
     @pytest.mark.parametrize(
         "side_effect",
@@ -121,11 +122,11 @@ class TestReboot(object):
     )
     def test_get_halt_timeout_from_platform_json_exceptions(self, side_effect):
         with (
-            mock.patch("reboot.device_info.get_path_to_platform_dir", return_value="/tmp/platform"),
+            mock.patch("host_modules.reboot.device_info.get_path_to_platform_dir", return_value="/tmp/platform"),
             mock.patch("builtins.open", mock.mock_open(read_data="{}")),
-            mock.patch("reboot.json.load", side_effect=side_effect),
+            mock.patch("host_modules.reboot.json.load", side_effect=side_effect),
         ):
-            assert sys.modules["reboot"].get_halt_timeout_from_platform_json() == HALT_TIMEOUT
+            assert host_reboot.get_halt_timeout_from_platform_json() == HALT_TIMEOUT
 
     def test_validate_reboot_request_success_cold_boot_enum_method(self):
         reboot_request = {"method": REBOOT_METHOD_COLD_BOOT_ENUM, "reason": "test reboot request reason"}

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -97,7 +97,7 @@ class TestReboot(object):
             mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_data))),
             mock.patch("reboot.json.load", return_value=mock_data),
         ):
-            assert get_halt_timeout_from_platform_json() == 120
+            assert self.reboot_module.get_halt_timeout_from_platform_json() == 120
 
     def test_get_halt_timeout_from_platform_json_none(self):
         mock_data = {"dpu_halt_services_timeout": None}
@@ -107,7 +107,7 @@ class TestReboot(object):
             mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_data))),
             mock.patch("reboot.json.load", return_value=mock_data),
         ):
-            assert get_halt_timeout_from_platform_json() == HALT_TIMEOUT
+            assert self.reboot_module.get_halt_timeout_from_platform_json() == HALT_TIMEOUT
 
     @pytest.mark.parametrize(
         "side_effect",
@@ -125,7 +125,7 @@ class TestReboot(object):
             mock.patch("builtins.open", mock.mock_open(read_data="{}")),
             mock.patch("reboot.json.load", side_effect=side_effect),
         ):
-            assert get_halt_timeout_from_platform_json() == HALT_TIMEOUT
+            assert self.reboot_module.get_halt_timeout_from_platform_json() == HALT_TIMEOUT
 
     def test_validate_reboot_request_success_cold_boot_enum_method(self):
         reboot_request = {"method": REBOOT_METHOD_COLD_BOOT_ENUM, "reason": "test reboot request reason"}

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -97,7 +97,7 @@ class TestReboot(object):
             mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_data))),
             mock.patch("reboot.json.load", return_value=mock_data),
         ):
-            assert self.reboot_module.get_halt_timeout_from_platform_json() == 120
+            assert reboot.get_halt_timeout_from_platform_json() == 120
 
     def test_get_halt_timeout_from_platform_json_none(self):
         mock_data = {"dpu_halt_services_timeout": None}
@@ -107,7 +107,7 @@ class TestReboot(object):
             mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_data))),
             mock.patch("reboot.json.load", return_value=mock_data),
         ):
-            assert self.reboot_module.get_halt_timeout_from_platform_json() == HALT_TIMEOUT
+            assert reboot.get_halt_timeout_from_platform_json() == HALT_TIMEOUT
 
     @pytest.mark.parametrize(
         "side_effect",
@@ -125,7 +125,7 @@ class TestReboot(object):
             mock.patch("builtins.open", mock.mock_open(read_data="{}")),
             mock.patch("reboot.json.load", side_effect=side_effect),
         ):
-            assert self.reboot_module.get_halt_timeout_from_platform_json() == HALT_TIMEOUT
+            assert reboot.get_halt_timeout_from_platform_json() == HALT_TIMEOUT
 
     def test_validate_reboot_request_success_cold_boot_enum_method(self):
         reboot_request = {"method": REBOOT_METHOD_COLD_BOOT_ENUM, "reason": "test reboot request reason"}

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -89,6 +89,44 @@ class TestReboot(object):
                 "message": ""
             }
 
+    def test_get_halt_timeout_from_platform_json_value(self):
+        mock_data = {"dpu_halt_services_timeout": 120}
+
+        with (
+            mock.patch("reboot.device_info.get_path_to_platform_dir", return_value="/tmp/platform"),
+            mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_data))),
+            mock.patch("reboot.json.load", return_value=mock_data),
+        ):
+            assert get_halt_timeout_from_platform_json() == 120
+
+    def test_get_halt_timeout_from_platform_json_none(self):
+        mock_data = {"dpu_halt_services_timeout": None}
+
+        with (
+            mock.patch("reboot.device_info.get_path_to_platform_dir", return_value="/tmp/platform"),
+            mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_data))),
+            mock.patch("reboot.json.load", return_value=mock_data),
+        ):
+            assert get_halt_timeout_from_platform_json() == HALT_TIMEOUT
+
+    @pytest.mark.parametrize(
+        "side_effect",
+        [
+            OSError(),
+            ValueError(),
+            TypeError(),
+            AttributeError(),
+            json.JSONDecodeError("Expecting value", "doc", 0),
+        ],
+    )
+    def test_get_halt_timeout_from_platform_json_exceptions(self, side_effect):
+        with (
+            mock.patch("reboot.device_info.get_path_to_platform_dir", return_value="/tmp/platform"),
+            mock.patch("builtins.open", mock.mock_open(read_data="{}")),
+            mock.patch("reboot.json.load", side_effect=side_effect),
+        ):
+            assert get_halt_timeout_from_platform_json() == HALT_TIMEOUT
+
     def test_validate_reboot_request_success_cold_boot_enum_method(self):
         reboot_request = {"method": REBOOT_METHOD_COLD_BOOT_ENUM, "reason": "test reboot request reason"}
         result = self.reboot_module.validate_reboot_request(reboot_request)

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -302,7 +302,7 @@ class TestReboot(object):
                 return_value=mock_data
             ),
         ):
-            assert reboot.get_dpu_halt_services_timeout() == reboot.HALT_TIMEOUT
+            assert get_dpu_halt_services_timeout() == HALT_TIMEOUT
 
     def test_execute_reboot_success_halt(self):
         with (

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -288,20 +288,20 @@ class TestReboot(object):
     def test_get_dpu_halt_services_timeout_key_absent(self):
         mock_data = {}
 
-        with contextlib.ExitStack() as stack:
-            stack.enter_context(mock.patch(
+        with (
+            mock.patch(
                 "reboot.device_info.get_path_to_platform_dir",
                 return_value="/usr/share/sonic/device/test_platform"
-            ))
-            stack.enter_context(mock.patch(
+            ),
+            mock.patch(
                 "builtins.open",
                 mock.mock_open(read_data=json.dumps(mock_data))
-            ))
-            stack.enter_context(mock.patch(
+            ),
+            mock.patch(
                 "reboot.json.load",
                 return_value=mock_data
-            ))
-
+            ),
+        ):
             assert reboot.get_dpu_halt_services_timeout() == reboot.HALT_TIMEOUT
 
     def test_execute_reboot_success_halt(self):

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -285,6 +285,25 @@ class TestReboot(object):
             assert caplog.records[0].message == msg
             mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 3, RebootStatus.STATUS_FAILURE)
 
+    def test_get_dpu_halt_services_timeout_key_absent(self):
+        mock_data = {}
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(mock.patch(
+                "reboot.device_info.get_path_to_platform_dir",
+                return_value="/usr/share/sonic/device/test_platform"
+            ))
+            stack.enter_context(mock.patch(
+                "builtins.open",
+                mock.mock_open(read_data=json.dumps(mock_data))
+            ))
+            stack.enter_context(mock.patch(
+                "reboot.json.load",
+                return_value=mock_data
+            ))
+
+            assert reboot.get_dpu_halt_services_timeout() == reboot.HALT_TIMEOUT
+
     def test_execute_reboot_success_halt(self):
         with (
             mock.patch("reboot._run_command") as mock_run_command,
@@ -292,6 +311,7 @@ class TestReboot(object):
             mock.patch("reboot.Reboot.is_halt_command_running", return_value=False) as mock_is_halt_command_running,
             mock.patch("reboot.Reboot.is_container_running", return_value=False) as mock_is_container_running,
             mock.patch("reboot.Reboot.populate_reboot_status_flag") as mock_populate_reboot_status_flag,
+            mock.patch("reboot.get_dpu_halt_services_timeout", return_value=60),
         ):
             mock_run_command.return_value = (0, ["stdout: execute halt reboot"], ["stderror: execute halt reboot"])
             self.reboot_module.execute_reboot(REBOOT_METHOD_HALT_BOOT_ENUM)
@@ -307,6 +327,7 @@ class TestReboot(object):
             mock.patch("reboot.Reboot.is_halt_command_running", return_value=True) as mock_is_halt_command_running,
             mock.patch("reboot.Reboot.is_container_running", return_value=True) as mock_is_container_running,
             mock.patch("reboot.Reboot.populate_reboot_status_flag") as mock_populate_reboot_status_flag,
+            mock.patch("reboot.get_dpu_halt_services_timeout", return_value=60),
             caplog.at_level(logging.ERROR),
         ):
             mock_run_command.return_value = (0, ["stdout: execute halt reboot"], ["stderror: execute halt reboot"])


### PR DESCRIPTION
### Description of PR
Summary:
On SmartSwitch platforms, HALT reboot may require additional time for DPU services and containers to terminate cleanly before the reboot sequence is considered complete.

The current implementation uses a fixed HALT_TIMEOUT=60 seconds, which may not be sufficient on all platforms and hardware combinations.

This change makes the HALT timeout configurable through platform.json using:

"dpu_halt_services_timeout"

while preserving the existing behavior by falling back to:

HALT_TIMEOUT = 60

when:

the key is missing,
the value is null,
the value is invalid,
the file cannot be read,
or the configured value is non-positive.

### Type of change
- [ x] Testbed and Framework(new/improvement)



### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### How did you do it
Added helper function get_dpu_halt_services_timeout()
Read dpu_halt_services_timeout from platform.json
Added validation to ensure only positive timeout values are accepted
Added informational logging when fallback timeout is used
Updated HALT reboot flow to use platform-configured timeout
Added unit test coverage for:
missing key in platform.json
stable mocking of timeout helper in HALT reboot tests
Default behavior

If dpu_halt_services_timeout is not configured, the existing default behavior remains unchanged:

HALT_TIMEOUT = 60


#### How did you verify/test it?

normal HALT reboot flow
HALT timeout failure flow
missing platform.json key handling
invalid/unreadable timeout fallback handling
existing reboot UTs
