### PR TITLE
Fix device_metadata_handler to ignore non-localhost key data event

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -2403,6 +2403,9 @@ class HostConfigDaemon:
 
     def device_metadata_handler(self, key, op, data):
         syslog.syslog(syslog.LOG_INFO, 'DeviceMeta handler...')
+        if key != 'localhost':
+            syslog.syslog(syslog.LOG_INFO, f'DeviceMeta handler: key {key} is not localhost')
+            return
         self.devmetacfg.hostname_update(data)
         self.devmetacfg.timezone_update(data)
         self.devmetacfg.rsyslog_config(data)

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -351,6 +351,27 @@ class TestHostcfgdDaemon(TestCase):
                 ]
                 mocked_syslog.syslog.assert_has_calls(expected)
 
+    def test_device_metadata_bmc_entry_does_not_trigger_hostname_update(self):
+        """
+        DEVICE_METADATA may include a 'bmc' row on BMC-capable systems. Those
+        updates must be ignored by device_metadata_handler so hostname_update
+        is not run with BMC-only fields (which lack hostname).
+        """
+        daemon = hostcfgd.HostConfigDaemon()
+        bmc_data = {
+            'bmc_addr': '169.254.0.1',
+            'bmc_if_addr': '169.254.0.2',
+            'bmc_if_name': 'usb0',
+            'bmc_net_mask': '255.255.255.252',
+        }
+        with mock.patch.object(daemon.devmetacfg, 'hostname_update') as mock_hostname_update:
+            with mock.patch.object(daemon.devmetacfg, 'timezone_update') as mock_tz_update:
+                with mock.patch.object(daemon.devmetacfg, 'rsyslog_config') as mock_rsyslog:
+                    daemon.device_metadata_handler('bmc', 'SET', bmc_data)
+                    mock_hostname_update.assert_not_called()
+                    mock_tz_update.assert_not_called()
+                    mock_rsyslog.assert_not_called()
+
     def test_mgmtiface_event(self):
         """
         Test handling mgmt events.

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -359,8 +359,8 @@ class TestHostcfgdDaemon(TestCase):
         """
         daemon = hostcfgd.HostConfigDaemon()
         bmc_data = {
-            'bmc_addr': '169.254.0.1',
-            'bmc_if_addr': '169.254.0.2',
+            'bmc_addr': '169.254.100.1',
+            'bmc_if_addr': '169.254.100.2',
             'bmc_if_name': 'usb0',
             'bmc_net_mask': '255.255.255.252',
         }


### PR DESCRIPTION
What I did:
I updated device_metadata_handler in hostcfgd so that hostname, timezone, and rsyslog handling run only when the CONFIG_DB notification is for the localhost row. For any other DEVICE_METADATA key (for example bmc), the handler logs once at INFO and returns without calling hostname_update, timezone_update, or rsyslog_config.

Why I did it:
DEVICE_METADATA can have multiple keys; host settings live under localhost, while BMC fields live under bmc. The handler used to ignore the row key and always ran hostname logic, so bmc updates passed a dict without hostname, which produced ERR (“Hostname was not updated: Empty not allowed”).

How to verify
Change DEVICE_METADATA|bmc and confirm no "ERR Empty not allowed" in syslog.