### PR TITLE
Added CACL entry for Redfish

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -131,6 +131,7 @@ class ControlPlaneAclManager(logger.Logger):
     bfdAllowed = False
     VxlanAllowed = False
     VxlanSrcIP = ""
+    RedfishAllowed = False
     # a map from dpu name to port
     dashHaPortMap = {}
 
@@ -166,6 +167,9 @@ class ControlPlaneAclManager(logger.Logger):
         # Get all features that are present {feature_name : True/False}
         self.feature_present = {}
         self.update_feature_present()
+
+        feature_tb = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.FEATURE_TABLE)
+        self.RedfishAllowed = feature_tb.get("redfish", {}).get("state") == "enabled"
 
         metadata = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.DEVICE_METADATA_TABLE)
         if 'subtype' in metadata['localhost'] and metadata['localhost']['subtype'] == 'DualToR':
@@ -753,6 +757,11 @@ class ControlPlaneAclManager(logger.Logger):
                                      .format(table_name, acl_service))
                     continue
 
+                if acl_service == "REDFISH" and not self.RedfishAllowed:
+                    self.log_warning("Ignoring control plane ACL '{}': REDFISH service is not enabled on this platform"
+                                     .format(table_name))
+                    continue
+
                 self.log_info("Translating ACL rules for control plane ACL '{}' (service: '{}')"
                               .format(table_name, acl_service))
 
@@ -1059,6 +1068,14 @@ class ControlPlaneAclManager(logger.Logger):
         self.VxlanSrcIP = ""
         return True
 
+    def allow_redfish(self):
+        self.RedfishAllowed = True
+        self.log_info("Enabled REDFISH control plane ACL handling")
+
+    def block_redfish(self):
+        self.RedfishAllowed = False
+        self.log_info("Disabled REDFISH control plane ACL handling")
+
     def remove_dash_ha_rules(self, namespace, port):
         iptables_cmds = []
         # Remove iptables/ip6tables commands that allow DASH-HA packets
@@ -1164,6 +1181,9 @@ class ControlPlaneAclManager(logger.Logger):
 
         subscribe_dpu_table = swsscommon.SubscriberStateTable(config_db_connector, self.DPU_TABLE)
         sel.addSelectable(subscribe_dpu_table)
+
+        subscribe_feature_table = swsscommon.SubscriberStateTable(config_db_connector, self.FEATURE_TABLE)
+        sel.addSelectable(subscribe_feature_table)
         # Map of Namespace <--> susbcriber table's object
         config_db_subscriber_table_map = {}
 
@@ -1250,6 +1270,8 @@ class ControlPlaneAclManager(logger.Logger):
                         self.update_dhcp_acl(key, op, dict(fvs), mark)
                 continue
 
+            ctrl_plane_acl_notification = set()
+
             if db_id == config_db_id:
                 while True:
                     key, op, fvs = subscribe_vxlan_table.pop()
@@ -1267,7 +1289,21 @@ class ControlPlaneAclManager(logger.Logger):
                     if "dash-ha" in self.feature_present:
                         self.update_dash_ha_rules(namespace, key, op, fvs)
 
-            ctrl_plane_acl_notification = set()
+                while True:
+                    key, op, fvs = subscribe_feature_table.pop()
+                    if not key:
+                        break
+                    if key != "redfish":
+                        continue
+                    new_state = (op == 'SET' and dict(fvs).get("state") == "enabled")
+                    if new_state == self.RedfishAllowed:
+                        continue
+                    if new_state:
+                        self.allow_redfish()
+                    else:
+                        self.block_redfish()
+                    # Re-walk so any existing REDFISH ACL rules get (de)programmed now.
+                    ctrl_plane_acl_notification.add(namespace)
 
             # Pop data of both Subscriber Table object of namespace that got config db acl table event
             for table in config_db_subscriber_table_map[namespace]:

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -1076,6 +1076,28 @@ class ControlPlaneAclManager(logger.Logger):
         self.RedfishAllowed = False
         self.log_info("Disabled REDFISH control plane ACL handling")
 
+    def handle_redfish_feature_events(self, subscribe_feature_table, namespace, ctrl_plane_acl_notification):
+        """Drain FEATURE table events and toggle REDFISH control plane ACL handling.
+
+        REDFISH iptables rules are only emitted when FEATURE.redfish is enabled. On a
+        state change, flip RedfishAllowed and request a re-walk so any existing REDFISH
+        ACL rules get (de)programmed immediately.
+        """
+        while True:
+            key, op, fvs = subscribe_feature_table.pop()
+            if not key:
+                break
+            if key != "redfish":
+                continue
+            new_state = (op == 'SET' and dict(fvs).get("state") == "enabled")
+            if new_state == self.RedfishAllowed:
+                continue
+            if new_state:
+                self.allow_redfish()
+            else:
+                self.block_redfish()
+            ctrl_plane_acl_notification.add(namespace)
+
     def remove_dash_ha_rules(self, namespace, port):
         iptables_cmds = []
         # Remove iptables/ip6tables commands that allow DASH-HA packets
@@ -1289,21 +1311,7 @@ class ControlPlaneAclManager(logger.Logger):
                     if "dash-ha" in self.feature_present:
                         self.update_dash_ha_rules(namespace, key, op, fvs)
 
-                while True:
-                    key, op, fvs = subscribe_feature_table.pop()
-                    if not key:
-                        break
-                    if key != "redfish":
-                        continue
-                    new_state = (op == 'SET' and dict(fvs).get("state") == "enabled")
-                    if new_state == self.RedfishAllowed:
-                        continue
-                    if new_state:
-                        self.allow_redfish()
-                    else:
-                        self.block_redfish()
-                    # Re-walk so any existing REDFISH ACL rules get (de)programmed now.
-                    ctrl_plane_acl_notification.add(namespace)
+                self.handle_redfish_feature_events(subscribe_feature_table, namespace, ctrl_plane_acl_notification)
 
             # Pop data of both Subscriber Table object of namespace that got config db acl table event
             for table in config_db_subscriber_table_map[namespace]:

--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -108,6 +108,11 @@ class ControlPlaneAclManager(logger.Logger):
             "dst_ports": ["22"],
             "multi_asic_ns_to_host_fwd":True
         },
+        "REDFISH": {
+            "ip_protocols": ["tcp"],
+            "dst_ports": ["443"],
+            "multi_asic_ns_to_host_fwd":False
+        },
         "EXTERNAL_CLIENT": {
             "ip_protocols": ["tcp"],
             "multi_asic_ns_to_host_fwd":False

--- a/tests/caclmgrd/caclmgrd_redfish_acl_test.py
+++ b/tests/caclmgrd/caclmgrd_redfish_acl_test.py
@@ -7,7 +7,7 @@ from sonic_py_common.general import load_module_from_source
 from unittest import TestCase, mock
 from pyfakefs.fake_filesystem_unittest import patchfs
 
-from .test_redfish_acl_vectors import REDFISH_ACL_TEST_VECTOR
+from .test_redfish_acl_vectors import REDFISH_ACL_TEST_VECTOR, REDFISH_ACL_DISABLED_FEATURE_VECTORS
 from tests.common.mock_configdb import MockConfigDb
 
 
@@ -43,8 +43,9 @@ class TestCaclmgrdRedfishAcl(TestCase):
         self.caclmgrd.ControlPlaneAclManager.get_chassis_midplane_interface_ip = mock.MagicMock(return_value='')
         caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
 
-        # Sanity: the dict entry under test must exist. If this assertion ever
-        # fires, scripts/caclmgrd is missing the REDFISH registration.
+        self.assertTrue(caclmgrd_daemon.RedfishAllowed,
+                        "Seed at __init__ should set RedfishAllowed=True for these vectors")
+
         self.assertIn("REDFISH", caclmgrd_daemon.ACL_SERVICES,
                       "ACL_SERVICES is missing the 'REDFISH' entry — see scripts/caclmgrd")
         self.assertEqual(caclmgrd_daemon.ACL_SERVICES["REDFISH"]["dst_ports"], ["443"])
@@ -55,3 +56,35 @@ class TestCaclmgrdRedfishAcl(TestCase):
         iptables_rules_ret = [tuple(i) for i in iptables_rules_ret]
         self.assertEqual(set(test_data["return"]).issubset(set(iptables_rules_ret)), True,
                          "Expected iptables rules not produced. Got: {}".format(iptables_rules_ret))
+
+    @parameterized.expand(REDFISH_ACL_DISABLED_FEATURE_VECTORS)
+    @patchfs
+    def test_caclmgrd_redfish_acl_skipped_when_feature_disabled(self, test_name, test_data, fs):
+        """
+            REDFISH only ships on BMC-equipped platforms. When the redfish FEATURE
+            is "disabled", RedfishAllowed stays False and an operator template
+            referencing the REDFISH service must not program any tcp/443 iptables
+            rules -- otherwise it would silently govern whatever else (if anything)
+            listens on 443. Parametrized over IPv4 and IPv6 to confirm the gate
+            skips REDFISH regardless of IP family.
+        """
+        if not os.path.exists(DBCONFIG_PATH):
+            fs.create_file(DBCONFIG_PATH)
+
+        MockConfigDb.set_config_db(test_data["config_db"])
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ip = mock.MagicMock()
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ipv6 = mock.MagicMock()
+        self.caclmgrd.ControlPlaneAclManager.generate_block_ip2me_traffic_iptables_commands = mock.MagicMock(return_value=[])
+        self.caclmgrd.ControlPlaneAclManager.get_chain_list = mock.MagicMock(return_value=["INPUT", "FORWARD", "OUTPUT"])
+        self.caclmgrd.ControlPlaneAclManager.get_chassis_midplane_interface_ip = mock.MagicMock(return_value='')
+        caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
+
+        self.assertFalse(caclmgrd_daemon.RedfishAllowed,
+                         "Seed at __init__ should set RedfishAllowed=False when FEATURE.redfish.state=disabled")
+
+        iptables_rules_ret, _ = caclmgrd_daemon.get_acl_rules_and_translate_to_iptables_commands('', MockConfigDb())
+
+        port_443_rules = [r for r in iptables_rules_ret if "--dport" in r and "443" in r]
+        self.assertEqual(port_443_rules, test_data["return"],
+                         "REDFISH ACL should be skipped when RedfishAllowed=False, "
+                         "but found tcp/443 rules: {}".format(port_443_rules))

--- a/tests/caclmgrd/caclmgrd_redfish_acl_test.py
+++ b/tests/caclmgrd/caclmgrd_redfish_acl_test.py
@@ -1,0 +1,57 @@
+import os
+import sys
+
+from swsscommon import swsscommon
+from parameterized import parameterized
+from sonic_py_common.general import load_module_from_source
+from unittest import TestCase, mock
+from pyfakefs.fake_filesystem_unittest import patchfs
+
+from .test_redfish_acl_vectors import REDFISH_ACL_TEST_VECTOR
+from tests.common.mock_configdb import MockConfigDb
+
+
+DBCONFIG_PATH = '/var/run/redis/sonic-db/database_config.json'
+
+
+class TestCaclmgrdRedfishAcl(TestCase):
+    """
+        Verifies that an ACL_TABLE referencing the REDFISH service produces
+        iptables rules on tcp/443. Guards against the ACL_SERVICES["REDFISH"]
+        entry being removed or renamed.
+    """
+    def setUp(self):
+        swsscommon.ConfigDBConnector = MockConfigDb
+        test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        modules_path = os.path.dirname(test_path)
+        scripts_path = os.path.join(modules_path, "scripts")
+        sys.path.insert(0, modules_path)
+        caclmgrd_path = os.path.join(scripts_path, 'caclmgrd')
+        self.caclmgrd = load_module_from_source('caclmgrd', caclmgrd_path)
+
+    @parameterized.expand(REDFISH_ACL_TEST_VECTOR)
+    @patchfs
+    def test_caclmgrd_redfish_acl(self, test_name, test_data, fs):
+        if not os.path.exists(DBCONFIG_PATH):
+            fs.create_file(DBCONFIG_PATH)
+
+        MockConfigDb.set_config_db(test_data["config_db"])
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ip = mock.MagicMock()
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ipv6 = mock.MagicMock()
+        self.caclmgrd.ControlPlaneAclManager.generate_block_ip2me_traffic_iptables_commands = mock.MagicMock(return_value=[])
+        self.caclmgrd.ControlPlaneAclManager.get_chain_list = mock.MagicMock(return_value=["INPUT", "FORWARD", "OUTPUT"])
+        self.caclmgrd.ControlPlaneAclManager.get_chassis_midplane_interface_ip = mock.MagicMock(return_value='')
+        caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
+
+        # Sanity: the dict entry under test must exist. If this assertion ever
+        # fires, scripts/caclmgrd is missing the REDFISH registration.
+        self.assertIn("REDFISH", caclmgrd_daemon.ACL_SERVICES,
+                      "ACL_SERVICES is missing the 'REDFISH' entry — see scripts/caclmgrd")
+        self.assertEqual(caclmgrd_daemon.ACL_SERVICES["REDFISH"]["dst_ports"], ["443"])
+        self.assertEqual(caclmgrd_daemon.ACL_SERVICES["REDFISH"]["ip_protocols"], ["tcp"])
+
+        iptables_rules_ret, _ = caclmgrd_daemon.get_acl_rules_and_translate_to_iptables_commands('', MockConfigDb())
+        test_data['return'] = [tuple(i) for i in test_data['return']]
+        iptables_rules_ret = [tuple(i) for i in iptables_rules_ret]
+        self.assertEqual(set(test_data["return"]).issubset(set(iptables_rules_ret)), True,
+                         "Expected iptables rules not produced. Got: {}".format(iptables_rules_ret))

--- a/tests/caclmgrd/caclmgrd_redfish_acl_test.py
+++ b/tests/caclmgrd/caclmgrd_redfish_acl_test.py
@@ -88,3 +88,58 @@ class TestCaclmgrdRedfishAcl(TestCase):
         self.assertEqual(port_443_rules, test_data["return"],
                          "REDFISH ACL should be skipped when RedfishAllowed=False, "
                          "but found tcp/443 rules: {}".format(port_443_rules))
+
+    @patchfs
+    def test_handle_redfish_feature_events(self, fs):
+        """
+            Drive handle_redfish_feature_events (the FEATURE-table subscription
+            handler) directly, covering every branch: enable transition, disable
+            transition, non-redfish event ignored, and same-state no-op.
+        """
+        if not os.path.exists(DBCONFIG_PATH):
+            fs.create_file(DBCONFIG_PATH)
+
+        MockConfigDb.set_config_db({
+            "DEVICE_METADATA": {"localhost": {}},
+            "FEATURE": {"redfish": {"state": "disabled"}},
+        })
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ip = mock.MagicMock()
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ipv6 = mock.MagicMock()
+        self.caclmgrd.ControlPlaneAclManager.generate_block_ip2me_traffic_iptables_commands = mock.MagicMock(return_value=[])
+        self.caclmgrd.ControlPlaneAclManager.get_chain_list = mock.MagicMock(return_value=["INPUT", "FORWARD", "OUTPUT"])
+        self.caclmgrd.ControlPlaneAclManager.get_chassis_midplane_interface_ip = mock.MagicMock(return_value='')
+        caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
+        self.assertFalse(caclmgrd_daemon.RedfishAllowed)
+
+        def sub_with(events):
+            sub = mock.MagicMock()
+            sub.pop.side_effect = events + [("", None, None)]
+            return sub
+
+        # enable: flag flips True and namespace queued for re-walk
+        notif = set()
+        caclmgrd_daemon.handle_redfish_feature_events(
+            sub_with([("redfish", "SET", (("state", "enabled"),))]), "", notif)
+        self.assertTrue(caclmgrd_daemon.RedfishAllowed)
+        self.assertIn("", notif)
+
+        # disable: flag flips False and namespace queued
+        notif = set()
+        caclmgrd_daemon.handle_redfish_feature_events(
+            sub_with([("redfish", "SET", (("state", "disabled"),))]), "", notif)
+        self.assertFalse(caclmgrd_daemon.RedfishAllowed)
+        self.assertIn("", notif)
+
+        # non-redfish FEATURE event: ignored, nothing queued
+        notif = set()
+        caclmgrd_daemon.handle_redfish_feature_events(
+            sub_with([("snmp", "SET", (("state", "enabled"),))]), "", notif)
+        self.assertFalse(caclmgrd_daemon.RedfishAllowed)
+        self.assertEqual(notif, set())
+
+        # same-state event (already disabled): no-op, nothing queued
+        notif = set()
+        caclmgrd_daemon.handle_redfish_feature_events(
+            sub_with([("redfish", "SET", (("state", "disabled"),))]), "", notif)
+        self.assertFalse(caclmgrd_daemon.RedfishAllowed)
+        self.assertEqual(notif, set())

--- a/tests/caclmgrd/test_redfish_acl_vectors.py
+++ b/tests/caclmgrd/test_redfish_acl_vectors.py
@@ -1,0 +1,77 @@
+"""
+    caclmgrd test redfish_acl vector
+
+    Verifies that an ACL_TABLE with services=["REDFISH"] is translated into
+    iptables rules targeting tcp/443. Mirrors test_external_client_acl_vectors
+    so the assertion shape is consistent across services.
+"""
+REDFISH_ACL_TEST_VECTOR = [
+    [
+        "Test single IPv4 src ip allow + default deny for REDFISH_ACL",
+        {
+            "config_db": {
+                "ACL_TABLE": {
+                    "REDFISH_ACL": {
+                        "stage": "INGRESS",
+                        "type": "CTRLPLANE",
+                        "services": [
+                            "REDFISH"
+                        ]
+                    }
+                },
+                "ACL_RULE": {
+                    "REDFISH_ACL|ALLOW_MGMT": {
+                        "PACKET_ACTION": "ACCEPT",
+                        "PRIORITY": "9998",
+                        "SRC_IP": "10.20.0.0/16"
+                    },
+                    "REDFISH_ACL|DENY_REST": {
+                        "PACKET_ACTION": "DROP",
+                        "PRIORITY": "1",
+                        "SRC_IP": "0.0.0.0/0"
+                    },
+                },
+                "DEVICE_METADATA": {
+                    "localhost": {
+                    }
+                },
+                "FEATURE": {},
+            },
+            "return": [
+                ['iptables', '-A', 'INPUT', '-p', 'tcp', '-s', '10.20.0.0/16', '--dport', '443', '-j', 'ACCEPT'],
+                ['iptables', '-A', 'INPUT', '-p', 'tcp', '-s', '0.0.0.0/0', '--dport', '443', '-j', 'DROP'],
+            ],
+        }
+    ],
+    [
+        "Test IPv6 src ip allow for REDFISH_ACL",
+        {
+            "config_db": {
+                "ACL_TABLE": {
+                    "REDFISH_ACL": {
+                        "stage": "INGRESS",
+                        "type": "CTRLPLANE",
+                        "services": [
+                            "REDFISH"
+                        ]
+                    }
+                },
+                "ACL_RULE": {
+                    "REDFISH_ACL|ALLOW_MGMT_V6": {
+                        "PACKET_ACTION": "ACCEPT",
+                        "PRIORITY": "9998",
+                        "SRC_IP": "2001:db8::/32"
+                    },
+                },
+                "DEVICE_METADATA": {
+                    "localhost": {
+                    }
+                },
+                "FEATURE": {},
+            },
+            "return": [
+                ['iptables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001:db8::/32', '--dport', '443', '-j', 'ACCEPT'],
+            ],
+        }
+    ],
+]

--- a/tests/caclmgrd/test_redfish_acl_vectors.py
+++ b/tests/caclmgrd/test_redfish_acl_vectors.py
@@ -60,7 +60,7 @@ REDFISH_ACL_TEST_VECTOR = [
                     "REDFISH_ACL|ALLOW_MGMT_V6": {
                         "PACKET_ACTION": "ACCEPT",
                         "PRIORITY": "9998",
-                        "SRC_IP": "2001:db8::/32"
+                        "SRC_IPV6": "2001:db8::/32"
                     },
                 },
                 "DEVICE_METADATA": {
@@ -70,7 +70,7 @@ REDFISH_ACL_TEST_VECTOR = [
                 "FEATURE": {},
             },
             "return": [
-                ['iptables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001:db8::/32', '--dport', '443', '-j', 'ACCEPT'],
+                ['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001:db8::/32', '--dport', '443', '-j', 'ACCEPT'],
             ],
         }
     ],

--- a/tests/caclmgrd/test_redfish_acl_vectors.py
+++ b/tests/caclmgrd/test_redfish_acl_vectors.py
@@ -35,7 +35,7 @@ REDFISH_ACL_TEST_VECTOR = [
                     "localhost": {
                     }
                 },
-                "FEATURE": {},
+                "FEATURE": {"redfish": {"state": "enabled"}},
             },
             "return": [
                 ['iptables', '-A', 'INPUT', '-p', 'tcp', '-s', '10.20.0.0/16', '--dport', '443', '-j', 'ACCEPT'],
@@ -44,7 +44,7 @@ REDFISH_ACL_TEST_VECTOR = [
         }
     ],
     [
-        "Test IPv6 src ip allow for REDFISH_ACL",
+        "Test IPv6 src ip allow + default deny for REDFISH_ACL",
         {
             "config_db": {
                 "ACL_TABLE": {
@@ -62,16 +62,98 @@ REDFISH_ACL_TEST_VECTOR = [
                         "PRIORITY": "9998",
                         "SRC_IPV6": "2001:db8::/32"
                     },
+                    "REDFISH_ACL|DENY_REST_V6": {
+                        "PACKET_ACTION": "DROP",
+                        "PRIORITY": "1",
+                        "SRC_IPV6": "::/0"
+                    },
                 },
                 "DEVICE_METADATA": {
                     "localhost": {
                     }
                 },
-                "FEATURE": {},
+                "FEATURE": {"redfish": {"state": "enabled"}},
             },
             "return": [
                 ['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '2001:db8::/32', '--dport', '443', '-j', 'ACCEPT'],
+                ['ip6tables', '-A', 'INPUT', '-p', 'tcp', '-s', '::/0', '--dport', '443', '-j', 'DROP'],
             ],
+        }
+    ],
+]
+
+
+# Same ACL_TABLE/ACL_RULE as the enabled vectors above, but with the redfish FEATURE
+# state set to "disabled" (the non-BMC platform case, or an Aspeed box where the
+# operator has disabled the feature). The gating test parametrizes over both IPv4
+# and IPv6 to confirm the walker skips REDFISH service regardless of IP family.
+REDFISH_ACL_DISABLED_FEATURE_VECTORS = [
+    [
+        "Disabled feature: IPv4 REDFISH ACL must be skipped",
+        {
+            "config_db": {
+                "ACL_TABLE": {
+                    "REDFISH_ACL": {
+                        "stage": "INGRESS",
+                        "type": "CTRLPLANE",
+                        "services": [
+                            "REDFISH"
+                        ]
+                    }
+                },
+                "ACL_RULE": {
+                    "REDFISH_ACL|ALLOW_MGMT": {
+                        "PACKET_ACTION": "ACCEPT",
+                        "PRIORITY": "9998",
+                        "SRC_IP": "10.20.0.0/16"
+                    },
+                    "REDFISH_ACL|DENY_REST": {
+                        "PACKET_ACTION": "DROP",
+                        "PRIORITY": "1",
+                        "SRC_IP": "0.0.0.0/0"
+                    },
+                },
+                "DEVICE_METADATA": {
+                    "localhost": {
+                    }
+                },
+                "FEATURE": {"redfish": {"state": "disabled"}},
+            },
+            "return": [],
+        }
+    ],
+    [
+        "Disabled feature: IPv6 REDFISH ACL must be skipped",
+        {
+            "config_db": {
+                "ACL_TABLE": {
+                    "REDFISH_ACL": {
+                        "stage": "INGRESS",
+                        "type": "CTRLPLANE",
+                        "services": [
+                            "REDFISH"
+                        ]
+                    }
+                },
+                "ACL_RULE": {
+                    "REDFISH_ACL|ALLOW_MGMT_V6": {
+                        "PACKET_ACTION": "ACCEPT",
+                        "PRIORITY": "9998",
+                        "SRC_IPV6": "2001:db8::/32"
+                    },
+                    "REDFISH_ACL|DENY_REST_V6": {
+                        "PACKET_ACTION": "DROP",
+                        "PRIORITY": "1",
+                        "SRC_IPV6": "::/0"
+                    },
+                },
+                "DEVICE_METADATA": {
+                    "localhost": {
+                    }
+                },
+                "FEATURE": {"redfish": {"state": "disabled"}},
+            },
+            "return": [],
         }
     ],
 ]


### PR DESCRIPTION
#### Why I did it
The Redfish docker (docker-sonic-redfish) binds host port `0.0.0.0:443:18080` (per the docker-sonic-redfish rules in sonic-buildimage), so any IP that can reach the BMC management interface on TCP/443 can hit the Redfish API. `caclmgrd` only emits iptables rules for services that are registered in its `ACL_SERVICES` dict. Without an entry for REDFISH, any operator-defined ACL_TABLE referencing it is silently dropped i.e. the framework has no way to translate the operator's intent into iptables rules. This patch adds that registration and gates it so it only takes effect on platforms where Redfish actually runs.


#### How I did it
1. **Registration:** Added a REDFISH entry (tcp/443) to ACL_SERVICES in `scripts/caclmgrd`, mirroring the existing SSH/SNMP/NTP entries.
2. **Platform gating:** REDFISH only ships on BMC platforms, so to keep a stray services=["REDFISH"] template from programming tcp/443 rules elsewhere, REDFISH handling is gated on the FEATURE.redfish state:
    * A RedfishAllowed flag, checked in `get_acl_rules_and_translate_to_iptables_commands` - REDFISH services are skipped (with a warning) when the feature isn't enabled.
    * A FEATURE table subscriber flips the flag on runtime config feature state redfish enabled/disabled and re-walks so iptables converges immediately.
    * The flag is seeded from CONFIG_DB in __init__, before the initial iptables walk, so a caclmgrd restart doesn't leave tcp/443 momentarily ungated.
**Net:** REDFISH rules are programmed iff FEATURE.redfish.state == "enabled". On non-BMC platforms a stray REDFISH template is a no-op (warn + ignore).
3. **Tests:** Unit tests covering the walker for IPv4 + IPv6, in both enabled (rules emitted) and disabled (rules skipped) states.

#### How to verify it

1. Confirm the entry shipped:
   ```bash
   sudo grep -A4 '"REDFISH"' /usr/local/bin/caclmgrd
   ```

2. Confirm the feature is enabled (rules are only programmed when it is):
   ```bash
   sonic-db-cli CONFIG_DB hget "FEATURE|redfish" state    # expect: enabled
   ```

3. Create the CTRLPLANE table (acl-loader manages rules, not tables), then load rules via `acl-loader`:

   ```bash
   # Table (one-time; acl-loader does not create CTRLPLANE tables)
   redis-cli -n 4 HSET "ACL_TABLE|REDFISH_ACL" \
       policy_desc REDFISH_ACL type CTRLPLANE stage ingress services@ REDFISH

   # Rules
   cat > /tmp/redfish_acl.json <<'EOF'
   {
       "acl": {
           "acl-sets": {
               "acl-set": {
                   "REDFISH-ACL": {
                       "config": { "name": "REDFISH-ACL" },
                       "acl-entries": {
                           "acl-entry": {
                               "1": {
                                   "config": { "sequence-id": 1 },
                                   "ip": { "config": { "source-ip-address": "<your-source-ip>/32" } },
                                   "actions": { "config": { "forwarding-action": "ACCEPT" } }
                               }
                           }
                       }
                   }
               }
           }
       }
   }
   EOF

   acl-loader update full /tmp/redfish_acl.json
   ```

   > The acl-set name `REDFISH-ACL` maps to table `REDFISH_ACL` (uppercased, `-`→`_`). `acl-loader` auto-appends a `DEFAULT_RULE` (DROP), so the allowlist behaves as deny-by-default — no explicit deny rule needed. The destination port (443) comes from the `ACL_SERVICES` entry, so the rule only specifies the source IP.

4. Confirm caclmgrd translated them into iptables:
   ```bash
   show acl table REDFISH_ACL
   show acl rule REDFISH_ACL
   sudo iptables -L INPUT -n --line-numbers | grep ':443'
   ```
   You should see your `ACCEPT` for `<your-source-ip>` on dport 443 plus a trailing `DROP`.

Remove when done:
```bash
acl-loader delete REDFISH_ACL
redis-cli -n 4 DEL "ACL_TABLE|REDFISH_ACL"
```