### PR TITLE
[Featured][systemd] Generated service should not be enabled in featured

### DIFF
--- a/scripts/featured
+++ b/scripts/featured
@@ -482,8 +482,9 @@ class FeatureHandler(object):
 
             # If feature has timer associated with it, start/enable corresponding systemd .timer unit
             # otherwise, start/enable corresponding systemd .service unit
-
-            cmds.append(["sudo", "systemctl", "enable", "{}.{}".format(feature_name, feature_suffixes[-1])])
+            if unit_file_state != "generated":
+                # if UnitFileState of service file is generated, enable it will generate error
+                cmds.append(["sudo", "systemctl", "enable", "{}.{}".format(feature_name, feature_suffixes[-1])])
             cmds.append(["sudo", "systemctl", "start", "{}.{}".format(feature_name, feature_suffixes[-1])])
 
             for cmd in cmds:


### PR DESCRIPTION
#### Why I did it
On multiasic platform, with Trixie, there will be services that will be defined in /run/systemd/generator as "generatad" UnitFileState. Such as  PMON, SNMP, radv and other are generated service.  Enabling such services fails because it's assumed to be always enabled.  This PR modifies the featured to skip enabling the generated services.  Fix issue https://github.com/sonic-net/sonic-buildimage/issues/25414
 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Featured always enabled the service files based on the configuration of the feature table.  This PR add code to check is UnitFileState is generated, skip and not append the "systemctl enable <service>" command to the  cmds list.

#### How to verify it
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
bootup the new image in the multiasic platform, the following log should not be seen in the syslog:
```
2026 Feb  4 05:37:49.443422  sonic ERR featured: ['sudo', 'systemctl', 'enable', 'eventd.service'] - failed: return code - 1, output:              
2026 Feb  4 05:37:55.587767 sonic ERR featured: ['sudo', 'systemctl', 'enable', 'pmon.service'] - failed: return code - 1, output:             
2026 Feb  4 05:37:58.027168 soinc ERR featured: ['sudo', 'systemctl', 'enable', 'radv.service'] - failed: return code - 1, output:
2026 Feb  4 05:40:41.483658 sonic ERR featured: ['sudo', 'systemctl', 'enable', 'gnmi.service'] - failed: return code - 1, output:              
2026 Feb  4 05:40:49.039632 sonic ERR featured: ['sudo', 'systemctl', 'enable', 'mgmt-framework.service'] - failed: return code - 1, output:              
2026 Feb  4 05:40:51.358646 sonic ERR featured: ['sudo', 'systemctl', 'enable', 'snmp.service'] - failed: return code - 1, output:
``` 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
