### PR TITLE
azure-pipelines: install libyang3 instead of libyang1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ stages:
         sudo dpkg -i libnl-genl-3-200_*.deb
         sudo dpkg -i libnl-route-3-200_*.deb
         sudo dpkg -i libnl-nf-3-200_*.deb
-        sudo dpkg -i libyang_1.0.73_*.deb
+        sudo dpkg -i libyang3_*.deb
         sudo dpkg -i libswsscommon_1.0.0_amd64.deb
         sudo dpkg -i libswsscommon-dev_1.0.0_amd64.deb
         sudo dpkg -i python3-swsscommon_1.0.0_amd64.deb


### PR DESCRIPTION
#### Why I did it
sonic-buildimage no longer builds the libyang1 Debian packages (`libyang_1.0.73`, `libyang-cpp`, `python3-yang`); it now builds only libyang3. The CI pipeline here installs `libyang_1.0.73_*.deb` from the downloaded sonic-buildimage build artifacts, which no longer exist, so the dependency install step would fail.

Part of sonic-net/sonic-buildimage#22385.

#### How I did it
Updated `azure-pipelines.yml` to install the libyang3 deb using a versionless glob instead of the removed libyang1 deb:
- `sudo dpkg -i libyang_1.0.73_*.deb` → `sudo dpkg -i libyang3_*.deb`

No `libyang-cpp`, `python3-yang`, or `libyang-dev` references exist in this repository, so no other changes were needed.

#### How to verify it
Run the Azure pipeline (or the "Install Debian dependencies" step) against artifacts from a current sonic-buildimage build. The `libyang3_*.deb` glob resolves to the libyang3 package produced by sonic-buildimage and installs successfully, where the old `libyang_1.0.73_*.deb` glob would match nothing.

#### Description for the changelog
azure-pipelines: install libyang3 instead of libyang1
