### PR TITLE
[caclmgrd]: Preserve dhcp_server_syslog rule during CACL rebuild

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -715,6 +715,10 @@ class ControlPlaneAclManager(logger.Logger):
         iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['iptables', '-A', 'INPUT', '-p', 'udp', '--dport', '546:547', '-j', 'ACCEPT'])
         iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-A', 'INPUT', '-p', 'udp', '--dport', '546:547', '-j', 'ACCEPT'])
 
+        # Add iptables command to allow dhcp_server syslog traffic via docker0
+        if not namespace and "dhcp_server" in self.feature_present:
+            iptables_cmds += self.get_dhcp_server_syslog_iptable_commands(namespace)
+
         # Add iptables/ip6tables commands to allow all incoming BGP traffic
         # TODO: Determine BGP ACLs based on configured device sessions, and remove this blanket acceptance
         iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + self.exclude_mgmt_port(['iptables', '-A', 'INPUT', '-p', 'tcp', '--dport', '179', '-j', 'ACCEPT']))
@@ -1056,6 +1060,12 @@ class ControlPlaneAclManager(logger.Logger):
         self.log_info("Disabled vxlan port for source ip " + self.VxlanSrcIP)
         self.VxlanSrcIP = ""
         return True
+
+    def get_dhcp_server_syslog_iptable_commands(self, namespace):
+        iptables_cmds = []
+        # IPv6 intentionally skipped: docker0 bridge traffic is IPv4-only
+        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['iptables', '-A', 'INPUT', '-i', 'docker0', '-p', 'udp', '--dport', '514', '-m', 'comment', '--comment', 'dhcp_server_syslog', '-j', 'ACCEPT'])
+        return iptables_cmds
 
     def remove_dash_ha_rules(self, namespace, port):
         iptables_cmds = []

--- a/tests/caclmgrd/caclmgrd_dhcp_server_syslog_test.py
+++ b/tests/caclmgrd/caclmgrd_dhcp_server_syslog_test.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+from swsscommon import swsscommon
+from parameterized import parameterized
+from unittest import TestCase, mock
+from pyfakefs.fake_filesystem_unittest import patchfs
+from sonic_py_common.general import load_module_from_source
+
+from .test_dhcp_server_syslog_vectors import CACLMGRD_DHCP_SERVER_SYSLOG_TEST_VECTOR
+from tests.common.mock_configdb import MockConfigDb
+
+DBCONFIG_PATH = '/var/run/redis/sonic-db/database_config.json'
+
+
+class TestCaclmgrdDhcpServerSyslog(TestCase):
+    """
+    Test to verify dhcp_server syslog iptables rule survives CACL rebuild when feature is enabled
+    """
+    def setUp(self):
+        swsscommon.ConfigDBConnector = MockConfigDb
+        test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        modules_path = os.path.dirname(test_path)
+        scripts_path = os.path.join(modules_path, "scripts")
+        sys.path.insert(0, modules_path)
+        caclmgrd_path = os.path.join(scripts_path, 'caclmgrd')
+        self.caclmgrd = load_module_from_source('caclmgrd', caclmgrd_path)
+        self.dhcp_server_syslog_rule = ('iptables', '-A', 'INPUT', '-i', 'docker0', '-p', 'udp', '--dport', '514', '-m', 'comment', '--comment', 'dhcp_server_syslog', '-j', 'ACCEPT')
+
+    @parameterized.expand(CACLMGRD_DHCP_SERVER_SYSLOG_TEST_VECTOR)
+    @patchfs
+    def test_caclmgrd_dhcp_server_syslog(self, test_name, test_data, fs):
+        if not os.path.exists(DBCONFIG_PATH):
+            fs.create_file(DBCONFIG_PATH)  # fake database_config.json
+
+        MockConfigDb.set_config_db(test_data["config_db"])
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ip = mock.MagicMock()
+        self.caclmgrd.ControlPlaneAclManager.get_namespace_mgmt_ipv6 = mock.MagicMock()
+        self.caclmgrd.ControlPlaneAclManager.generate_block_ip2me_traffic_iptables_commands = mock.MagicMock(return_value=[])
+        self.caclmgrd.ControlPlaneAclManager.get_chain_list = mock.MagicMock(return_value=["INPUT", "FORWARD", "OUTPUT"])
+        self.caclmgrd.ControlPlaneAclManager.get_chassis_midplane_interface_ip = mock.MagicMock(return_value='')
+        caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
+
+        iptables_rules_ret, _ = caclmgrd_daemon.get_acl_rules_and_translate_to_iptables_commands('', MockConfigDb())
+        iptables_rules_ret = [tuple(i) for i in iptables_rules_ret]
+        if test_data["rule_should_be_present"]:
+            self.assertIn(self.dhcp_server_syslog_rule, iptables_rules_ret)
+        else:
+            self.assertNotIn(self.dhcp_server_syslog_rule, iptables_rules_ret)

--- a/tests/caclmgrd/test_dhcp_server_syslog_vectors.py
+++ b/tests/caclmgrd/test_dhcp_server_syslog_vectors.py
@@ -1,0 +1,42 @@
+from unittest.mock import call
+
+"""
+    caclmgrd dhcp_server syslog test vector
+"""
+CACLMGRD_DHCP_SERVER_SYSLOG_TEST_VECTOR = [
+    [
+        "DHCP_SERVER_SYSLOG_PRESENT",
+        {
+            "config_db": {
+                "DEVICE_METADATA": {
+                    "localhost": {
+                        "subtype": "DualToR",
+                        "type": "ToRRouter",
+                    }
+                },
+                "FEATURE": {
+                    "dhcp_server": {
+                        "auto_restart": "enabled",
+                        "state": "enabled",
+                    },
+                },
+            },
+            "rule_should_be_present": True,
+        }
+    ],
+    [
+        "DHCP_SERVER_SYSLOG_ABSENT",
+        {
+            "config_db": {
+                "DEVICE_METADATA": {
+                    "localhost": {
+                        "subtype": "DualToR",
+                        "type": "ToRRouter",
+                    }
+                },
+                "FEATURE": {},
+            },
+            "rule_should_be_present": False,
+        }
+    ],
+]


### PR DESCRIPTION
#### Why I did it

Fix https://github.com/sonic-net/sonic-buildimage/issues/27584

The dhcp_server container uses Docker bridge networking and sends syslog traffic to the host through docker0. Its iptables rule (`-A INPUT -i docker0 -p udp --dport 514 -m comment --comment dhcp_server_syslog -j ACCEPT`) is created by docker_image_ctl.j2 during container startup but has no representation in CONFIG_DB.

When caclmgrd processes a CACL update, it flushes all INPUT chain rules and rebuilds from CONFIG_DB state. Since the dhcp_server_syslog rule exists only in the kernel, it is permanently lost until the dhcp_server container is restarted. This silently breaks syslog delivery from dhcp_server after any CACL configuration change.

#### How I did it
* Regenerate the dhcp_server_syslog iptables rule during caclmgrd's flush-and-rebuild cycle when the dhcp_server feature is present in the FEATURE table, gated to host namespace only
* Add unit tests validating both feature-present (rule inserted) and feature-absent (rule skipped) cases

#### How to verify it
1. Enable dhcp_server feature and verify the syslog rule exists: `iptables -S | grep dhcp_server_syslog`
2. Apply a CACL update: `sonic-db-cli CONFIG_DB HSET "ACL_TABLE|TEST" "policy_desc" "test" "type" "CTRLPLANE" "stage" "ingress" "services@" "SSH"`
3. Verify the syslog rule is preserved: `iptables -S | grep dhcp_server_syslog`

#### Description for the changelog
Fix caclmgrd to preserve dhcp_server_syslog iptables rule during CACL flush-and-rebuild cycle