### PR TITLE
[reboot_test] Fix flaky time.time() assertions on second boundaries

### DIFF
--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -201,6 +201,7 @@ class TestReboot(object):
             assert any("Error checking if halt command is running: [psutil error]" in record.message for record in caplog.records)
 
     def test_execute_reboot_success(self):
+        """WARM reboot reaches the post-sleep failure-flag path when reboot command returns success."""
         with (
             mock.patch("reboot._run_command") as mock_run_command,
             mock.patch("time.sleep") as mock_sleep,
@@ -220,6 +221,7 @@ class TestReboot(object):
             assert caplog.records[0].message == msg
 
     def test_execute_reboot_fail_issue_reboot_command_cold_boot(self, caplog):
+        """Cold-boot reboot command returning non-zero logs the error and records a failure timestamp."""
         with (
             mock.patch("reboot._run_command") as mock_run_command,
             mock.patch("time.time", return_value=TIME),
@@ -235,6 +237,7 @@ class TestReboot(object):
             mock_populate_reboot_status_flag.assert_called_once_with(False, TIME, "Failed to execute reboot command", 1, RebootStatus.STATUS_FAILURE)
 
     def test_execute_reboot_fail_issue_reboot_command_halt(self, caplog):
+        """Halt reboot command returning non-zero logs the error and records a failure timestamp."""
         with (
             mock.patch("reboot._run_command") as mock_run_command,
             mock.patch("time.time", return_value=TIME),
@@ -265,6 +268,7 @@ class TestReboot(object):
             mock_populate_reboot_status_flag.assert_called_once_with(False, 0, 'Halt reboot completed', 3, RebootStatus.STATUS_SUCCESS)
 
     def test_execute_reboot_fail_halt_timeout(self, caplog):
+        """Halt reboot times out with pmon still running and records a failure timestamp."""
         with (
             mock.patch("reboot._run_command") as mock_run_command,
             mock.patch("time.sleep") as mock_sleep,
@@ -283,6 +287,7 @@ class TestReboot(object):
             mock_populate_reboot_status_flag.assert_called_once_with(False, TIME, 'Halt reboot did not complete', 3, RebootStatus.STATUS_FAILURE)
 
     def test_execute_reboot_fail_issue_reboot_command_warm(self, caplog):
+        """WARM reboot command returning non-zero logs the error and records a failure timestamp."""
         with (
             mock.patch("reboot._run_command") as mock_run_command,
             mock.patch("time.time", return_value=TIME),

--- a/tests/host_modules/reboot_test.py
+++ b/tests/host_modules/reboot_test.py
@@ -204,13 +204,14 @@ class TestReboot(object):
         with (
             mock.patch("reboot._run_command") as mock_run_command,
             mock.patch("time.sleep") as mock_sleep,
+            mock.patch("time.time", return_value=TIME),
             mock.patch("reboot.Reboot.populate_reboot_status_flag") as mock_populate_reboot_status_flag,
         ):
             mock_run_command.return_value = (0, ["stdout: execute WARM reboot"], ["stderror: execute WARM reboot"])
             self.reboot_module.execute_reboot("WARM")
             mock_run_command.assert_called_once_with("sudo warm-reboot")
             mock_sleep.assert_called_once_with(260)
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int(time.time()), "Reboot command failed to execute", 'WARM', RebootStatus.STATUS_FAILURE)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, TIME, "Reboot command failed to execute", 'WARM', RebootStatus.STATUS_FAILURE)
 
     def test_execute_reboot_fail_unknown_reboot(self, caplog):
         with caplog.at_level(logging.ERROR):
@@ -221,6 +222,7 @@ class TestReboot(object):
     def test_execute_reboot_fail_issue_reboot_command_cold_boot(self, caplog):
         with (
             mock.patch("reboot._run_command") as mock_run_command,
+            mock.patch("time.time", return_value=TIME),
             mock.patch("reboot.Reboot.populate_reboot_status_flag") as mock_populate_reboot_status_flag,
             caplog.at_level(logging.ERROR),
         ):
@@ -230,11 +232,12 @@ class TestReboot(object):
                     "stdout: ['stdout: execute cold reboot'], stderr: "
                     "['stderror: execute cold reboot']")
             assert caplog.records[0].message == msg
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 1, RebootStatus.STATUS_FAILURE)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, TIME, "Failed to execute reboot command", 1, RebootStatus.STATUS_FAILURE)
 
     def test_execute_reboot_fail_issue_reboot_command_halt(self, caplog):
         with (
             mock.patch("reboot._run_command") as mock_run_command,
+            mock.patch("time.time", return_value=TIME),
             mock.patch("reboot.Reboot.populate_reboot_status_flag") as mock_populate_reboot_status_flag,
             caplog.at_level(logging.ERROR),
         ):
@@ -244,7 +247,7 @@ class TestReboot(object):
                    "stdout: ['stdout: execute halt reboot'], stderr: "
                    "['stderror: execute halt reboot']")
             assert caplog.records[0].message == msg
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 3, RebootStatus.STATUS_FAILURE)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, TIME, "Failed to execute reboot command", 3, RebootStatus.STATUS_FAILURE)
 
     def test_execute_reboot_success_halt(self):
         with (
@@ -265,6 +268,7 @@ class TestReboot(object):
         with (
             mock.patch("reboot._run_command") as mock_run_command,
             mock.patch("time.sleep") as mock_sleep,
+            mock.patch("time.time", return_value=TIME),
             mock.patch("reboot.Reboot.is_halt_command_running", return_value=True) as mock_is_halt_command_running,
             mock.patch("reboot.Reboot.is_container_running", return_value=True) as mock_is_container_running,
             mock.patch("reboot.Reboot.populate_reboot_status_flag") as mock_populate_reboot_status_flag,
@@ -276,11 +280,12 @@ class TestReboot(object):
             mock_sleep.assert_called_with(5)
             mock_is_halt_command_running.assert_called()
             assert any("HALT reboot failed: Services are still running" in record.message for record in caplog.records)
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int(time.time()), 'Halt reboot did not complete', 3, RebootStatus.STATUS_FAILURE)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, TIME, 'Halt reboot did not complete', 3, RebootStatus.STATUS_FAILURE)
 
     def test_execute_reboot_fail_issue_reboot_command_warm(self, caplog):
         with (
             mock.patch("reboot._run_command") as mock_run_command,
+            mock.patch("time.time", return_value=TIME),
             mock.patch("reboot.Reboot.populate_reboot_status_flag") as mock_populate_reboot_status_flag,
             caplog.at_level(logging.ERROR),
         ):
@@ -290,7 +295,7 @@ class TestReboot(object):
                     "stdout: ['stdout: execute WARM reboot'], stderr: "
                     "['stderror: execute WARM reboot']")
             assert caplog.records[0].message == msg
-            mock_populate_reboot_status_flag.assert_called_once_with(False, int (time.time()), "Failed to execute reboot command", 'WARM', RebootStatus.STATUS_FAILURE)
+            mock_populate_reboot_status_flag.assert_called_once_with(False, TIME, "Failed to execute reboot command", 'WARM', RebootStatus.STATUS_FAILURE)
 
     def test_issue_reboot_success_cold_boot(self):
         with (


### PR DESCRIPTION
**Why I did it**

The execute_reboot pytest cases in tests/host_modules/reboot_test.py were flaky on second boundaries. The production code in host_modules/reboot.py records a failure timestamp via int(time.time()) and the tests compared that recorded value against another freshly-sampled int(time.time()) inside the assertion. When the wall clock ticked over a second between the production call and the assertion, the two integers differed by 1 and the test failed.

This was observed in a SONiC builds where test_execute_reboot_fail_issue_reboot_command_warm failed with:

```
Expected: populate_reboot_status_flag(False, 1779879232, 'Failed to execute reboot command', 'WARM', STATUS_FAILURE)
  Actual: populate_reboot_status_flag(False, 1779879231, 'Failed to execute reboot command', 'WARM', STATUS_FAILURE)
```

Four other tests in the same file shared the identical race and would have failed at random as well.


**How I did it**
In each of the five affected tests, added mock.patch("time.time", return_value=TIME) to the existing with block and replaced the in-assertion int(time.time()) with the literal TIME constant (already defined at the top of the file as 1617811205). This matches the pattern already in use by test_populate_reboot_status_flag and test_populate_reboot_status_flag_with_status in the same file.

Tests updated:

- test_execute_reboot_success
- test_execute_reboot_fail_issue_reboot_command_cold_boot
- test_execute_reboot_fail_issue_reboot_command_halt
- test_execute_reboot_fail_halt_timeout
- test_execute_reboot_fail_issue_reboot_command_warm

Production code is untouched. The halt-timeout loop in reboot.py uses time.monotonic() rather than time.time(), so patching time.time does not affect any production control flow.