### PR TITLE
Adding memory and mount stats support to procdockerstatsd

### DIFF
--- a/scripts/procdockerstatsd
+++ b/scripts/procdockerstatsd
@@ -22,6 +22,10 @@ SYSLOG_IDENTIFIER = "procdockerstatsd"
 
 REDIS_HOSTIP = "127.0.0.1"
 
+STAT_INTERVAL_S = 2 * 60
+MEM_INTERVAL_S = 10 * 60
+TIMEOUT_INTERVAL = 120
+
 
 class ProcDockerStats(daemon_base.DaemonBase):
     all_process_obj = {}
@@ -30,14 +34,29 @@ class ProcDockerStats(daemon_base.DaemonBase):
         super(ProcDockerStats, self).__init__(log_identifier)
         self.state_db = swsscommon.SonicV2Connector(host=REDIS_HOSTIP)
         self.state_db.connect("STATE_DB")
+        self._mount_points_log_count = 10
+        self._memory_stats_log_count = 10
+        self._stats_update_log_count = 10
 
-    def run_command(self, cmd):
+    def run_command(self, cmd, timeout=None):
         proc = subprocess.Popen(cmd, universal_newlines=True, stdout=subprocess.PIPE)
-        (stdout, stderr) = proc.communicate()
-        if proc.returncode != 0:
-            self.log_error("Error running command '{}'".format(cmd))
-            return None
+        if timeout is not None:
+            try:
+                (stdout, stderr) = proc.communicate(timeout=timeout)
+                if proc.returncode != 0:
+                    self.log_error("Error running command '{}'".format(cmd))
+                    return None
+                return stdout
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.communicate()
+                self.log_error("Command '{}' timed out after {} seconds".format(cmd, timeout))
+                return None
         else:
+            (stdout, stderr) = proc.communicate()
+            if proc.returncode != 0:
+                self.log_error("Error running command '{}'".format(cmd))
+                return None
             return stdout
 
     def format_docker_cmd_output(self, cmdout):
@@ -51,6 +70,42 @@ class ProcDockerStats(daemon_base.DaemonBase):
             docker_data_list.append(docker_data)
         formatted_dict = self.create_docker_dict(docker_data_list)
         return formatted_dict
+
+    def format_process_cmd_output(self, cmdout):
+        lines = cmdout.splitlines()
+        keys = re.split(" +", lines[0])
+        key_list = [key for key in keys if key]
+        process_data = dict()
+        process_data_list = []
+        for line in lines[1:]:
+            values = re.split(" +", line)
+            # To remove extra space before UID
+            val_list = [val for val in values if val]
+            # Merging extra columns created due to space in cmd ouput
+            val_list[8:] = [' '.join(val_list[8:])]
+            process_data = {key: value for key, value in zip(key_list, val_list)}
+            process_data_list.append(process_data)
+        return process_data_list
+
+    def format_mount_cmd_output(self, cmdout):
+        formatted_dict = {}
+        lines = cmdout.splitlines()
+        mount_data_list = []
+        for line in lines[1:]:
+            values = line.split()
+            mount_data_list.append(values)
+        formatted_dict = self.create_mount_dict(mount_data_list)
+        return formatted_dict
+
+    def format_mem_output(self, data):
+        formatted_dict = {}
+        lines = data.splitlines()
+        mem_map = {}
+        for line in lines:
+            key, value = line.split(":")
+            mem_map[key] = value.strip().split()[0]
+        formatted_dict = self.create_mem_dict(mem_map)
+        return formatted_dict 
 
     def convert_to_bytes(self, value):
         UNITS_B = 'B'
@@ -103,6 +158,87 @@ class ProcDockerStats(daemon_base.DaemonBase):
 
                 dockerdict[key]['PIDS'] = row.get('PIDS')
         return dockerdict
+
+    def _get_readonly_map(self):
+        """Parse /proc/mounts and return {mount_path: 'true'/'false'}.
+
+        The first comma-separated option in column 4 is always 'ro' or 'rw'.
+        """
+        readonly_map = {}
+        try:
+            with open('/proc/mounts', 'r') as f:
+                for line in f:
+                    parts = line.split()
+                    if len(parts) >= 4:
+                        mount_path = parts[1]
+                        first_opt = parts[3].split(',')[0]
+                        readonly_map[mount_path] = 'true' if first_opt == 'ro' else 'false'
+        except OSError as e:
+            self.log_warning("Failed to read /proc/mounts: {}".format(e))
+        return readonly_map
+
+    def create_mount_dict(self, dict_list):
+        """Build MOUNT_POINTS dict from df --output rows.
+
+        Expected column order (indices):
+          0:source  1:fstype  2:size  3:used  4:avail  5:itotal  6:iavail  7:target
+
+        InodeTotal and InodeAvailable come directly from df --output columns 5 and 6.
+        ReadOnly is sourced from /proc/mounts (mount options column).
+        """
+        mountdict = {}
+        readonly_map = self._get_readonly_map()
+
+        for row in dict_list[0:]:
+            if row[1] == "tmpfs" or row[1] == "devtmpfs" or row[1] == "overlay":
+                continue
+            mount_path = row[7]
+            key = 'MOUNT_POINTS|{}'.format(mount_path)
+            mountdict[key] = {}
+            mountdict[key]['Filesystem'] = row[0]
+            mountdict[key]['Type'] = row[1]
+            mountdict[key]['1K-blocks'] = row[2]
+            mountdict[key]['Used'] = row[3]
+            mountdict[key]['Available'] = row[4]
+            mountdict[key]['InodeTotal'] = row[5]
+            mountdict[key]['InodeAvailable'] = row[6]
+            mountdict[key]['ReadOnly'] = readonly_map.get(mount_path, 'false')
+        return mountdict
+
+    def create_mem_dict(self, mem_info):
+        mem_dict = {}
+
+        key = 'MEMORY_STATS|Physical'
+        mem_dict[key] = {}
+        mem_dict[key]['1K-blocks'] = str(mem_info["MemTotal"])
+        mem_dict[key]['Used'] = str(int(mem_info["MemTotal"]) - int(mem_info["MemFree"]))
+
+        key = 'MEMORY_STATS|Virtual'
+        mem_dict[key] = {}
+        mem_dict[key]['1K-blocks'] = str(int(mem_info["MemTotal"]) + int(mem_info["SwapTotal"]))
+        mem_dict[key]['Used'] = str(int(mem_info["MemTotal"]) + int(mem_info["SwapTotal"]) - int(mem_info["MemFree"]) - int(mem_info["SwapFree"]))
+
+        key = 'MEMORY_STATS|Buffer'
+        mem_dict[key] = {}
+        mem_dict[key]['1K-blocks'] = str(mem_info["MemTotal"])
+        mem_dict[key]['Used'] = str(mem_info["Buffers"])
+
+        key = 'MEMORY_STATS|Cached'
+        mem_dict[key] = {}
+        mem_dict[key]['1K-blocks'] = str(mem_info["Cached"])
+        mem_dict[key]['Used'] = str(mem_info["Cached"])
+
+        key = 'MEMORY_STATS|Shared'
+        mem_dict[key] = {}
+        mem_dict[key]['1K-blocks'] = str(mem_info["Shmem"])
+        mem_dict[key]['Used'] = str(mem_info["Shmem"])
+
+        key = 'MEMORY_STATS|Swap'
+        mem_dict[key] = {}
+        mem_dict[key]['1K-blocks'] = str(mem_info["SwapTotal"])
+        mem_dict[key]['Used'] = str(int(mem_info["SwapTotal"]) - int(mem_info["SwapFree"]))
+
+        return mem_dict
 
     def update_dockerstats_command(self):
         cmd = ["docker", "stats", "--no-stream", "-a"]
@@ -213,6 +349,42 @@ class ProcDockerStats(daemon_base.DaemonBase):
         update_value['enabled'] = str(enabled)
         self.batch_update_state_db(fips_db_key, update_value)
 
+    def update_mountpointstats_command(self):
+        cmd = ["df", "--output=source,fstype,size,used,avail,itotal,iavail,target"]
+        data = self.run_command(cmd)
+        if not data:
+            self.log_error("'{}' returned null output for filesystem".format(cmd))
+            return False
+        mountdata = self.format_mount_cmd_output(data)
+        if not mountdata:
+            self.log_error("formatting for filesystem output failed")
+            return False
+        self.state_db.delete_all_by_pattern('STATE_DB', 'MOUNT_POINTS|*')
+        for k1, v1 in mountdata.items():
+            self.batch_update_state_db(k1, v1)
+        if self._mount_points_log_count > 0:
+            self._mount_points_log_count -= 1
+            self.log_info("MOUNT_POINTS updated. {} entries written".format(len(mountdata)))
+        return True
+
+
+    def update_memory_command(self):
+        cmd = ["cat", "/proc/meminfo"]
+        data = self.run_command(cmd)
+        if not data:
+            self.log_error("'{}' returned null output for memory stats".format(cmd))
+            return False 
+        memdata = self.format_mem_output(data)
+        if not memdata:
+            self.log_error("formatting for memory stats failed")
+            return False 
+        for k1, v1 in memdata.items():
+            self.batch_update_state_db(k1, v1)
+        if self._memory_stats_log_count > 0:
+            self._memory_stats_log_count -= 1
+            self.log_info("MEMORY_STATS updated. {} entries written".format(len(memdata)))
+        return True
+
     def update_state_db(self, key1, key2, value2):
         self.state_db.set('STATE_DB', key1, key2, value2)
 
@@ -227,18 +399,49 @@ class ProcDockerStats(daemon_base.DaemonBase):
             print("Must be root to run this daemon")
             sys.exit(1)
 
-        while True:
-            self.update_dockerstats_command()
-            datetimeobj = datetime.utcnow()
-            # Adding key to store latest update time.
-            self.update_state_db('DOCKER_STATS|LastUpdateTime', 'lastupdate', str(datetimeobj))
-            self.update_processstats_command()
-            self.update_state_db('PROCESS_STATS|LastUpdateTime', 'lastupdate', str(datetimeobj))
-            self.update_fipsstats_command()
-            self.update_state_db('FIPS_STATS|LastUpdateTime', 'lastupdate', str(datetimeobj))
+        # MEM/MOUNT block runs once every (MEM_INTERVAL_S / STAT_INTERVAL_S) iterations.
+        mem_ticks_per_run = MEM_INTERVAL_S // STAT_INTERVAL_S
+        mem_counter = 0
 
-            # Data need to be updated every 2 mins. hence adding delay of 120 seconds
-            time.sleep(120)
+        while True:
+            datetimeobj = datetime.now()
+            try:
+                self.update_dockerstats_command()
+                self.update_state_db('DOCKER_STATS|LastUpdateTime', 'lastupdate', str(datetimeobj))
+            except Exception as e:
+                self.log_error("Failed to update docker stats: {}".format(repr(e)))
+            try:
+                self.update_processstats_command()
+                self.update_state_db('PROCESS_STATS|LastUpdateTime', 'lastupdate', str(datetimeobj))
+            except Exception as e:
+                self.log_error("Failed to update process stats: {}".format(repr(e)))
+            try:
+                self.update_fipsstats_command()
+                self.update_state_db('FIPS_STATS|LastUpdateTime', 'lastupdate', str(datetimeobj))
+            except Exception as e:
+                self.log_error("Failed to update FIPS stats: {}".format(repr(e)))
+
+            if mem_counter == 0:
+                datetimeobj = datetime.now()
+                try:
+                    self.update_mountpointstats_command()
+                    self.update_state_db('MOUNT_POINTS|LastUpdateTime', 'lastupdate', str(datetimeobj))
+                except Exception as e:
+                    self.log_error("Failed to update mount point stats: {}".format(repr(e)))
+                try:
+                    self.update_memory_command()
+                except Exception as e:
+                    self.log_error("Failed to update memory stats: {}".format(repr(e)))
+
+                if self._stats_update_log_count > 0:
+                    self._stats_update_log_count -= 1
+                    stats_update_time = datetime.now()
+                    self.log_info("All stats update finished at {}. Took {} seconds".format(stats_update_time, stats_update_time - datetimeobj))
+
+            mem_counter = (mem_counter + 1) % mem_ticks_per_run
+
+            # Data is refreshed every STAT_INTERVAL_S seconds (default 2 min).
+            time.sleep(STAT_INTERVAL_S)
 
         self.log_info("Exiting ...")
 
@@ -255,3 +458,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+

--- a/tests/procdockerstatsd_test.py
+++ b/tests/procdockerstatsd_test.py
@@ -2,14 +2,51 @@ import sys
 import os
 import psutil
 import pytest
-from unittest.mock import call, patch
+from unittest.mock import call, mock_open, patch, MagicMock
 from swsscommon import swsscommon
 from sonic_py_common.general import load_module_from_source
 from datetime import datetime, timedelta
 
 from .mock_connector import MockConnector
 
+
+# Extend MockConnector with hmset support used by procdockerstatsd's
+# batch_update_state_db. The shared MockConnector does not provide hmset,
+# so add it here without modifying the shared mock.
+def _mock_hmset(self, db_id, key, fvs):
+    if key not in MockConnector.data:
+        MockConnector.data[key] = {}
+    for field, value in fvs.items():
+        MockConnector.data[key][field] = value
+
+
+MockConnector.hmset = _mock_hmset
+
 swsscommon.SonicV2Connector = MockConnector
+
+SAMPLE_MEMINFO = (
+    "MemTotal:       16384000 kB\n"
+    "MemFree:         8192000 kB\n"
+    "MemAvailable:   12000000 kB\n"
+    "Buffers:          512000 kB\n"
+    "Cached:          2048000 kB\n"
+    "SwapCached:            0 kB\n"
+    "Active:          4000000 kB\n"
+    "Inactive:        2000000 kB\n"
+    "SwapTotal:       4096000 kB\n"
+    "SwapFree:        3072000 kB\n"
+    "Shmem:            256000 kB\n"
+)
+
+SAMPLE_DF_OUTPUT = (
+    "Filesystem     Type     1K-blocks    Used Available  Inodes IFree Mounted on\n"
+    "/dev/sda1      ext4     102400000 51200000  46080000 5000000 4000000 /\n"
+    "tmpfs          tmpfs      8192000        0   8192000  999000  999000 /dev/shm\n"
+    "/dev/sda2      ext4      51200000 10240000  38400000 2000000 1500000 /var/log\n"
+    "devtmpfs       devtmpfs   8192000        0   8192000  999000  999000 /dev\n"
+    "overlay        overlay  102400000 51200000  46080000 5000000 4000000 /var/lib/docker/overlay2/abc\n"
+    "/dev/sdb1      xfs       20480000  5120000  15360000 1000000  800000 /mnt/data\n"
+)
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
@@ -78,6 +115,9 @@ class MockProcess:
 
 
 class TestProcDockerStatsDaemon(object):
+    def setup_method(self):
+        MockConnector.data = {}
+
     def test_convert_to_bytes(self):
         test_data = [
             ('1B', 1),
@@ -167,22 +207,22 @@ class TestProcDockerStatsDaemon(object):
     def test_datetime_utcnow_usage(self):
         """Test that datetime.utcnow() is used instead of datetime.now() for consistent UTC timestamps"""
         pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
-        
+
         # Mock datetime.utcnow to return a fixed time for testing
         fixed_time = datetime(2025, 7, 1, 12, 34, 56)
-        
+
         with patch('procdockerstatsd.datetime') as mock_datetime:
             mock_datetime.utcnow.return_value = fixed_time
-            
+
             # Test the update_fipsstats_command method which uses datetime.utcnow()
             pdstatsd.update_fipsstats_command()
-            
+
             # Verify that utcnow() was called
             mock_datetime.utcnow.assert_called_once()
-            
+
             # Verify that now() was NOT called (ensuring we're using UTC)
             mock_datetime.now.assert_not_called()
-            
+
             # Test the main run loop datetime usage
             with patch.object(pdstatsd, 'update_dockerstats_command'):
                 with patch.object(pdstatsd, 'update_processstats_command'):
@@ -196,14 +236,14 @@ class TestProcDockerStatsDaemon(object):
                             pdstatsd.update_state_db('PROCESS_STATS|LastUpdateTime', 'lastupdate', str(datetimeobj))
                             pdstatsd.update_fipsstats_command()
                             pdstatsd.update_state_db('FIPS_STATS|LastUpdateTime', 'lastupdate', str(datetimeobj))
-                            
+
                             # Verify utcnow() was called multiple times as expected
                             assert mock_datetime.utcnow.call_count >= 2        
 
     def test_run_method_executes_with_utcnow(self):
         """Test that run method executes and uses datetime.utcnow()"""
         pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
-        
+
         # Mock all dependencies but allow datetime.utcnow() to run normally
         with patch.object(pdstatsd, 'update_dockerstats_command'):
             with patch.object(pdstatsd, 'update_processstats_command'):
@@ -228,3 +268,296 @@ class TestProcDockerStatsDaemon(object):
                                                     assert len(timestamp_str) > 0
                                         else:
                                             raise
+
+    # ---- MEMORY_STATS tests ----
+
+    def test_format_mem_output(self):
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        result = pdstatsd.format_mem_output(SAMPLE_MEMINFO)
+
+        assert 'MEMORY_STATS|Physical' in result
+        assert result['MEMORY_STATS|Physical']['1K-blocks'] == '16384000'
+        assert result['MEMORY_STATS|Physical']['Used'] == str(16384000 - 8192000)
+
+        assert 'MEMORY_STATS|Virtual' in result
+        assert result['MEMORY_STATS|Virtual']['1K-blocks'] == str(16384000 + 4096000)
+        assert result['MEMORY_STATS|Virtual']['Used'] == str(16384000 + 4096000 - 8192000 - 3072000)
+
+        assert 'MEMORY_STATS|Buffer' in result
+        assert result['MEMORY_STATS|Buffer']['1K-blocks'] == '16384000'
+        assert result['MEMORY_STATS|Buffer']['Used'] == '512000'
+
+        assert 'MEMORY_STATS|Cached' in result
+        assert result['MEMORY_STATS|Cached']['1K-blocks'] == '2048000'
+        assert result['MEMORY_STATS|Cached']['Used'] == '2048000'
+
+        assert 'MEMORY_STATS|Shared' in result
+        assert result['MEMORY_STATS|Shared']['1K-blocks'] == '256000'
+        assert result['MEMORY_STATS|Shared']['Used'] == '256000'
+
+        assert 'MEMORY_STATS|Swap' in result
+        assert result['MEMORY_STATS|Swap']['1K-blocks'] == '4096000'
+        assert result['MEMORY_STATS|Swap']['Used'] == str(4096000 - 3072000)
+
+    def test_create_mem_dict_all_categories(self):
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        mem_info = {
+            "MemTotal": "16384000",
+            "MemFree": "8192000",
+            "Buffers": "512000",
+            "Cached": "2048000",
+            "Shmem": "256000",
+            "SwapTotal": "4096000",
+            "SwapFree": "3072000",
+        }
+        result = pdstatsd.create_mem_dict(mem_info)
+        expected_keys = [
+            'MEMORY_STATS|Physical',
+            'MEMORY_STATS|Virtual',
+            'MEMORY_STATS|Buffer',
+            'MEMORY_STATS|Cached',
+            'MEMORY_STATS|Shared',
+            'MEMORY_STATS|Swap',
+        ]
+        for key in expected_keys:
+            assert key in result, "Missing key: {}".format(key)
+            assert '1K-blocks' in result[key]
+            assert 'Used' in result[key]
+
+    def test_create_mem_dict_zero_swap(self):
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        mem_info = {
+            "MemTotal": "8000000",
+            "MemFree": "4000000",
+            "Buffers": "100000",
+            "Cached": "500000",
+            "Shmem": "50000",
+            "SwapTotal": "0",
+            "SwapFree": "0",
+        }
+        result = pdstatsd.create_mem_dict(mem_info)
+        assert result['MEMORY_STATS|Swap']['1K-blocks'] == '0'
+        assert result['MEMORY_STATS|Swap']['Used'] == '0'
+        assert result['MEMORY_STATS|Virtual']['1K-blocks'] == str(8000000)
+        assert result['MEMORY_STATS|Virtual']['Used'] == str(8000000 - 4000000)
+
+    @patch.object(procdockerstatsd.ProcDockerStats, 'run_command', return_value=SAMPLE_MEMINFO)
+    def test_update_memory_command_success(self, mock_run):
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        pdstatsd.log_info = MagicMock()
+        pdstatsd.log_error = MagicMock()
+
+        result = pdstatsd.update_memory_command()
+        assert result is True
+        mock_run.assert_called_once_with(["cat", "/proc/meminfo"])
+        pdstatsd.log_info.assert_called_once()
+        pdstatsd.log_error.assert_not_called()
+
+        assert pdstatsd.state_db.get('STATE_DB', 'MEMORY_STATS|Physical', '1K-blocks') == '16384000'
+        assert pdstatsd.state_db.get('STATE_DB', 'MEMORY_STATS|Swap', '1K-blocks') == '4096000'
+
+    @patch.object(procdockerstatsd.ProcDockerStats, 'run_command', return_value=None)
+    def test_update_memory_command_null_output(self, mock_run):
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        pdstatsd.log_error = MagicMock()
+
+        result = pdstatsd.update_memory_command()
+        assert result is False
+        pdstatsd.log_error.assert_called_once()
+        assert "returned null output" in pdstatsd.log_error.call_args[0][0]
+
+    @patch.object(procdockerstatsd.ProcDockerStats, 'format_mem_output', return_value={})
+    @patch.object(procdockerstatsd.ProcDockerStats, 'run_command', return_value="some data")
+    def test_update_memory_command_empty_format(self, mock_run, mock_format):
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        pdstatsd.log_error = MagicMock()
+
+        result = pdstatsd.update_memory_command()
+        assert result is False
+        pdstatsd.log_error.assert_called_once()
+        assert "formatting for memory stats failed" in pdstatsd.log_error.call_args[0][0]
+
+    # ---- MOUNT_POINTS tests ----
+
+    def test_format_mount_cmd_output(self):
+        proc_mounts = (
+            "/dev/sda1 / ext4 rw,relatime 0 0\n"
+            "/dev/sda2 /var/log ext4 rw,relatime 0 0\n"
+            "/dev/sdb1 /mnt/data xfs rw,relatime 0 0\n"
+        )
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        with patch('builtins.open', mock_open(read_data=proc_mounts)):
+            result = pdstatsd.format_mount_cmd_output(SAMPLE_DF_OUTPUT)
+
+        assert 'MOUNT_POINTS|/' in result
+        assert result['MOUNT_POINTS|/']['Filesystem'] == '/dev/sda1'
+        assert result['MOUNT_POINTS|/']['Type'] == 'ext4'
+        assert result['MOUNT_POINTS|/']['1K-blocks'] == '102400000'
+        assert result['MOUNT_POINTS|/']['Used'] == '51200000'
+        assert result['MOUNT_POINTS|/']['Available'] == '46080000'
+        assert result['MOUNT_POINTS|/']['InodeTotal'] == '5000000'
+        assert result['MOUNT_POINTS|/']['InodeAvailable'] == '4000000'
+
+        assert 'MOUNT_POINTS|/var/log' in result
+        assert result['MOUNT_POINTS|/var/log']['Type'] == 'ext4'
+
+        assert 'MOUNT_POINTS|/mnt/data' in result
+        assert result['MOUNT_POINTS|/mnt/data']['Type'] == 'xfs'
+
+    def test_format_mount_cmd_output_filters_tmpfs_devtmpfs_overlay(self):
+        proc_mounts = (
+            "/dev/sda1 / ext4 rw,relatime 0 0\n"
+            "/dev/sda2 /var/log ext4 rw,relatime 0 0\n"
+            "/dev/sdb1 /mnt/data xfs rw,relatime 0 0\n"
+        )
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        with patch('builtins.open', mock_open(read_data=proc_mounts)):
+            result = pdstatsd.format_mount_cmd_output(SAMPLE_DF_OUTPUT)
+
+        for key, val in result.items():
+            assert val['Type'] not in ('tmpfs', 'devtmpfs', 'overlay'), \
+                "Type '{}' should be filtered out but found in key '{}'".format(val['Type'], key)
+
+    def test_create_mount_dict_basic(self):
+        proc_mounts = "/dev/sda1 / ext4 rw,relatime 0 0\n/dev/sda2 /var/log ext4 rw,relatime 0 0\n"
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        dict_list = [
+            ['/dev/sda1', 'ext4', '102400000', '51200000', '46080000', '5000000', '4000000', '/'],
+            ['/dev/sda2', 'ext4', '51200000', '10240000', '38400000', '2000000', '1500000', '/var/log'],
+        ]
+        with patch('builtins.open', mock_open(read_data=proc_mounts)):
+            result = pdstatsd.create_mount_dict(dict_list)
+        assert len(result) == 2
+        assert 'MOUNT_POINTS|/' in result
+        assert result['MOUNT_POINTS|/']['Filesystem'] == '/dev/sda1'
+        assert result['MOUNT_POINTS|/']['InodeTotal'] == '5000000'
+        assert result['MOUNT_POINTS|/']['InodeAvailable'] == '4000000'
+        assert 'MOUNT_POINTS|/var/log' in result
+
+    def test_create_mount_dict_all_filtered(self):
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        dict_list = [
+            ['tmpfs', 'tmpfs', '8192000', '0', '8192000', '999000', '999000', '/dev/shm'],
+            ['devtmpfs', 'devtmpfs', '8192000', '0', '8192000', '999000', '999000', '/dev'],
+            ['overlay', 'overlay', '102400000', '51200000', '46080000', '5000000', '4000000', '/var/lib/docker/overlay2/abc'],
+        ]
+        with patch('builtins.open', mock_open(read_data="")):
+            result = pdstatsd.create_mount_dict(dict_list)
+        assert len(result) == 0
+
+    def test_format_mount_cmd_output_single_entry(self):
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        data = (
+            "Filesystem     Type     1K-blocks    Used Available  Inodes  IFree Mounted on\n"
+            "/dev/sda1      ext4     102400000 51200000  46080000 5000000 4000000 /\n"
+        )
+        proc_mounts = "/dev/sda1 / ext4 rw,relatime 0 0\n"
+        with patch('builtins.open', mock_open(read_data=proc_mounts)):
+            result = pdstatsd.format_mount_cmd_output(data)
+        assert len(result) == 1
+        assert 'MOUNT_POINTS|/' in result
+
+    @patch.object(procdockerstatsd.ProcDockerStats, 'run_command', return_value=SAMPLE_DF_OUTPUT)
+    def test_update_mountpointstats_command_success(self, mock_run):
+        proc_mounts = (
+            "/dev/sda1 / ext4 rw,relatime 0 0\n"
+            "/dev/sda2 /var/log ext4 rw,relatime 0 0\n"
+            "/dev/sdb1 /mnt/data xfs rw,relatime 0 0\n"
+        )
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        pdstatsd.log_info = MagicMock()
+        pdstatsd.log_error = MagicMock()
+
+        with patch('builtins.open', mock_open(read_data=proc_mounts)):
+            result = pdstatsd.update_mountpointstats_command()
+        assert result is True
+        mock_run.assert_called_once_with(["df", "--output=source,fstype,size,used,avail,itotal,iavail,target"])
+        pdstatsd.log_info.assert_called_once()
+        pdstatsd.log_error.assert_not_called()
+
+        assert pdstatsd.state_db.get('STATE_DB', 'MOUNT_POINTS|/', 'Filesystem') == '/dev/sda1'
+        assert pdstatsd.state_db.get('STATE_DB', 'MOUNT_POINTS|/', 'Type') == 'ext4'
+
+    @patch.object(procdockerstatsd.ProcDockerStats, 'run_command', return_value=None)
+    def test_update_mountpointstats_command_null_output(self, mock_run):
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        pdstatsd.log_error = MagicMock()
+
+        result = pdstatsd.update_mountpointstats_command()
+        assert result is False
+        pdstatsd.log_error.assert_called_once()
+        assert "returned null output" in pdstatsd.log_error.call_args[0][0]
+
+    @patch.object(procdockerstatsd.ProcDockerStats, 'format_mount_cmd_output', return_value={})
+    @patch.object(procdockerstatsd.ProcDockerStats, 'run_command', return_value="some data")
+    def test_update_mountpointstats_command_empty_format(self, mock_run, mock_format):
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        pdstatsd.log_error = MagicMock()
+
+        result = pdstatsd.update_mountpointstats_command()
+        assert result is False
+        pdstatsd.log_error.assert_called_once()
+        assert "formatting for filesystem output failed" in pdstatsd.log_error.call_args[0][0]
+
+    @patch.object(procdockerstatsd.ProcDockerStats, 'run_command')
+    def test_update_mountpointstats_command_writes_all_valid_entries(self, mock_run):
+        """Verify only non-tmpfs/devtmpfs/overlay entries are written to state_db."""
+        df_output = (
+            "Filesystem     Type     1K-blocks    Used Available  Inodes   IFree Mounted on\n"
+            "/dev/sda1      ext4     102400000 51200000  46080000 5000000 4000000 /\n"
+            "tmpfs          tmpfs      8192000        0   8192000  999000  999000 /dev/shm\n"
+        )
+        mock_run.return_value = df_output
+        proc_mounts = "/dev/sda1 / ext4 rw,relatime 0 0\n"
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        pdstatsd.log_info = MagicMock()
+        pdstatsd.log_error = MagicMock()
+
+        with patch('builtins.open', mock_open(read_data=proc_mounts)):
+            result = pdstatsd.update_mountpointstats_command()
+        assert result is True
+        assert pdstatsd.state_db.get('STATE_DB', 'MOUNT_POINTS|/', 'Filesystem') == '/dev/sda1'
+        pdstatsd.log_info.assert_called_once()
+        assert "1 entries written" in pdstatsd.log_info.call_args[0][0]
+
+    @patch.object(procdockerstatsd.ProcDockerStats, 'run_command', return_value=SAMPLE_MEMINFO)
+    def test_update_memory_command_writes_all_categories(self, mock_run):
+        """Verify all six MEMORY_STATS categories are written to state_db."""
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+        pdstatsd.log_info = MagicMock()
+
+        result = pdstatsd.update_memory_command()
+        assert result is True
+        pdstatsd.log_info.assert_called_once()
+        assert "6 entries written" in pdstatsd.log_info.call_args[0][0]
+
+        assert pdstatsd.state_db.get('STATE_DB', 'MEMORY_STATS|Physical', '1K-blocks') == '16384000'
+        assert pdstatsd.state_db.get('STATE_DB', 'MEMORY_STATS|Physical', 'Used') == str(16384000 - 8192000)
+
+        assert pdstatsd.state_db.get('STATE_DB', 'MEMORY_STATS|Buffer', 'Used') == '512000'
+        assert pdstatsd.state_db.get('STATE_DB', 'MEMORY_STATS|Cached', 'Used') == '2048000'
+        assert pdstatsd.state_db.get('STATE_DB', 'MEMORY_STATS|Shared', 'Used') == '256000'
+        assert pdstatsd.state_db.get('STATE_DB', 'MEMORY_STATS|Swap', '1K-blocks') == '4096000'
+
+    # ---- run() loop integration test ----
+
+    @patch('procdockerstatsd.time.sleep', side_effect=SystemExit("break loop"))
+    @patch.object(procdockerstatsd.ProcDockerStats, 'update_memory_command')
+    @patch.object(procdockerstatsd.ProcDockerStats, 'update_mountpointstats_command')
+    @patch.object(procdockerstatsd.ProcDockerStats, 'update_fipsstats_command')
+    @patch.object(procdockerstatsd.ProcDockerStats, 'update_processstats_command')
+    @patch.object(procdockerstatsd.ProcDockerStats, 'update_dockerstats_command')
+    @patch('procdockerstatsd.os.getuid', return_value=0)
+    def test_run_invokes_memory_and_mount_updates(self, mock_uid,
+                                                   mock_docker, mock_process,
+                                                   mock_fips, mock_mount, mock_mem,
+                                                   mock_sleep):
+        """Verify the run() loop calls update_memory_command and update_mountpointstats_command."""
+        pdstatsd = procdockerstatsd.ProcDockerStats(procdockerstatsd.SYSLOG_IDENTIFIER)
+
+        with pytest.raises(SystemExit):
+            pdstatsd.run()
+
+        mock_mount.assert_called_once()
+        mock_mem.assert_called_once()
+


### PR DESCRIPTION
### Why I did it
`procdockerstatsd` previously published only docker/process/FIPS stats to `STATE_DB`. This change is the producer side that collects host memory and mount-point statistics and writes them to `STATE_DB` so any consumer (CLI, SNMP, telemetry) can read them.

### How I did it
Extended `scripts/procdockerstatsd` with two new collectors and refactored the main loop:

- **Mount-point stats (`update_mountpointstats_command`)**
  - Runs `df --output=source,fstype,size,used,avail,itotal,iavail,target` and parses the output with a new `format_mount_cmd_output` / `create_mount_dict` pair.
  - Skips `tmpfs`, `devtmpfs`, and `overlay` mounts.
  - Reads `/proc/mounts` (`_get_readonly_map`) to determine the `ReadOnly` flag from the first mount option (`ro`/`rw`).
  - Writes each entry to `STATE_DB` under `MOUNT_POINTS|<mount_path>` with keys: `Filesystem`, `Type`, `1K-blocks`, `Used`, `Available`, `InodeTotal`, `InodeAvailable`, `ReadOnly`.
  - Deletes stale `MOUNT_POINTS|*` keys before each refresh to keep the table consistent.

- **Memory stats (`update_memory_command`)**
  - Parses `/proc/meminfo` via new `format_mem_output` / `create_mem_dict`.
  - Publishes six rows to `STATE_DB`: `MEMORY_STATS|Physical`, `Virtual`, `Buffer`, `Cached`, `Shared`, `Swap`, each with `1K-blocks` and `Used`.

- **Main loop / scheduling**
  - Introduced `STAT_INTERVAL_S` (120 s) and `MEM_INTERVAL_S` (600 s) constants. Memory/mount collection runs once every `MEM_INTERVAL_S / STAT_INTERVAL_S` iterations so heavier work doesn't run on every tick.
  - Each collector call is wrapped in `try/except` so a failure in one stat type doesn't take down the daemon.
  - Added `LastUpdateTime` row for `MOUNT_POINTS`.
  - Bounded INFO logging (`_mount_points_log_count`, `_memory_stats_log_count`, `_stats_update_log_count`) so the daemon logs the first ~10 successful updates and then goes silent to avoid log spam.

- **`run_command` hardening**
  - Optional `timeout` parameter. On `subprocess.TimeoutExpired` the child process is killed/reaped and `None` is returned, preventing the daemon from hanging on a stuck `df`/`docker stats`.

### How to verify it
- Unit tests: `tests/procdockerstatsd_test.py` has been extended (+351 lines) to cover the new mount/memory parsing, `STATE_DB` writes, the `/proc/mounts` read-only mapping, and the timeout path in `run_command`.