### PR TITLE
`hostcfgd`: fix `mgmtVrfEnabled` state caching causing unnecessary interface restarts

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -1617,7 +1617,7 @@ class MgmtIfaceCfg(object):
     def load(self, mgmt_iface={}, mgmt_vrf={}):
         # Get initial data
         self.iface_config_data = mgmt_iface
-        self.mgmt_vrf_enabled = mgmt_vrf.get('mgmtVrfEnabled', '')
+        self.mgmt_vrf_enabled = mgmt_vrf.get('vrf_global', {}).get('mgmtVrfEnabled', '')
         syslog.syslog(syslog.LOG_DEBUG,
                       f'Initial mgmt interface conf: {self.iface_config_data}')
         syslog.syslog(syslog.LOG_DEBUG,

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -415,9 +415,30 @@ class TestHostcfgdDaemon(TestCase):
                 ]
                 mocked_check_output.assert_has_calls(expected)
 
+    def test_mgmtvrf_no_restart_on_same_state(self):
+        """
+        Verify that load() correctly reads mgmtVrfEnabled from the nested
+        'vrf_global' row so that a subsequent update_mgmt_vrf() call with the
+        same value does NOT trigger an interfaces-config restart.
+
+        This is a regression test for the bug where load() used
+        mgmt_vrf.get('mgmtVrfEnabled') instead of
+        mgmt_vrf.get('vrf_global', {}).get('mgmtVrfEnabled'), causing the
+        cache to always be initialised to '' and every config load to
+        incorrectly detect a state change and restart interfaces-config.
+        """
+        mgmtiface = hostcfgd.MgmtIfaceCfg()
+        mgmtiface.load({}, {'vrf_global': {'mgmtVrfEnabled': 'true'}})
+        assert mgmtiface.mgmt_vrf_enabled == 'true'
+
+        with mock.patch('hostcfgd.subprocess') as mocked_subprocess:
+            mocked_subprocess.CalledProcessError = CalledProcessError
+            mgmtiface.update_mgmt_vrf({'mgmtVrfEnabled': 'true'})
+            mocked_subprocess.check_call.assert_not_called()
+
     def test_mgmtvrf_route_check_failed(self):
         mgmtiface = hostcfgd.MgmtIfaceCfg()
-        mgmtiface.load({}, {'mgmtVrfEnabled' : "false"})
+        mgmtiface.load({}, {'vrf_global': {'mgmtVrfEnabled': "false"}})
         with mock.patch('hostcfgd.check_output_pipe') as mocked_check_output:
             with mock.patch('hostcfgd.subprocess') as mocked_subprocess:
                 popen_mock = mock.Mock()


### PR DESCRIPTION
# Problem Summary
Executing `config load -y` repeatedly on a SONiC switch causes unexpected SSH session teardowns. The management interface would be reconfigured on every configuration load even when no actual configuration changes were made.

# Symptoms
- SSH sessions to the switch device are terminated unexpectedly during `config load -y` operations
- The `interfaces-config` service restarts unnecessarily on every config load
- Management connectivity instability during configuration operations

# Root Cause
The `MgmtIfaceCfg.load()` method in `hostcfgd` was incorrectly retrieving the `mgmtVrfEnabled` value from the top level of the `mgmt_vrf` dictionary:

```python
self.mgmt_vrf_enabled = mgmt_vrf.get('mgmtVrfEnabled', '')
```

However, the actual data structure passed from `HostConfigDaemon.load()` is a full table dict keyed by row name, following [the YANG model](https://github.com/sonic-net/sonic-buildimage/blob/bb0715a3f15fc523dbf14b1643861d3b1704bf85/src/sonic-yang-models/yang-models/sonic-mgmt_vrf.yang#L25) for `sonic-mgmt_vrf`. This means the correct way to read the value is:

```python
mgmt_vrf.get('vrf_global', {}).get('mgmtVrfEnabled', '')
```

## Impact
The internal cache (`self.mgmt_vrf_enabled`) was always initialized to `''` (empty string)
`update_mgmt_vrf()` would compare the actual value (`'true'` or `'false'`) against `''`
This resulted in a "state change" detection interfaces-config service would be restarted on every config load, disrupting network connectivity.

# Full changes description

- Fixed the retrieval logic in `MgmtIfaceCfg.load()` to properly access the nested `vrf_global` row
- Added a regression test (`test_mgmtvrf_no_restart_on_same_state`) that verifies:
  - Correct initialization of `mgmt_vrf_enabled` from the nested structure;
  - No service restart is triggered when the VRF state hasn't changed;
- Updated the existing test (`test_mgmtvrf_route_check_failed`) to use the correct nested dictionary structure.

# Evidence (system logs)

## 1. `hostcfgd` detects VRF state change and restarts interfaces-config
```
2026 Jun 19 13:01:39.121253 device-**** DEBUG hostcfgd: MgmtIfaceCfg: mgmt vrf state update
2026 Jun 19 13:01:39.121312 device-**** INFO hostcfgd: Set mgmt vrf state true
```

## 2. `interfaces-config` service is stopped (causing network disruption)
```
2026 Jun 19 13:01:39.150709 device-****INFO systemd[1]: interfaces-config.service: Deactivated successfully.
2026 Jun 19 13:01:39.151148 device-**** INFO systemd[1]: Stopped interfaces-config.service - Update interfaces configuration.
2026 Jun 19 13:01:39.151354 device-**** INFO systemd[1]: Stopping interfaces-config.service - Update interfaces configuration...
```

## 3. Management interface goes down (`eth0`)
```
2026 Jun 19 13:01:40.783461 device-**** INFO bgp#pimd[45]: [W6DJA-XRCK3] PIM INTERFACE DOWN: on interface mgmt: link down
2026 Jun 19 13:01:41.549599 device-**** INFO kernel: [ 4758.942832] igb 0000:02:00.0 eth0: igb: eth0 NIC Link is Up 1000 Mbps Full Duplex
```

## 4. Network services restart causing connectivity loss
```
2026 Jun 19 13:01:40.390748 device-**** INFO systemd[1]: Stopping networking.service - Network initialization...
2026 Jun 19 13:01:40.952964 device-**** INFO systemd[1]: networking.service: Deactivated successfully.
2026 Jun 19 13:01:40.953374 device-**** INFO systemd[1]: Stopped networking.service - Network initialization.
2026 Jun 19 13:01:40.983539 device-**** INFO systemd[1]: Starting networking.service - Network initialization...
```