### PR TITLE
Withdrawn: no-op placeholder

### DIFF
--- a/data/PR401_WITHDRAWN.txt
+++ b/data/PR401_WITHDRAWN.txt
@@ -1,0 +1,1 @@
+Withdrawn PR placeholder. No code change intended.


### PR DESCRIPTION
Withdrawn.

This PR is intentionally replaced with a no-op placeholder and closed. The change is moved to internal tracking.
