### PR TITLE
[hostcfgd] Fix run_cmd error handling when the command binary is missing

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -125,8 +125,8 @@ def run_cmd(cmd, log_err=True, raise_exception=False):
         subprocess.check_call(cmd)
     except Exception as err:
         if log_err:
-            syslog.syslog(syslog.LOG_ERR, "{} - failed: return code - {}, output:\n{}"
-                  .format(err.cmd, err.returncode, err.output))
+            syslog.syslog(syslog.LOG_ERR, "{} - failed: return code - {}, output:\n{}, err: {}"
+                  .format(getattr(err, 'cmd', cmd), getattr(err, 'returncode', None), getattr(err, 'output', None), err))
         if raise_exception:
             raise
 
@@ -135,8 +135,8 @@ def run_cmd_pipe(cmd0, cmd1, cmd2, log_err=True, raise_exception=False):
         check_output_pipe(cmd0, cmd1, cmd2)
     except Exception as err:
         if log_err:
-            syslog.syslog(syslog.LOG_WARNING, "{} - failed: return code - {}, output:\n{}"
-                  .format(err.cmd, err.returncode, err.output))
+            syslog.syslog(syslog.LOG_WARNING, "{} - failed: return code - {}, output:\n{}, err: {}"
+                  .format(getattr(err, 'cmd', [cmd0, cmd1, cmd2]), getattr(err, 'returncode', None), getattr(err, 'output', None), err))
         if raise_exception:
             raise
 
@@ -146,8 +146,8 @@ def run_cmd_output(cmd, log_err=True, raise_exception=False):
         output = subprocess.check_output(cmd)
     except Exception as err:
         if log_err:
-            syslog.syslog(syslog.LOG_ERR, "{} - failed: return code - {}, output:\n{}"
-                  .format(err.cmd, err.returncode, err.output))
+            syslog.syslog(syslog.LOG_ERR, "{} - failed: return code - {}, output:\n{}, err: {}"
+                  .format(getattr(err, 'cmd', cmd), getattr(err, 'returncode', None), getattr(err, 'output', None), err))
         if raise_exception:
             raise
     return output

--- a/tests/hostcfgd/hostcfgd_test.py
+++ b/tests/hostcfgd/hostcfgd_test.py
@@ -3,6 +3,7 @@ import sys
 import time
 import signal
 import psutil
+import pytest
 import swsscommon as swsscommon_package
 from subprocess import CalledProcessError
 from sonic_py_common import device_info
@@ -461,6 +462,79 @@ class TestHostcfgdDaemon(TestCase):
             except TimeoutError:
                 pass
             mocked_run_cmd.assert_has_calls([call(['systemctl', 'restart', 'resolv-config'], True, False)])
+
+class TestRunCmd:
+    """Tests for the run_cmd family error handling.
+
+    Regression for the case where the executed command's binary is missing:
+    subprocess raises FileNotFoundError (no .cmd/.returncode/.output attrs),
+    and the error-logging path must not itself raise AttributeError. When
+    raise_exception=True the original exception must propagate unchanged.
+    """
+
+    @staticmethod
+    def _last_msg(mock_syslog):
+        # syslog.syslog(level, msg) -> return the formatted msg of the last call
+        assert mock_syslog.called
+        args = mock_syslog.call_args.args
+        return args[1] if len(args) > 1 else args[0]
+
+    @mock.patch('hostcfgd.syslog.syslog')
+    def test_run_cmd_missing_binary_does_not_raise(self, mock_syslog):
+        exc = FileNotFoundError(2, 'No such file or directory', 'systemctl')
+        with mock.patch('hostcfgd.subprocess.check_call', side_effect=exc):
+            # Should swallow the error (raise_exception defaults to False) and
+            # must not blow up on err.cmd/err.returncode in the logging path.
+            hostcfgd.run_cmd(['systemctl', 'restart', 'resolv-config'])
+        # The logged message carries the command and the real error reason.
+        msg = self._last_msg(mock_syslog)
+        assert "['systemctl', 'restart', 'resolv-config']" in msg
+        assert 'systemctl' in msg
+
+    @mock.patch('hostcfgd.syslog.syslog')
+    def test_run_cmd_missing_binary_reraises_original(self, mock_syslog):
+        with mock.patch('hostcfgd.subprocess.check_call',
+                        side_effect=FileNotFoundError(2, 'No such file or directory', 'systemctl')):
+            with pytest.raises(FileNotFoundError):
+                hostcfgd.run_cmd(['systemctl', 'restart', 'resolv-config'],
+                                 log_err=True, raise_exception=True)
+
+    @mock.patch('hostcfgd.syslog.syslog')
+    def test_run_cmd_called_process_error_still_logged(self, mock_syslog):
+        err = CalledProcessError(returncode=1, cmd=['false'], output='boom')
+        with mock.patch('hostcfgd.subprocess.check_call', side_effect=err):
+            hostcfgd.run_cmd(['false'])
+        # Assert directly on the formatted syslog message (stable/precise).
+        msg = self._last_msg(mock_syslog)
+        assert "['false']" in msg
+        assert 'return code - 1' in msg
+        assert 'boom' in msg
+
+    @mock.patch('hostcfgd.syslog.syslog')
+    def test_run_cmd_pipe_missing_binary_does_not_raise(self, mock_syslog):
+        exc = FileNotFoundError(2, 'No such file or directory', 'grep')
+        with mock.patch('hostcfgd.check_output_pipe', side_effect=exc):
+            hostcfgd.run_cmd_pipe(['cat', '/x'], ['grep', 'y'], ['wc', '-l'])
+        msg = self._last_msg(mock_syslog)
+        assert 'grep' in msg
+
+    @mock.patch('hostcfgd.syslog.syslog')
+    def test_run_cmd_pipe_missing_binary_reraises_original(self, mock_syslog):
+        with mock.patch('hostcfgd.check_output_pipe',
+                        side_effect=FileNotFoundError(2, 'No such file or directory', 'grep')):
+            with pytest.raises(FileNotFoundError):
+                hostcfgd.run_cmd_pipe(['cat', '/x'], ['grep', 'y'], ['wc', '-l'],
+                                      log_err=True, raise_exception=True)
+
+    @mock.patch('hostcfgd.syslog.syslog')
+    def test_run_cmd_output_missing_binary_does_not_raise(self, mock_syslog):
+        exc = FileNotFoundError(2, 'No such file or directory', 'ip')
+        with mock.patch('hostcfgd.subprocess.check_output', side_effect=exc):
+            out = hostcfgd.run_cmd_output(['ip', 'addr'])
+        assert out == ''
+        msg = self._last_msg(mock_syslog)
+        assert 'ip' in msg
+
 
 class TestDnsHandler:
 


### PR DESCRIPTION
#### Why I did it

`run_cmd`, `run_cmd_pipe` and `run_cmd_output` in `hostcfgd` catch a broad `except Exception as err` and then build the log message using `err.cmd`, `err.returncode` and `err.output`. Those attributes only exist on `subprocess.CalledProcessError`.

When the invoked binary is missing, `subprocess` raises `FileNotFoundError` (an `OSError`, which has none of those attributes). The error-logging path then raises `AttributeError` itself, which:

- masks the real failure in the logs, and
- when `raise_exception=True`, propagates `AttributeError` instead of the original exception.

This is reachable on any host/environment where a helper hostcfgd shells out to is absent. For example, `DnsCfg.dns_update()` calls `run_cmd(['systemctl', 'restart', 'resolv-config'], ...)`; on a system without `systemctl` the resulting `FileNotFoundError` turns into an `AttributeError` inside `run_cmd`, which aborts the CONFIG_DB init handler (`ConfigDBConnector.listen(init_data_handler=self.load)`) and brings `hostcfgd` down.

##### How I did it

Use `getattr(err, 'cmd', <cmd>)` / `getattr(err, 'returncode', None)` / `getattr(err, 'output', None)` when formatting the log message, so the log line is always formattable regardless of the exception type. `raise_exception` now re-raises the original exception unchanged. Behavior for `CalledProcessError` is unchanged (cmd / return code / output are still logged).

##### How to verify it

Added unit tests in `tests/hostcfgd/hostcfgd_test.py` (`TestRunCmd`):

- `run_cmd` / `run_cmd_output` with a missing binary (`FileNotFoundError`): no `AttributeError` is raised and the error is logged.
- `run_cmd(..., raise_exception=True)` with a missing binary: the original `FileNotFoundError` propagates (not `AttributeError`).
- Regression: `run_cmd` with a `CalledProcessError` still logs the command, return code and output.

Run:

```
pytest tests/hostcfgd/hostcfgd_test.py -k TestRunCmd
```

##### Description for the changelog

Fix `hostcfgd` `run_cmd`/`run_cmd_pipe`/`run_cmd_output` error handling so a missing command binary (`FileNotFoundError`) is logged and re-raised correctly instead of raising `AttributeError`.
