### PR TITLE
[gnoi_shutdown_daemon] Log gNOI Reboot failure details

### DIFF
--- a/scripts/gnoi_shutdown_daemon.py
+++ b/scripts/gnoi_shutdown_daemon.py
@@ -243,9 +243,9 @@ class GnoiRebootHandler:
             "-rpc", "Reboot",
             "-jsonin", json.dumps({"method": REBOOT_METHOD_HALT, "message": "Triggered by SmartSwitch graceful shutdown"})
         ]
-        rc, out, err = execute_command(reboot_cmd, timeout_sec=REBOOT_RPC_TIMEOUT_SEC, suppress_stderr=True)
+        rc, out, err = execute_command(reboot_cmd, timeout_sec=REBOOT_RPC_TIMEOUT_SEC)
         if rc != 0:
-            logger.log_error(f"{dpu_name}: Reboot command failed")
+            logger.log_error(f"{dpu_name}: Reboot command failed (rc={rc}, target={dpu_ip}:{port}): {err}")
             return False
         return True
 


### PR DESCRIPTION
#### Why I did it
When the gNOI Reboot (HALT) call to a DPU failed during graceful shutdown, the daemon only logged
"Reboot command failed" and hid stderr. That made failures hard to debug.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- Stopped hiding stderr on the gNOI Reboot call.
- Added the return code, target IP:port, and the real error text to the log message.

#### How to verify it
- Run a graceful shutdown where the gNOI Reboot call fails (for example, an unreachable DPU).
- Check syslog and confirm the log now shows rc, target IP:port, and the gNOI error text.

#### Description for the changelog
Log full gNOI Reboot failure details (rc, target, stderr) in gnoi_shutdown_daemon.