### PR TITLE
[process-reboot-cause] Save boot_id and device fields for DPU reboot cause

### DIFF
--- a/host_modules/showtech.py
+++ b/host_modules/showtech.py
@@ -40,7 +40,7 @@ class Showtech(host_service.HostModule):
             print("%Error: Host side: Failed: " + str(err.returncode))
             return err.returncode, output
 
-        output_file_match = re.search('\/var\/.*dump.*\.gz', result.stdout)
+        output_file_match = re.search(r'/var/.*dump.*\.gz', result.stdout)
         output_filename = output_file_match.group()
         return result.returncode, output_filename
 

--- a/scripts/process-reboot-cause
+++ b/scripts/process-reboot-cause
@@ -32,6 +32,8 @@ USER_ISSUED_REBOOT_CAUSE_REGEX ="User issued \'{}\' command [User: {}, Time: {}]
 REBOOT_CAUSE_UNKNOWN = "Unknown"
 REBOOT_CAUSE_TABLE_NAME = "REBOOT_CAUSE"
 MAX_HISTORY_FILES = 10
+DPU_REBOOT_CAUSE_DB_FIELDS = ("cause", "time", "user", "comment", "boot_id")
+NPU_REBOOT_CAUSE_DB_FIELDS = ("cause", "time", "user", "comment")
 
 REDIS_HOSTIP = "127.0.0.1"
 state_db = None
@@ -73,10 +75,10 @@ def read_reboot_cause_files_and_save_to_db(device='npu'):
                             sonic_logger.log_warning(f"Missing 'name' in reboot-cause file")
                             continue  # Skip this file
                         _hash = f"{REBOOT_CAUSE_TABLE_NAME}|{device.upper()}|{data['name']}"
-                    db.set(table, _hash, 'cause', data.get('cause', ''))
-                    db.set(table, _hash, 'time', data.get('time', ''))
-                    db.set(table, _hash, 'user', data.get('user', ''))
-                    db.set(table, _hash, 'comment', data.get('comment', ''))
+                    db_fields = (NPU_REBOOT_CAUSE_DB_FIELDS if device == 'npu'
+                                 else DPU_REBOOT_CAUSE_DB_FIELDS)
+                    for field in db_fields:
+                        db.set(table, _hash, field, data.get(field, ''))
                 except json.decoder.JSONDecodeError as je:
                     sonic_logger.log_error("Unable to process reload cause file {}: {}".format(x, je))
                     pass

--- a/scripts/process-reboot-cause
+++ b/scripts/process-reboot-cause
@@ -32,8 +32,8 @@ USER_ISSUED_REBOOT_CAUSE_REGEX ="User issued \'{}\' command [User: {}, Time: {}]
 REBOOT_CAUSE_UNKNOWN = "Unknown"
 REBOOT_CAUSE_TABLE_NAME = "REBOOT_CAUSE"
 MAX_HISTORY_FILES = 10
-DPU_REBOOT_CAUSE_DB_FIELDS = ("cause", "time", "user", "comment", "boot_id")
 NPU_REBOOT_CAUSE_DB_FIELDS = ("cause", "time", "user", "comment")
+DPU_REBOOT_CAUSE_DB_FIELDS = NPU_REBOOT_CAUSE_DB_FIELDS + ("boot_id", "device")
 
 REDIS_HOSTIP = "127.0.0.1"
 state_db = None

--- a/tests/process-reboot-cause_test.py
+++ b/tests/process-reboot-cause_test.py
@@ -81,7 +81,7 @@ class TestProcessRebootCause(TestCase):
         output = mock_stdout.getvalue()
 
     # Test read_reboot_cause_files_and_save_to_db - smartswitch
-    @patch("builtins.open", new_callable=mock_open, read_data='{"cause": "Non-Hardware", "user": "admin", "name": "2024_12_13_01_12_36", "comment": "Switch rebooted DPU", "device": "DPU0", "time": "Fri Dec 13 01:12:36 AM UTC 2024"}')
+    @patch("builtins.open", new_callable=mock_open, read_data='{"cause": "Non-Hardware", "user": "admin", "name": "2024_12_13_01_12_36", "comment": "Switch rebooted DPU", "device": "DPU0", "time": "Fri Dec 13 01:12:36 AM UTC 2024", "boot_id": "e4252288-be0d-40ec-8338-d1e5ec206771"}')
     @patch("os.listdir", return_value=["file1.json"])
     @patch("os.path.isfile", return_value=True)
     @patch("os.path.exists", return_value=True)
@@ -103,7 +103,14 @@ class TestProcessRebootCause(TestCase):
 
         # Simulate running the script
         with patch.object(sys, "argv", ["process-reboot-cause"]):
-            process_reboot_cause.read_reboot_cause_files_and_save_to_db('dpu1')
+            process_reboot_cause.read_reboot_cause_files_and_save_to_db('dpu0')
+
+        mock_db.set.assert_any_call(
+            mock_db.CHASSIS_STATE_DB,
+            "REBOOT_CAUSE|DPU0|2024_12_13_01_12_36",
+            "boot_id",
+            "e4252288-be0d-40ec-8338-d1e5ec206771",
+        )
 
     # Test read_reboot_cause_files_and_save_to_db - smartswitch - name not in data
     @patch("builtins.open", new_callable=mock_open, read_data='{"cause": "Non-Hardware", "user": "admin", "comment": "Switch rebooted DPU", "device": "DPU0", "time": "Fri Dec 13 01:12:36 AM UTC 2024"}')

--- a/tests/process-reboot-cause_test.py
+++ b/tests/process-reboot-cause_test.py
@@ -112,6 +112,13 @@ class TestProcessRebootCause(TestCase):
             "e4252288-be0d-40ec-8338-d1e5ec206771",
         )
 
+        mock_db.set.assert_any_call(
+            mock_db.CHASSIS_STATE_DB,
+            "REBOOT_CAUSE|DPU0|2024_12_13_01_12_36",
+            "device",
+            "DPU0",
+        )
+
     # Test read_reboot_cause_files_and_save_to_db - smartswitch - name not in data
     @patch("builtins.open", new_callable=mock_open, read_data='{"cause": "Non-Hardware", "user": "admin", "comment": "Switch rebooted DPU", "device": "DPU0", "time": "Fri Dec 13 01:12:36 AM UTC 2024"}')
     @patch("os.listdir", return_value=["file1.json"])


### PR DESCRIPTION
#### Why I did it
DPU reboot-cause entries written to `CHASSIS_STATE_DB` were missing the `boot_id` and
`device` fields, so consumers couldn't correlate a DPU reboot with its boot instance or
source device. NPU entries are unaffected.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- Defined `NPU_REBOOT_CAUSE_DB_FIELDS` (cause, time, user, comment) and
  `DPU_REBOOT_CAUSE_DB_FIELDS` (adds boot_id, device) in `process-reboot-cause`.
- Replaced the hardcoded per-field `db.set` calls with a loop over the field set
  selected by device type, so DPU rows now include `boot_id` and `device`.
- Converted the showtech dump-path regex to a raw string to avoid invalid escape
  sequence warnings without changing its matching behavior.

#### How to verify it
- Run the unit tests: `tests/process-reboot-cause_test.py` now asserts that a DPU
  reboot-cause file results in `boot_id` and `device` being written to
  `CHASSIS_STATE_DB`.

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

#### Description for the changelog
Save boot_id and device fields for DPU reboot-cause entries