### PR TITLE
Lazy connect to config_db during first collect instead of during init

### DIFF
--- a/host_modules/debug_info.py
+++ b/host_modules/debug_info.py
@@ -40,6 +40,7 @@ PERSISTENT_STORAGE_KEY = "use_persistent_storage"
 
 
 DEBUG_INFO_FLAG = "debug_info"
+DEFAULT_HOSTNAME = "switch"
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +48,7 @@ class DebugArtifactCollector(host_service.HostModule):
   """DBus endpoint that collects debug artifacts."""
 
   def __init__(self, mod_name):
-    self._hostname = "switch"
+    self._hostname = DEFAULT_HOSTNAME
     self._board_type = ""
     super(DebugArtifactCollector, self).__init__(mod_name)
 
@@ -100,7 +101,7 @@ class DebugArtifactCollector(host_service.HostModule):
     Get hostname and board_type from CONFIG_DB
     using a single swsscommon call.
     """
-    hostname = "switch"
+    hostname = DEFAULT_HOSTNAME
     board_type = ""
     try:
       # Connect to CONFIG_DB
@@ -361,7 +362,7 @@ class DebugArtifactCollector(host_service.HostModule):
     except json.JSONDecodeError:
       return 1, "invalid input: " + options[0]
 
-    if not self._board_type or self._hostname == "switch":
+    if not self._board_type or self._hostname == DEFAULT_HOSTNAME:
       self._hostname, self._board_type = DebugArtifactCollector.get_device_metadata()
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S%f")

--- a/host_modules/debug_info.py
+++ b/host_modules/debug_info.py
@@ -47,7 +47,8 @@ class DebugArtifactCollector(host_service.HostModule):
   """DBus endpoint that collects debug artifacts."""
 
   def __init__(self, mod_name):
-    self._hostname, self._board_type = DebugArtifactCollector.get_device_metadata()
+    self._hostname = "switch"
+    self._board_type = ""
     super(DebugArtifactCollector, self).__init__(mod_name)
 
   @staticmethod

--- a/tests/debug_info_test.py
+++ b/tests/debug_info_test.py
@@ -43,7 +43,18 @@ class TestDebugArtifactCollector:
 
     def teardown_method(self):
         self.tmpdir.cleanup()
-    
+
+    def test_init_does_not_read_device_metadata(self):
+        metadata_mock_path = (
+            "debug_info.DebugArtifactCollector.get_device_metadata")
+        with mock.patch(metadata_mock_path) as mock_get_metadata, \
+             mock.patch("debug_info.super"):
+            debug_info_module = DebugArtifactCollector(MOD_NAME)
+
+        assert debug_info_module._hostname == "switch"
+        assert debug_info_module._board_type == ""
+        mock_get_metadata.assert_not_called()
+
     def test_run_command_success(self):
         with mock.patch("debug_info.subprocess.Popen") as mp:
             proc = mock.Mock()

--- a/tests/debug_info_test.py
+++ b/tests/debug_info_test.py
@@ -51,7 +51,7 @@ class TestDebugArtifactCollector:
              mock.patch("debug_info.super"):
             debug_info_module = DebugArtifactCollector(MOD_NAME)
 
-        assert debug_info_module._hostname == "switch"
+        assert debug_info_module._hostname == DEFAULT_HOSTNAME
         assert debug_info_module._board_type == ""
         mock_get_metadata.assert_not_called()
 
@@ -82,7 +82,7 @@ class TestDebugArtifactCollector:
             instance = mock_conn.return_value
             instance.get_all.side_effect = Exception("db error")
             hostname, board_type = self.debug_info_module.get_device_metadata()
-            assert hostname == "switch"
+            assert hostname == DEFAULT_HOSTNAME
             assert board_type == ""
             mock_warn.assert_called_with("Failed to read hostname/board_type from CONFIG_DB: db error")
 
@@ -102,7 +102,7 @@ class TestDebugArtifactCollector:
             instance = mock_conn.return_value
             instance.get_all.return_value = {}
             hostname, board_type = self.debug_info_module.get_device_metadata()
-            assert hostname == "switch"
+            assert hostname == DEFAULT_HOSTNAME
             assert board_type == ""
 
     def test_collect_invalid_json(self):


### PR DESCRIPTION
#### Why I did it
Avoid reading CONFIG_DB when `sonic-hostservice` initializes. On DPU boot, the host service can start before database files are ready, causing a transient `parseDatabaseConfig` error even though artifact collection is not requested yet.

Observed log:
```text
2026 Jul  7 09:27:01.087175 sonic INFO systemd[1]: Started sonic-hostservice.service - SONiC Host Service.
2026 Jul  7 09:27:01.092005 sonic ERR python3: :- parseDatabaseConfig: Sonic database config file doesn't exist at /var/run/redis/sonic-db/database_config.json
2026 Jul  7 09:27:01.095411 sonic INFO python3[1218]: Failed to read hostname/board_type from CONFIG_DB: Sonic database config file doesn't exist at /var/run/redis/sonic-db/database_config.json
2026 Jul  7 09:27:08.163389 sonic INFO systemd[1]: Starting database.service - Database container...
```

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- Initialize debug artifact metadata with safe defaults in `DebugArtifactCollector.__init__`.
- Keep CONFIG_DB metadata lookup lazy during the first `collect()` call.
- Add a unit test to ensure constructor initialization does not read device metadata.

#### How to verify it
- Run `tests/debug_info_test.py`.
- Restart `sonic-hostservice` before database readiness and verify init emits no `parseDatabaseConfig` error.

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202605

Reason: fixes a DPU boot-time false error log.

#### Tested branch (Please provide the tested image version)
- [x] 202605
- [x] master

#### Description for the changelog
Lazy connect to config_db during first collect instead of during init