### PR TITLE
[hostcfgd] Wait for chage before checking status

### DIFF
--- a/scripts/hostcfgd
+++ b/scripts/hostcfgd
@@ -966,7 +966,7 @@ class PasswHardening(object):
         for normal_account in normal_accounts:
             try:
                 chage_p_m = subprocess.Popen(('chage', chage_flag + str(curr_expiration), normal_account), stdout=subprocess.PIPE)
-                return_code_chage_p_m = chage_p_m.poll()
+                return_code_chage_p_m = chage_p_m.wait()
                 if return_code_chage_p_m != 0:
                     syslog.syslog(syslog.LOG_ERR, "failed: return code - {}".format(return_code_chage_p_m))
 

--- a/tests/hostcfgd/hostcfgd_passwh_test.py
+++ b/tests/hostcfgd/hostcfgd_passwh_test.py
@@ -5,6 +5,7 @@ import shutil
 import os
 import sys
 import subprocess
+import syslog
 import re
 
 from parameterized import parameterized
@@ -180,3 +181,41 @@ class TestHostcfgdPASSWH(TestCase):
         """
 
         self.check_config(test_name, test_data, "enable_digits_class")
+
+    def test_passwd_aging_expire_modify_success(self):
+        """
+            Test passwd_aging_expire_modify() does not log an error when chage succeeds
+        """
+        passwh = hostcfgd.PasswHardening()
+        passwh.get_normal_accounts = mock.Mock(return_value=["testuser"])
+
+        with mock.patch('hostcfgd.subprocess.Popen') as mock_popen, \
+                mock.patch('hostcfgd.syslog.syslog') as mock_syslog:
+            mock_popen.return_value.wait.return_value = 0
+
+            passwh.passwd_aging_expire_modify(100, 'MAX_DAYS')
+
+            mock_popen.assert_called_once_with(('chage', '-M 100', 'testuser'), stdout=subprocess.PIPE)
+            mock_popen.return_value.wait.assert_called_once_with()
+
+            mock_syslog.assert_not_called()
+
+    def test_passwd_aging_expire_modify_failure(self):
+        """
+            Test passwd_aging_expire_modify() logs an error when chage exits with a nonzero status
+        """
+        passwh = hostcfgd.PasswHardening()
+        passwh.get_normal_accounts = mock.Mock(return_value=["testuser"])
+
+        with mock.patch('hostcfgd.subprocess.Popen') as mock_popen, \
+                mock.patch('hostcfgd.syslog.syslog') as mock_syslog:
+            mock_popen.return_value.wait.return_value = 1
+
+            passwh.passwd_aging_expire_modify(100, 'MAX_DAYS')
+
+            mock_popen.assert_called_once_with(('chage', '-M 100', 'testuser'), stdout=subprocess.PIPE)
+            mock_popen.return_value.wait.assert_called_once_with()
+            mock_syslog.assert_called_once_with(
+                syslog.LOG_ERR,
+                "failed: return code - 1"
+            )


### PR DESCRIPTION
#### Why I did it

`PasswHardening.passwd_aging_expire_modify()` checked the `chage` process status immediately with `poll()`.

When the process was still running, `poll()` returned `None`. Because `None != 0`, hostcfgd logged a failure even when `chage` completed successfully.

Fixes #397.

##### Work item tracking

* Microsoft ADO: N/A

#### How I did it

* Replaced the immediate `poll()` call with `wait()` so hostcfgd checks the completed process exit status.
* Preserved the existing `chage` command arguments and nonzero-return error message.
* Added focused unit tests for successful and failed `chage` execution.
* Mocked the subprocess and syslog calls so the tests do not modify real user accounts.

#### How to verify it

Completed locally:

* `git diff --check`
* `python3 -m py_compile scripts/hostcfgd tests/hostcfgd/hostcfgd_passwh_test.py`

The compile check completed successfully with two pre-existing `SyntaxWarning` messages for unrelated escape sequences in `scripts/hostcfgd`.

The focused tests could not be executed locally because the environment does not have `pytest` or the `parameterized` test dependency installed.

In a SONiC host-services test environment, run:

```bash
python3 -m pytest \
  tests/hostcfgd/hostcfgd_passwh_test.py \
  -k 'passwd_aging_expire_modify' \
  -v
```

To run the full password-hardening test file:

```bash
python3 -m pytest \
  tests/hostcfgd/hostcfgd_passwh_test.py \
  -v
```

#### Previous behavior

A successful `chage` process could still generate:

```text
failed: return code - None
```

#### New behavior

Hostcfgd waits for `chage` to complete and logs the existing error only when the process exits with a nonzero status.
