### PR TITLE
[202605][featured] fix stale FEATURE entry after concurrent package uninstall

### DIFF
--- a/scripts/featured
+++ b/scripts/featured
@@ -266,8 +266,12 @@ class FeatureHandler(object):
             return False
 
         if not enable and not disable:
-            syslog.syslog(syslog.LOG_ERR, "Unexpected state value '{}' for feature {}"
-                          .format(feature.state, feature.name))
+            # state=None means the FEATURE entry was deleted by a concurrent uninstall
+            # while this notification was queued — not an error.  Any other non-None
+            # value here is a genuinely unexpected state and should be flagged.
+            if feature.state is not None:
+                syslog.syslog(syslog.LOG_ERR, "Unexpected state value '{}' for feature {}"
+                              .format(feature.state, feature.name))
             return False
 
         if feature.delayed and not self.is_delayed_enabled:
@@ -349,6 +353,13 @@ class FeatureHandler(object):
         new_per_asic = str(feature_config.has_per_asic_scope)
         new_global = str(feature_config.has_global_scope)
         self._conditional_update_scope(self._config_db, feature_config.name, new_per_asic, new_global)
+        # If the entry was deleted by a concurrent deregister, _conditional_update_scope
+        # may have recreated it without a 'state' field.  Remove the partial entry to
+        # avoid a ghost record.
+        post_entry = self._config_db.get_entry(FEATURE_TBL, feature_config.name)
+        if post_entry and 'state' not in post_entry:
+            self._config_db.set_entry(FEATURE_TBL, feature_config.name, None)
+            return
 
         # Sync both has_per_asic_scope and has_global_scope to CONFIG_DB in namespaces on multi-asic platforms
         for ns, db in self.ns_cfg_db.items():
@@ -549,7 +560,17 @@ class FeatureHandler(object):
 
     def resync_feature_state(self, feature):
         current_entry = self._config_db.get_entry('FEATURE', feature.name)
-        current_feature_state = current_entry.get('state') if current_entry else None
+
+        # Entry was deleted by a concurrent deregister — do not recreate it.
+        if not current_entry:
+            return
+
+        # Partial entry left by sync_feature_scope racing with deregister — remove it.
+        if 'state' not in current_entry:
+            self._config_db.set_entry('FEATURE', feature.name, None)
+            return
+
+        current_feature_state = current_entry.get('state')
 
         if feature.state == current_feature_state:
             return

--- a/scripts/featured
+++ b/scripts/featured
@@ -353,6 +353,7 @@ class FeatureHandler(object):
         new_per_asic = str(feature_config.has_per_asic_scope)
         new_global = str(feature_config.has_global_scope)
         self._conditional_update_scope(self._config_db, feature_config.name, new_per_asic, new_global)
+
         # If the entry was deleted by a concurrent deregister, _conditional_update_scope
         # may have recreated it without a 'state' field.  Remove the partial entry to
         # avoid a ghost record.

--- a/tests/featured/featured_test.py
+++ b/tests/featured/featured_test.py
@@ -282,7 +282,8 @@ class TestFeatureHandler(TestCase):
         }
         mock_db.get_entry.return_value = None
         feature_handler.sync_state_field(feature_table)
-        mock_db.mod_entry.assert_called_with('FEATURE', 'sflow', {'state': 'enabled'})
+        # Missing FEATURE row: resync_feature_state skips mod_entry (avoid recreating a row removed concurrently).
+        mock_db.mod_entry.assert_not_called()
         mock_db.mod_entry.reset_mock()
 
         feature_handler = featured.FeatureHandler(mock_db, mock_feature_state_table, {}, False)
@@ -321,7 +322,46 @@ class TestFeatureHandler(TestCase):
         }
         feature_handler.sync_state_field(feature_table)
         mock_db.mod_entry.assert_called_with('FEATURE', 'sflow', {'state': 'enabled'})
-    
+        mock_db.mod_entry.reset_mock()
+
+        # Partial entry (no 'state' key): left behind by sync_feature_scope racing with
+        # deregister.  resync_feature_state must delete it rather than completing it.
+        feature_handler = featured.FeatureHandler(mock_db, mock_feature_state_table, {}, False)
+        mock_db.get_entry.return_value = {
+            'has_per_asic_scope': 'False',
+            'has_global_scope': 'True',
+        }
+        mock_db.set_entry = mock.MagicMock()
+        feature_handler.sync_state_field(feature_table)
+        mock_db.set_entry.assert_called_with('FEATURE', 'sflow', None)
+        mock_db.mod_entry.assert_not_called()
+
+    def test_sync_feature_scope_toctou(self):
+        """sync_feature_scope must delete a partial entry it accidentally creates when
+        the FEATURE row is deleted by a concurrent deregister between the mod_entry
+        calls and the post-write existence check (TOCTOU)."""
+        mock_db = mock.MagicMock()
+        mock_feature_state_table = mock.MagicMock()
+
+        feature_handler = featured.FeatureHandler(mock_db, mock_feature_state_table, {}, False)
+        feature = featured.Feature('sflow', {
+            'state': 'disabled',
+            'has_global_scope': 'True',
+            'has_per_asic_scope': 'False',
+            'delayed': 'False',
+        })
+
+        # Post-write check sees a partial entry (no 'state' key): the FEATURE row was
+        # deleted by deregister and then recreated by mod_entry during the race
+        # window, leaving only the scope fields.
+        mock_db.get_entry.return_value = {
+            'has_per_asic_scope': 'False',
+            'has_global_scope': 'True',
+        }
+
+        feature_handler.sync_feature_scope(feature)
+        mock_db.set_entry.assert_called_with(featured.FEATURE_TBL, 'sflow', None)
+
     def test_port_init_done_twice(self):
         """There could be multiple "PortInitDone" event in case of swss
         restart(either due to crash or due to manual operation). swss

--- a/tests/featured/featured_test.py
+++ b/tests/featured/featured_test.py
@@ -338,8 +338,8 @@ class TestFeatureHandler(TestCase):
 
     def test_sync_feature_scope_toctou(self):
         """sync_feature_scope must delete a partial entry it accidentally creates when
-        the FEATURE row is deleted by a concurrent deregister between the mod_entry
-        calls and the post-write existence check (TOCTOU)."""
+        the FEATURE row is deleted by a concurrent deregister between the mod_entry and
+        the post-write existence check (TOCTOU)."""
         mock_db = mock.MagicMock()
         mock_feature_state_table = mock.MagicMock()
 

--- a/tests/featured/featured_test.py
+++ b/tests/featured/featured_test.py
@@ -485,6 +485,7 @@ class TestFeatureHandler(TestCase):
 
         # Host differs -> both host and namespaces should be written
         mock_db.get_entry.return_value = {
+            'state': 'enabled',
             'has_per_asic_scope': 'False',
             'has_global_scope': 'False',
         }
@@ -508,6 +509,7 @@ class TestFeatureHandler(TestCase):
 
         # Host matches but namespaces are stale -> namespaces should still be written
         mock_db.get_entry.return_value = {
+            'state': 'enabled',
             'has_per_asic_scope': 'True',
             'has_global_scope': 'True',
         }


### PR DESCRIPTION
Cherry-pick of #384 onto the 202605 branch.

**Why I did it**

After uninstalling a SONiC application package, the feature could reappear in `show feature status` with an incomplete entry (state: disabled, missing auto_restart, set_owner, etc.), even though the package was fully removed. This was caused by a race between `featured` and `sonic-package-manager` during uninstall.

`sonic-package-manager` unblocks as soon as `featured` writes `disabled` to STATE_DB, then immediately runs `deregister()` which deletes the FEATURE entry from CONFIG_DB. At that point `featured` is still inside its handler and has not finished writing back to CONFIG_DB. Two code paths independently recreate the deleted entry with partial data:

1. `sync_feature_scope` — called after a successful `disable_feature()`, it writes `has_per_asic_scope` and `has_global_scope` back to CONFIG_DB. `mod_entry` on a missing Redis key recreates the hash with only those two fields (no `state` key). `featured` then receives a notification for this partial entry, reads `state=None`, and logs `ERR featured: Unexpected state value 'None' for feature <name>`. There is also a TOCTOU gap: spm can delete the entry between the `mod_entry` calls and the post-write read.

2. `resync_feature_state` — called when `update_feature_state()` fails (e.g. `systemctl start` fails because the service file was already removed by the concurrent uninstall). `get_entry()` returns `{}` for a deleted key, `_feature_state_is_template(None)` evaluates True, and `mod_entry` writes `{state: disabled}` back — recreating the entry with no other fields. The same function also completes partial entries left by (1).

**How I did it**

Three guards added to `featured`:

- `sync_feature_scope` — post-write check: after both `mod_entry` calls, re-read the entry. If it exists but has no `state` key, the write raced with deregister and recreated a deleted key; delete the partial entry immediately.
- `resync_feature_state` — deleted-entry check: if `get_entry()` returns an empty dict, return without touching CONFIG_DB.
- `resync_feature_state` — partial-entry check: if the entry is non-empty but has no `state` key, delete it rather than completing the ghost record.

Additionally, the ERR log for `state=None` in `update_feature_state` is suppressed since `state=None` means the FEATURE entry was deleted by a concurrent uninstall while the notification was queued — not a programming error.

**Cherry-pick notes**

Picked cleanly from #384 (commits 8c1737f, b10757c, ad26790, 800288d) with no conflicts.
