### PR TITLE
Add console mirror recording and control support

### DIFF
--- a/host_modules/console_mirror.py
+++ b/host_modules/console_mirror.py
@@ -103,7 +103,7 @@ def printable_escape(payload: bytes) -> str:
         if byte < 0x20 or 0x7F <= byte <= 0x9F:
             return r"\x{:02x}".format(byte)
         return None
-    
+
     def _utf8_width(byte: int) -> int:
         if 0xC2 <= byte <= 0xDF:
             return 2
@@ -615,7 +615,13 @@ class RecordingArchiver:
 
 
 class MirrorManager:
-    """Thread-safe per-line mirror state machine."""
+    """Coordinate one console line's mirror session and runtime state.
+
+    Construction resets the line to ``idle`` in STATE_DB. Use :meth:`start`,
+    :meth:`submit`, :meth:`update_timeout`, :meth:`status`, and :meth:`stop` to
+    manage a session, then call :meth:`shutdown` when the proxy exits. Public
+    methods are thread-safe.
+    """
 
     def __init__(
         self,
@@ -677,6 +683,7 @@ class MirrorManager:
         self._state_set(values)
 
     def start(self, options: Dict[str, Any]) -> Dict[str, Any]:
+        """Start an idle mirror session and return its active-session metadata."""
         direction = options.get("direction", "both")
         if not isinstance(direction, str) or direction not in VALID_DIRECTIONS:
             raise MirrorError("invalid_direction", "Direction must be rx, tx, or both")
@@ -684,6 +691,10 @@ class MirrorManager:
         max_file_size = options.get("max_file_size", DEFAULT_MAX_FILE_SIZE_MB)
         if isinstance(max_file_size, bool) or not isinstance(max_file_size, int) or max_file_size <= 0:
             raise MirrorError("invalid_max_file_size", "max_file_size must be a positive integer in MB")
+        owner_pid = options.get("owner_pid")
+        if isinstance(owner_pid, bool) or not isinstance(owner_pid, int) or owner_pid <= 0:
+            raise MirrorError("invalid_owner_pid", "owner_pid must be a positive integer")
+        started_by = str(options.get("started_by", "root"))
 
         with self._lock:
             if self.state != "idle":
@@ -718,8 +729,8 @@ class MirrorManager:
             self.timeout_seconds = timeout_seconds
             self.deadline = time.monotonic() + timeout_seconds
             self.file_path = writer.file_path
-            self._owner_pid = int(options.get("owner_pid", 0))
-            self._started_by = str(options.get("started_by", "root"))
+            self._owner_pid = owner_pid
+            self._started_by = started_by
             self.writer_drop_count = 0
             self.timer = timer
             self.state = "active"
@@ -754,6 +765,7 @@ class MirrorManager:
         self.writer_drop_count = 0
 
     def submit(self, direction: str, payload: bytes) -> None:
+        """Best-effort submit RX/TX bytes without blocking the proxy data path."""
         if direction not in ("rx", "tx") or not payload:
             return
         if not self._lock.acquire(blocking=False):
@@ -779,6 +791,7 @@ class MirrorManager:
             self._lock.release()
 
     def update_timeout(self, timeout_value: Any) -> Dict[str, Any]:
+        """Reset an active session's timeout from now and return the new timeout."""
         timeout_text, timeout_seconds = parse_duration(timeout_value)
         replacement = threading.Timer(
             timeout_seconds, lambda: self._on_timeout(replacement)
@@ -812,6 +825,10 @@ class MirrorManager:
         archive: bool = False,
         expected_timer: Optional[threading.Timer] = None,
     ) -> Dict[str, Any]:
+        """Stop an active session, optionally submitting its files for archiving.
+
+        ``expected_timer`` rejects callbacks from a superseded timeout timer.
+        """
         with self._lock:
             if self.state != "active" or self.writer is None:
                 raise MirrorError("mirror_not_active", "Line {} has no active mirror session".format(self.line))
@@ -870,6 +887,7 @@ class MirrorManager:
         }
 
     def status(self) -> Dict[str, Any]:
+        """Return the current state and any active-session metadata."""
         with self._lock:
             response: Dict[str, Any] = {"status": "ok", "state": self.state, "line": self.line}
             if self.state in ("active", "stopping"):
@@ -918,6 +936,7 @@ class MirrorManager:
             self._write_active_state()
 
     def shutdown(self, archive_timeout: float = 5.0) -> None:
+        """Stop any active session and shut down the archiver within the timeout."""
         with self._lock:
             active = self.state == "active"
         if active:
@@ -929,3 +948,264 @@ class MirrorManager:
         with self._lock:
             self.state = "idle"
             self._write_idle_state()
+
+
+def _recv_exact(connection: socket.socket, size: int) -> Optional[bytes]:
+    chunks = []
+    remaining = size
+    while remaining:
+        chunk = connection.recv(remaining)
+        if not chunk:
+            return None
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+def recv_message(connection: socket.socket) -> Optional[Dict[str, Any]]:
+    """Receive one length-prefixed JSON object, or ``None`` after a clean EOF."""
+    header = _recv_exact(connection, 4)
+    if header is None:
+        return None
+    length = struct.unpack("!I", header)[0]
+    if length <= 0 or length > MAX_CONTROL_MESSAGE:
+        raise MirrorError("invalid_message", "Invalid control message length")
+    payload = _recv_exact(connection, length)
+    if payload is None:
+        raise MirrorError("invalid_message", "Truncated control message")
+    try:
+        message = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError):
+        raise MirrorError("invalid_message", "Control message is not valid UTF-8 JSON")
+    if not isinstance(message, dict):
+        raise MirrorError("invalid_message", "Control message must be a JSON object")
+    return message
+
+def send_message(connection: socket.socket, message: Dict[str, Any]) -> None:
+    """Send one JSON object using the control protocol's length prefix."""
+    payload = json.dumps(message, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    connection.sendall(struct.pack("!I", len(payload)) + payload)
+
+class MirrorControlServer:
+    """Serve root-only mirror control requests for one console line.
+
+    The server listens on ``line<line>.sock`` below ``runtime_dir`` and delegates
+    validated start, stop, status, and timeout requests to ``manager``. Call
+    :meth:`start` after construction and :meth:`stop` during proxy shutdown.
+    Client handling and archive-completion waits run on bounded worker threads.
+    """
+
+    def __init__(
+        self,
+        line: str,
+        manager: MirrorManager,
+        runtime_dir: str = MIRROR_RUNTIME_DIR,
+        archive_wait_seconds: float = ARCHIVE_WAIT_SECONDS,
+        max_clients: int = 8,
+    ) -> None:
+        self.line = validate_line(line)
+        self.manager = manager
+        self.runtime_dir = runtime_dir
+        self.archive_wait_seconds = archive_wait_seconds
+        self.max_clients = max_clients
+        self.socket_path = os.path.join(runtime_dir, "line{}.sock".format(self.line))
+        self._socket: Optional[socket.socket] = None
+        self._thread: Optional[threading.Thread] = None
+        self._running = threading.Event()
+        self._clients = threading.Semaphore(max_clients)
+        self._client_threads: List[threading.Thread] = []
+
+    @staticmethod
+    def _root_only(uid: int) -> bool:
+        return uid == 0
+
+    def start(self) -> None:
+        """Create the control socket and start accepting client requests."""
+        _ensure_secure_directory(self.runtime_dir)
+        # Ensure the socket path is safe to use
+        try:
+            info = os.lstat(self.socket_path)
+            if not stat.S_ISSOCK(info.st_mode):
+                raise MirrorError("unsafe_socket_path", "Control socket path is occupied by a non-socket")
+            os.unlink(self.socket_path)
+        except FileNotFoundError:
+            pass
+        # Create the socket and bind
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            server.bind(self.socket_path)
+            server.listen(self.max_clients)
+            server.settimeout(0.2)
+        except Exception:
+            server.close()
+            try:
+                os.unlink(self.socket_path)
+            except OSError:
+                pass
+            raise
+        self._socket = server
+        # Start the background thread
+        self._running.set()
+        self._thread = threading.Thread(
+            target=self._serve,
+            name="console-mirror-control-{}".format(self.line),
+            daemon=True
+        )
+        self._thread.start()
+
+    def _serve(self) -> None:
+        while self._running.is_set():
+            try:
+                connection, _ = self._socket.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            if not self._clients.acquire(blocking=False):
+                connection.close()
+                continue
+            thread = threading.Thread(
+                target=self._handle_and_release,
+                args=(connection,),
+                name="console-mirror-client-{}".format(self.line),
+                daemon=True,
+            )
+            self._client_threads.append(thread)
+            thread.start()
+
+    def _handle_and_release(self, connection: socket.socket) -> None:
+        try:
+            self._handle_client(connection)
+        finally:
+            connection.close()
+            self._clients.release()
+            try:
+                self._client_threads.remove(threading.current_thread())
+            except ValueError:
+                pass
+
+    def _peer_credentials(self, connection: socket.socket) -> Tuple[int, int, int]:
+        credentials = connection.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize("3i"))
+        return struct.unpack("3i", credentials)
+
+    def _send_archive_completion(self, connection: socket.socket, handle: ArchiveHandle) -> None:
+        try:
+            deadline = time.monotonic() + self.archive_wait_seconds
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    handle.cancel()
+                    return
+                try:
+                    result = handle.result(timeout=min(0.2, remaining))
+                    break
+                # If the client disconnects while waiting, stop waiting and return
+                except concurrent.futures.TimeoutError:
+                    readable, _, _ = select.select([connection], [], [], 0)
+                    if readable and connection.recv(1, socket.MSG_PEEK) == b"":
+                        return
+            if result.undeleted_sources:
+                send_message(
+                    connection,
+                    {
+                        "status": "error",
+                        "code": "archive_cleanup_failed",
+                        "message": "Archive is valid but some source logs could not be deleted",
+                        "archive_path": result.archive_path,
+                        "source_paths": list(result.undeleted_sources),
+                    },
+                )
+            else:
+                send_message(connection, {"status": "ok", "archive_path": result.archive_path})
+        except MirrorError as error:
+            send_message(
+                connection,
+                {
+                    "status": "error",
+                    "code": error.code,
+                    "message": error.message + "; original log parts were preserved",
+                },
+            )
+        except (OSError, BrokenPipeError):
+            # A disconnected CLI loses only its response subscription.
+            pass
+        except Exception as error:
+            send_message(
+                connection,
+                {
+                    "status": "error",
+                    "code": "archive_failed",
+                    "message": "Archive packaging failed: {}; original log parts were preserved".format(error),
+                },
+            )
+
+    def _handle_client(self, connection: socket.socket) -> None:
+        try:
+            pid, uid, gid = self._peer_credentials(connection)
+            if not self._root_only(uid):
+                raise MirrorError("permission_denied", "Mirror control requires root privileges")
+            request = recv_message(connection)
+            if request is None:
+                return
+            if str(request.get("line")) != self.line:
+                raise MirrorError("line_mismatch", "Requested line does not match this proxy")
+            operation = request.get("op")
+            if operation == "start":
+                username = request.get("started_by")
+                if not isinstance(username, str) or not username or len(username) > 256:
+                    try:
+                        username = pwd.getpwuid(uid).pw_name
+                    except KeyError:
+                        username = str(uid)
+                options = dict(request)
+                options.update(owner_pid=pid, started_by=username)
+                response = self.manager.start(options)
+                send_message(connection, response)
+            elif operation == "stop":
+                archive = request.get("archive", False)
+                if not isinstance(archive, bool):
+                    raise MirrorError("invalid_archive", "archive must be a boolean")
+                response = self.manager.stop(reason="manual", archive=archive)
+                handle = response.pop("archive_handle", None)
+                send_message(connection, response)
+                if handle is not None:
+                    self._send_archive_completion(connection, handle)
+            elif operation == "status":
+                send_message(connection, self.manager.status())
+            elif operation == "timeout":
+                send_message(connection, self.manager.update_timeout(request.get("timeout")))
+            else:
+                raise MirrorError("unsupported_operation", "Unsupported mirror operation")
+        except MirrorError as error:
+            response = {"status": "error", "code": error.code, "message": error.message}
+            response.update(error.details)
+            try:
+                send_message(connection, response)
+            except OSError:
+                pass
+            except Exception as error:
+                log.exception("[%s] Unexpected mirror control error", self.line)
+                try:
+                    send_message(
+                        connection,
+                        {"status": "error", "code": "internal_error", "message": str(error)},
+                    )
+                except OSError:
+                    pass
+
+    def stop(self) -> None:
+        """Stop accepting clients, join workers boundedly, and remove the socket."""
+        self._running.clear()
+        if self._socket is not None:
+            self._socket.close()
+            self._socket = None
+        if self._thread is not None:
+            self._thread.join(1.0)
+            self._thread = None
+        for thread in list(self._client_threads):
+            if thread.is_alive():
+                thread.join(0.1)
+        try:
+            os.unlink(self.socket_path)
+        except OSError as error:
+            if error.errno != errno.ENOENT:
+                log.warning("Failed to remove mirror control socket %s: %s", self.socket_path, error)

--- a/host_modules/console_mirror.py
+++ b/host_modules/console_mirror.py
@@ -15,8 +15,9 @@ import struct
 import threading
 import time
 import zipfile
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any
 
 log = logging.getLogger("console-monitor.mirror")
 
@@ -41,18 +42,22 @@ class MirrorError(Exception):
         self.message = message
         self.details = details
 
+
 class ArchiveCancelled(Exception):
     pass
 
-def parse_duration(value: Any) -> Tuple[str, int]:
+
+def parse_duration(value: Any) -> tuple[str, int]:
     """Parse a duration string into (orginal text, seconds) tuple. Accepts formats like '30m', '2h', '1d'."""
     if not isinstance(value, str):
-        raise MirrorError("invalid_timeout",
-                          "Timeout must use the form <integer>[s|m|h|d]")
+        raise MirrorError(
+            "invalid_timeout", "Timeout must use the form <integer>[s|m|h|d]"
+        )
     match = _DURATION_RE.match(value)
     if not match:
-        raise MirrorError("invalid_timeout",
-                          "Timeout must use the form <integer>[s|m|h|d]")
+        raise MirrorError(
+            "invalid_timeout", "Timeout must use the form <integer>[s|m|h|d]"
+        )
     amount, unit = match.groups()
     amount = int(amount)
     if amount <= 0:
@@ -60,8 +65,7 @@ def parse_duration(value: Any) -> Tuple[str, int]:
     multipliers = {"s": 1, "m": 60, "h": 3600, "d": 86400}
     seconds = amount * multipliers[unit]
     if seconds * 1000 > MAX_DELTA_MS:
-        raise MirrorError("invalid_timeout",
-                          "Timeout exceeds the SCM-Text delta range")
+        raise MirrorError("invalid_timeout", "Timeout exceeds the SCM-Text delta range")
     return value.strip(), seconds
 
 
@@ -70,26 +74,28 @@ def validate_line(value: Any) -> str:
     line = str(value).strip()
     if not re.fullmatch(r"[0-9]+", line):
         raise MirrorError(
-            "invalid_line", "Console line must contain decimal digits only")
+            "invalid_line", "Console line must contain decimal digits only"
+        )
     return line
 
 
 def format_remaining(seconds: float) -> str:
     """Format a duration in seconds into a human-readable string like '1d2h3m4s'."""
-    remaining = max(0, int(math.ceil(seconds)))
+    remaining = max(0, math.ceil(seconds))
     if remaining == 0:
         return "0s"
     parts = []
     for suffix, unit in (("d", 86400), ("h", 3600), ("m", 60), ("s", 1)):
         value, remaining = divmod(remaining, unit)
         if value:
-            parts.append("{}{}".format(value, suffix))
+            parts.append(f"{value}{suffix}")
     return "".join(parts)
 
 
 def printable_escape(payload: bytes) -> str:
     """Return a deterministic, terminal-safe representation of a bytes payload."""
-    def _escape_control_byte(byte: int) -> Optional[str]:
+
+    def _escape_control_byte(byte: int) -> str | None:
         """Escape a single control byte"""
         escaped = {
             0x0A: r"\n",
@@ -101,7 +107,7 @@ def printable_escape(payload: bytes) -> str:
         if escaped is not None:
             return escaped
         if byte < 0x20 or 0x7F <= byte <= 0x9F:
-            return r"\x{:02x}".format(byte)
+            return rf"\x{byte:02x}"
         return None
 
     def _utf8_width(byte: int) -> int:
@@ -113,9 +119,9 @@ def printable_escape(payload: bytes) -> str:
             return 4
         return 1
 
-    def _decode_printable_utf8(payload: bytes, index: int) -> Optional[Tuple[str, int]]:
+    def _decode_printable_utf8(payload: bytes, index: int) -> tuple[str, int] | None:
         width = _utf8_width(payload[index])
-        chunk = payload[index:index + width]
+        chunk = payload[index : index + width]
         try:
             char = chunk.decode("utf-8")
         except UnicodeDecodeError:
@@ -124,7 +130,7 @@ def printable_escape(payload: bytes) -> str:
             return char, width
         return None
 
-    def _escape_byte(payload: bytes, index: int) -> Tuple[str, int]:
+    def _escape_byte(payload: bytes, index: int) -> tuple[str, int]:
         """Escape one unit"""
         byte = payload[index]
         if escaped := _escape_control_byte(byte):
@@ -133,9 +139,9 @@ def printable_escape(payload: bytes) -> str:
             return chr(byte), 1
         if decoded := _decode_printable_utf8(payload, index):
             return decoded
-        return r"\x{:02x}".format(byte), 1
+        return rf"\x{byte:02x}", 1
 
-    output: List[str] = []
+    output: list[str] = []
     index = 0
     while index < len(payload):
         escaped, consumed = _escape_byte(payload, index)
@@ -146,12 +152,12 @@ def printable_escape(payload: bytes) -> str:
 
 def _rfc3339_ms(timestamp: float) -> str:
     dt = datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc)
-    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + "{:03d}Z".format(dt.microsecond // 1000)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
 
 
 def _timestamp_token(timestamp: float) -> str:
     dt = datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc)
-    return dt.strftime("%Y%m%dT%H%M%S") + "{:06d}Z".format(dt.microsecond)
+    return dt.strftime("%Y%m%dT%H%M%S") + f"{dt.microsecond:06d}Z"
 
 
 def _ensure_secure_directory(path: str) -> None:
@@ -159,11 +165,14 @@ def _ensure_secure_directory(path: str) -> None:
     os.makedirs(path, mode=0o700, exist_ok=True)
     info = os.lstat(path)
     if not stat.S_ISDIR(info.st_mode) or stat.S_ISLNK(info.st_mode):
-        raise MirrorError("unsafe_recording_path",
-                          "Recording directory is not a real directory: {}".format(path))
+        raise MirrorError(
+            "unsafe_recording_path",
+            f"Recording directory is not a real directory: {path}",
+        )
     os.chmod(path, 0o700)
     if os.geteuid() == 0:
         os.chown(path, 0, 0)
+
 
 @dataclass(frozen=True)
 class WriterRecord:
@@ -171,6 +180,7 @@ class WriterRecord:
     payload: bytes
     timestamp: float
     is_event: bool = False
+
 
 class RecordingWriter:
     """Write one mirror session through a bounded background queue.
@@ -194,8 +204,8 @@ class RecordingWriter:
         base_dir: str = MIRROR_BASE_DIR,
         queue_size: int = 4096,
         shutdown_timeout: float = 5.0,
-        on_fatal: Optional[Callable[["RecordingWriter", Exception], None]] = None,
-        on_rotate: Optional[Callable[[str], None]] = None,
+        on_fatal: Callable[["RecordingWriter", Exception], None] | None = None,
+        on_rotate: Callable[[str], None] | None = None,
     ) -> None:
         self.line = validate_line(line)
         if direction not in VALID_DIRECTIONS:
@@ -204,7 +214,7 @@ class RecordingWriter:
         self.timeout_text = timeout_text
         self.max_file_size = max_file_size_mb * 1024 * 1024
         self.base_dir = base_dir
-        self.line_dir = os.path.join(base_dir, "line{}".format(line))
+        self.line_dir = os.path.join(base_dir, f"line{line}")
         self.queue_size = queue_size
         self.shutdown_timeout = shutdown_timeout
         self.on_fatal = on_fatal
@@ -223,7 +233,7 @@ class RecordingWriter:
         self._queue: queue.Queue = queue.Queue(maxsize=queue_size + 4)
         self._accepting = True
         self._closing = threading.Event()
-        self._shutdown_deadline: Optional[float] = None
+        self._shutdown_deadline: float | None = None
         self._lock = threading.Lock()
         self._fatal_reported = False
 
@@ -231,7 +241,7 @@ class RecordingWriter:
         self._prepare_paths_and_open()
         # Start the background thread to process the queue
         self._thread = threading.Thread(
-            target=self._run, name="console-mirror-writer-{}".format(line), daemon=True
+            target=self._run, name=f"console-mirror-writer-{line}", daemon=True
         )
         self._thread.start()
 
@@ -244,9 +254,7 @@ class RecordingWriter:
             self.start_timestamp = time.time()
             self.start_monotonic = time.monotonic()
             self.timestamp_token = _timestamp_token(self.start_timestamp)
-            basename = "console-mirror-line{}-{}-{}".format(
-                self.line, self.direction, self.timestamp_token
-            )
+            basename = f"console-mirror-line{self.line}-{self.direction}-{self.timestamp_token}"
             self.recording_prefix = os.path.join(self.line_dir, basename)
             try:
                 self._open_part(1, exclusive=True)
@@ -254,15 +262,17 @@ class RecordingWriter:
             except FileExistsError as error:
                 last_error = error
                 time.sleep(0.000001)
-        raise MirrorError("file_open_failed", "Could not create a unique recording file") from last_error
+        raise MirrorError(
+            "file_open_failed", "Could not create a unique recording file"
+        ) from last_error
 
     def _open_part(self, part_number: int, exclusive: bool = True) -> None:
-        path = "{}-part{:04d}.log".format(self.recording_prefix, part_number)
-        flags = os.O_WRONLY | os.O_CREAT # Write-only, create if not exists
+        path = f"{self.recording_prefix}-part{part_number:04d}.log"
+        flags = os.O_WRONLY | os.O_CREAT  # Write-only, create if not exists
         if exclusive:
-            flags |= os.O_EXCL # Fail if the file already exists
+            flags |= os.O_EXCL  # Fail if the file already exists
         if hasattr(os, "O_NOFOLLOW"):
-            flags |= os.O_NOFOLLOW # Do not follow symlinks
+            flags |= os.O_NOFOLLOW  # Do not follow symlinks
         fd = os.open(path, flags, 0o600)
         file_object = None
         try:
@@ -270,17 +280,11 @@ class RecordingWriter:
             if os.geteuid() == 0:
                 os.fchown(fd, 0, 0)
             file_object = os.fdopen(fd, "w", encoding="utf-8", newline="\n")
-            fd = -1 # Mark fd as closed since we now have a file object
+            fd = -1  # Mark fd as closed since we now have a file object
             header = (
                 "# SONIC_CONSOLE_MIRROR_TEXT version=1\n"
-                "# line={} direction={} start_time={} timeout={} part=part{:04d} encoding=printable-escape\n"
+                f"# line={self.line} direction={self.direction} start_time={_rfc3339_ms(self.start_timestamp)} timeout={self.timeout_text} part=part{part_number:04d} encoding=printable-escape\n"
                 "# fields=timestamp delta seq direction length payload\n"
-            ).format(
-                self.line,
-                self.direction,
-                _rfc3339_ms(self.start_timestamp),
-                self.timeout_text,
-                part_number,
             )
             file_object.write(header)
             file_object.flush()
@@ -316,9 +320,11 @@ class RecordingWriter:
             nonblocking=True,
         )
 
-    def submit_event(self, event: Dict[str, Any], nonblocking: bool = False) -> bool:
+    def submit_event(self, event: dict[str, Any], nonblocking: bool = False) -> bool:
         """Enqueue a JSON event; optionally avoid waiting for the state lock."""
-        payload = json.dumps(event, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        payload = json.dumps(event, separators=(",", ":"), ensure_ascii=False).encode(
+            "utf-8"
+        )
         return self._submit(
             WriterRecord("EVENT", payload, time.time(), is_event=True),
             priority=True,
@@ -344,37 +350,37 @@ class RecordingWriter:
 
     def _render_record(self, record: WriterRecord, seq: int) -> bytes:
         # Calculate the time delta in milliseconds
-        delta_ms = int(round((record.timestamp - self.start_timestamp) * 1000))
+        delta_ms = round((record.timestamp - self.start_timestamp) * 1000)
         delta_ms: int = min(MAX_DELTA_MS, max(0, delta_ms))
         # Decode the payload for display
-        payload_text: str = record.payload.decode("utf-8") if record.is_event else printable_escape(record.payload)
+        payload_text: str = (
+            record.payload.decode("utf-8")
+            if record.is_event
+            else printable_escape(record.payload)
+        )
         # Format the line
         # timestamp delta seq direction length payload
         # 2026-07-14T12:00:01.000Z +000000001000ms 00000002 RX 00000005 hello
-        line: str = "{} +{:012d}ms {:08d} {} {:08d} {}\n".format(
-            _rfc3339_ms(record.timestamp),
-            delta_ms,
-            seq,
-            record.direction,
-            len(record.payload),
-            payload_text,
-        )
+        line: str = f"{_rfc3339_ms(record.timestamp)} +{delta_ms:012d}ms {seq:08d} {record.direction} {len(record.payload):08d} {payload_text}\n"
         return line.encode("utf-8")
 
     def _rotate(self) -> None:
         next_part = self.part_number + 1
         if next_part > MAX_PART_NUMBER:
-            raise MirrorError("part_limit_exceeded", "Recording reached the maximum part count")
+            raise MirrorError(
+                "part_limit_exceeded", "Recording reached the maximum part count"
+            )
         rotate = WriterRecord(
             "EVENT",
             json.dumps(
-                {"event": "rotate", "next_part": "part{:04d}".format(next_part)},
+                {"event": "rotate", "next_part": f"part{next_part:04d}"},
                 separators=(",", ":"),
             ).encode("utf-8"),
             time.time(),
             is_event=True,
         )
         rotate_bytes = self._render_record(rotate, self._seq + 1)
+        assert self._file is not None
         # If the current part has enough space, write the rotate event to it before closing
         if self._file_size + len(rotate_bytes) <= self.max_file_size:
             self._file.write(rotate_bytes.decode("utf-8"))
@@ -392,10 +398,14 @@ class RecordingWriter:
     def _write_record(self, record: WriterRecord) -> None:
         encoded = self._render_record(record, self._seq + 1)
         # Rotate if not the first record and exceeds the max file size
-        if self._part_has_records and self._file_size + len(encoded) > self.max_file_size:
+        if (
+            self._part_has_records
+            and self._file_size + len(encoded) > self.max_file_size
+        ):
             self._rotate()
             # Re-render the record after rotation to get the correct seq
             encoded = self._render_record(record, self._seq + 1)
+        assert self._file is not None
         self._file.write(encoded.decode("utf-8"))
         self._file_size += len(encoded)
         self._part_has_records = True
@@ -408,7 +418,10 @@ class RecordingWriter:
                 if self._closing.is_set():
                     if self._queue.empty():
                         break
-                    if self._shutdown_deadline is not None and time.monotonic() >= self._shutdown_deadline:
+                    if (
+                        self._shutdown_deadline is not None
+                        and time.monotonic() >= self._shutdown_deadline
+                    ):
                         break
                 try:
                     # Wait for a record to be available
@@ -419,6 +432,7 @@ class RecordingWriter:
                     self._write_record(record)
                 finally:
                     self._queue.task_done()
+            assert self._file is not None
             self._file.flush()
         except Exception as error:
             fatal_error = error
@@ -465,17 +479,19 @@ class ArchiveJob:
 @dataclass(frozen=True)
 class ArchiveResult:
     archive_path: str
-    undeleted_sources: Tuple[str, ...] = ()
+    undeleted_sources: tuple[str, ...] = ()
 
 
 class ArchiveHandle:
     """Caller-facing handle for waiting on or cancelling an archive job."""
 
-    def __init__(self, future: concurrent.futures.Future, cancel_event: threading.Event) -> None:
+    def __init__(
+        self, future: concurrent.futures.Future, cancel_event: threading.Event
+    ) -> None:
         self.future = future
         self.cancel_event = cancel_event
 
-    def result(self, timeout: Optional[float] = None) -> ArchiveResult:
+    def result(self, timeout: float | None = None) -> ArchiveResult:
         """Wait for completion and return the result, subject to ``timeout``."""
         return self.future.result(timeout=timeout)
 
@@ -497,7 +513,7 @@ class RecordingArchiver:
             max_workers=1, thread_name_prefix="console-mirror-archiver"
         )
         self._lock = threading.Lock()
-        self._handles: List[ArchiveHandle] = []
+        self._handles: list[ArchiveHandle] = []
         self._pending_slots = threading.BoundedSemaphore(max_pending_jobs)
 
     def submit(self, job: ArchiveJob) -> ArchiveHandle:
@@ -531,19 +547,25 @@ class RecordingArchiver:
         line_dir = os.path.dirname(job.recording_prefix)
         prefix_name = os.path.basename(job.recording_prefix)
         # Eg: <prefix>-part0001.log
-        pattern = re.compile(r"^{}-part([0-9]{{4}})\.log$".format(re.escape(prefix_name)))
-        parts: List[Tuple[int, str]] = []
+        pattern = re.compile(
+            rf"^{re.escape(prefix_name)}-part([0-9]{{4}})\.log$"
+        )
+        parts: list[tuple[int, str]] = []
         for entry in os.scandir(line_dir):
             match = pattern.fullmatch(entry.name)
             if match and entry.is_file(follow_symlinks=False):
                 parts.append((int(match.group(1)), entry.path))
         parts.sort()
-        if not parts or [number for number, _ in parts] != list(range(1, len(parts) + 1)):
-            raise MirrorError("archive_failed", "Recording parts are missing or non-contiguous")
+        if not parts or [number for number, _ in parts] != list(
+            range(1, len(parts) + 1)
+        ):
+            raise MirrorError(
+                "archive_failed", "Recording parts are missing or non-contiguous"
+            )
         for _, path in parts:
             with open(path, "rb"):
                 pass
-        
+
         # Create a temporary archive file and write the parts into it
         temporary_path = job.archive_path + ".tmp"
         flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
@@ -551,7 +573,7 @@ class RecordingArchiver:
             flags |= os.O_NOFOLLOW
         fd = -1
         try:
-             # Create file
+            # Create file
             if cancel_event.is_set():
                 raise ArchiveCancelled()
             fd = os.open(temporary_path, flags, 0o600)
@@ -562,17 +584,21 @@ class RecordingArchiver:
             # Write parts
             with os.fdopen(fd, "w+b") as archive_file:
                 fd = -1
-                with zipfile.ZipFile(archive_file, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+                with zipfile.ZipFile(
+                    archive_file, "w", compression=zipfile.ZIP_DEFLATED
+                ) as archive:
                     for _, source in parts:
                         if cancel_event.is_set():
                             raise ArchiveCancelled()
                         archive.write(source, arcname=os.path.basename(source))
-                        
+
             # Validate the archive by checking for any bad files and ensuring the number of files matches
             if cancel_event.is_set():
                 raise ArchiveCancelled()
             with zipfile.ZipFile(temporary_path, "r") as archive:
-                if archive.testzip() is not None or len(archive.infolist()) != len(parts):
+                if archive.testzip() is not None or len(archive.infolist()) != len(
+                    parts
+                ):
                     raise MirrorError("archive_failed", "ZIP validation failed")
             os.replace(temporary_path, job.archive_path)
 
@@ -588,11 +614,16 @@ class RecordingArchiver:
 
             return ArchiveResult(job.archive_path, tuple(undeleted))
         except ArchiveCancelled:
-            raise MirrorError("archive_cancelled", "Archive packaging was cancelled; source logs were preserved")
+            raise MirrorError(
+                "archive_cancelled",
+                "Archive packaging was cancelled; source logs were preserved",
+            )
         except MirrorError:
             raise
         except Exception as error:
-            raise MirrorError("archive_failed", "Archive packaging failed: {}".format(error))
+            raise MirrorError(
+                "archive_failed", f"Archive packaging failed: {error}"
+            )
         finally:
             if fd >= 0:
                 os.close(fd)
@@ -600,14 +631,20 @@ class RecordingArchiver:
                 os.unlink(temporary_path)
             except OSError as error:
                 if error.errno != errno.ENOENT:
-                    log.warning("Failed to remove temporary archive %s: %s", temporary_path, error)
+                    log.warning(
+                        "Failed to remove temporary archive %s: %s",
+                        temporary_path,
+                        error,
+                    )
 
     def shutdown(self, timeout: float = 5.0) -> None:
         """Wait boundedly, request cancellation, and stop accepting new jobs."""
         with self._lock:
             handles = list(self._handles)
         if handles:
-            concurrent.futures.wait([handle.future for handle in handles], timeout=timeout)
+            concurrent.futures.wait(
+                [handle.future for handle in handles], timeout=timeout
+            )
         for handle in handles:
             if not handle.future.done():
                 handle.cancel()
@@ -629,7 +666,7 @@ class MirrorManager:
         state_table: Any,
         base_dir: str = MIRROR_BASE_DIR,
         writer_factory: Callable[..., RecordingWriter] = RecordingWriter,
-        archiver: Optional[RecordingArchiver] = None,
+        archiver: RecordingArchiver | None = None,
         writer_queue_size: int = 4096,
     ) -> None:
         self.line = validate_line(line)
@@ -639,38 +676,51 @@ class MirrorManager:
         self.archiver = archiver or RecordingArchiver()
         self.writer_queue_size = writer_queue_size
         self.state = "idle"
-        self.direction: Optional[str] = None
-        self.start_time: Optional[float] = None
-        self.timeout_text: Optional[str] = None
-        self.timeout_seconds: Optional[int] = None
-        self.deadline: Optional[float] = None
-        self.file_path: Optional[str] = None
-        self.writer: Optional[RecordingWriter] = None
-        self.timer: Optional[threading.Timer] = None
+        self.direction: str | None = None
+        self.start_time: float | None = None
+        self.timeout_text: str | None = None
+        self.timeout_seconds: int | None = None
+        self.deadline: float | None = None
+        self.file_path: str | None = None
+        self.writer: RecordingWriter | None = None
+        self.timer: threading.Timer | None = None
         self.writer_drop_count = 0
-        self._owner_pid: Optional[int] = None
-        self._started_by: Optional[str] = None
+        self._owner_pid: int | None = None
+        self._started_by: str | None = None
         self._lock = threading.RLock()
         self._write_idle_state()
 
-    def _state_set(self, values: List[Tuple[str, str]]) -> None:
+    def _state_set(self, values: list[tuple[str, str]]) -> None:
         try:
             self.state_table.set(self.line, values)
         except Exception as error:
             log.error("[%s] Failed to update mirror STATE_DB: %s", self.line, error)
 
     def _state_delete_fields(self) -> None:
-        for field in ("owner_pid", "started_by", "start_time", "timeout", "file_path", "direction"):
+        for field in (
+            "owner_pid",
+            "started_by",
+            "start_time",
+            "timeout",
+            "file_path",
+            "direction",
+        ):
             try:
                 self.state_table.hdel(self.line, field)
             except Exception as error:
-                log.error("[%s] Failed to clear mirror STATE_DB field %s: %s", self.line, field, error)
+                log.error(
+                    "[%s] Failed to clear mirror STATE_DB field %s: %s",
+                    self.line,
+                    field,
+                    error,
+                )
 
     def _write_idle_state(self) -> None:
         self._state_set([("state", "idle")])
         self._state_delete_fields()
 
     def _write_active_state(self) -> None:
+        assert self.start_time is not None
         values = [
             ("state", self.state),
             ("owner_pid", str(self._owner_pid)),
@@ -682,25 +732,40 @@ class MirrorManager:
         ]
         self._state_set(values)
 
-    def start(self, options: Dict[str, Any]) -> Dict[str, Any]:
+    def start(self, options: dict[str, Any]) -> dict[str, Any]:
         """Start an idle mirror session and return its active-session metadata."""
         direction = options.get("direction", "both")
         if not isinstance(direction, str) or direction not in VALID_DIRECTIONS:
             raise MirrorError("invalid_direction", "Direction must be rx, tx, or both")
-        timeout_text, timeout_seconds = parse_duration(options.get("timeout", DEFAULT_TIMEOUT))
+        timeout_text, timeout_seconds = parse_duration(
+            options.get("timeout", DEFAULT_TIMEOUT)
+        )
         max_file_size = options.get("max_file_size", DEFAULT_MAX_FILE_SIZE_MB)
-        if isinstance(max_file_size, bool) or not isinstance(max_file_size, int) or max_file_size <= 0:
-            raise MirrorError("invalid_max_file_size", "max_file_size must be a positive integer in MB")
+        if (
+            isinstance(max_file_size, bool)
+            or not isinstance(max_file_size, int)
+            or max_file_size <= 0
+        ):
+            raise MirrorError(
+                "invalid_max_file_size",
+                "max_file_size must be a positive integer in MB",
+            )
         owner_pid = options.get("owner_pid")
-        if isinstance(owner_pid, bool) or not isinstance(owner_pid, int) or owner_pid <= 0:
-            raise MirrorError("invalid_owner_pid", "owner_pid must be a positive integer")
+        if (
+            isinstance(owner_pid, bool)
+            or not isinstance(owner_pid, int)
+            or owner_pid <= 0
+        ):
+            raise MirrorError(
+                "invalid_owner_pid", "owner_pid must be a positive integer"
+            )
         started_by = str(options.get("started_by", "root"))
 
         with self._lock:
             if self.state != "idle":
                 raise MirrorError(
                     "mirror_already_active",
-                    "Line {} already has an active mirror session".format(self.line),
+                    f"Line {self.line} already has an active mirror session",
                 )
             try:
                 writer = self.writer_factory(
@@ -716,11 +781,12 @@ class MirrorManager:
             except MirrorError:
                 raise
             except Exception as error:
-                raise MirrorError("file_open_failed", "Failed to open recording file: {}".format(error))
+                raise MirrorError(
+                    "file_open_failed",
+                    f"Failed to open recording file: {error}",
+                )
 
-            timer = threading.Timer(
-                timeout_seconds, lambda: self._on_timeout(timer)
-            )
+            timer = threading.Timer(timeout_seconds, lambda: self._on_timeout(timer))
             timer.daemon = True
             self.writer = writer
             self.direction = direction
@@ -743,7 +809,10 @@ class MirrorManager:
                 writer.close()
                 self._clear_runtime_fields()
                 self._write_idle_state()
-                raise MirrorError("timer_setup_failed", "Failed to arm mirror timeout: {}".format(error))
+                raise MirrorError(
+                    "timer_setup_failed",
+                    f"Failed to arm mirror timeout: {error}",
+                )
             writer.submit_event({"event": "start"})
             self._write_active_state()
             return {
@@ -790,7 +859,7 @@ class MirrorManager:
         finally:
             self._lock.release()
 
-    def update_timeout(self, timeout_value: Any) -> Dict[str, Any]:
+    def update_timeout(self, timeout_value: Any) -> dict[str, Any]:
         """Reset an active session's timeout from now and return the new timeout."""
         timeout_text, timeout_seconds = parse_duration(timeout_value)
         replacement = threading.Timer(
@@ -799,15 +868,25 @@ class MirrorManager:
         replacement.daemon = True
         with self._lock:
             if self.state != "active" or self.writer is None:
-                raise MirrorError("mirror_not_active", "Line {} has no active mirror session".format(self.line))
+                raise MirrorError(
+                    "mirror_not_active",
+                    f"Line {self.line} has no active mirror session",
+                )
+            assert self.start_time is not None
             elapsed_ms = max(0, int((time.time() - self.start_time) * 1000))
             if elapsed_ms + timeout_seconds * 1000 > MAX_DELTA_MS:
-                raise MirrorError("invalid_timeout", "Elapsed time plus timeout exceeds the SCM-Text delta range")
+                raise MirrorError(
+                    "invalid_timeout",
+                    "Elapsed time plus timeout exceeds the SCM-Text delta range",
+                )
             previous_timer = self.timer
             try:
                 replacement.start()
             except Exception as error:
-                raise MirrorError("timer_setup_failed", "Failed to reset mirror timeout: {}".format(error))
+                raise MirrorError(
+                    "timer_setup_failed",
+                    f"Failed to reset mirror timeout: {error}",
+                )
             self.timer = replacement
             self.timeout_text = timeout_text
             self.timeout_seconds = timeout_seconds
@@ -815,7 +894,9 @@ class MirrorManager:
             self.writer.update_timeout(timeout_text)
             if previous_timer:
                 previous_timer.cancel()
-            self.writer.submit_event({"event": "timeout_update", "timeout": timeout_text})
+            self.writer.submit_event(
+                {"event": "timeout_update", "timeout": timeout_text}
+            )
             self._write_active_state()
             return {"status": "ok", "timeout": timeout_text, "remaining": timeout_text}
 
@@ -823,15 +904,18 @@ class MirrorManager:
         self,
         reason: str = "manual",
         archive: bool = False,
-        expected_timer: Optional[threading.Timer] = None,
-    ) -> Dict[str, Any]:
+        expected_timer: threading.Timer | None = None,
+    ) -> dict[str, Any]:
         """Stop an active session, optionally submitting its files for archiving.
 
         ``expected_timer`` rejects callbacks from a superseded timeout timer.
         """
         with self._lock:
             if self.state != "active" or self.writer is None:
-                raise MirrorError("mirror_not_active", "Line {} has no active mirror session".format(self.line))
+                raise MirrorError(
+                    "mirror_not_active",
+                    f"Line {self.line} has no active mirror session",
+                )
             if expected_timer is not None and self.timer is not expected_timer:
                 raise MirrorError("stale_timeout", "Superseded mirror timeout ignored")
             self.state = "stopping"
@@ -862,6 +946,7 @@ class MirrorManager:
                 "message": "Mirror stopped; recording files retained",
                 "recording_prefix": recording_prefix,
             }
+        assert start_timestamp is not None and direction is not None
         job = ArchiveJob(
             line=self.line,
             direction=direction,
@@ -877,7 +962,7 @@ class MirrorManager:
         except Exception as error:
             raise MirrorError(
                 "archive_failed",
-                "Could not submit archive job: {}; source logs were preserved".format(error),
+                f"Could not submit archive job: {error}; source logs were preserved",
             )
         return {
             "status": "packaging",
@@ -886,12 +971,19 @@ class MirrorManager:
             "archive_handle": handle,
         }
 
-    def status(self) -> Dict[str, Any]:
+    def status(self) -> dict[str, Any]:
         """Return the current state and any active-session metadata."""
         with self._lock:
-            response: Dict[str, Any] = {"status": "ok", "state": self.state, "line": self.line}
+            response: dict[str, Any] = {
+                "status": "ok",
+                "state": self.state,
+                "line": self.line,
+            }
             if self.state in ("active", "stopping"):
-                remaining = 0 if self.deadline is None else self.deadline - time.monotonic()
+                remaining = (
+                    0 if self.deadline is None else self.deadline - time.monotonic()
+                )
+                assert self.start_time is not None
                 response.update(
                     {
                         "start_time": _rfc3339_ms(self.start_time),
@@ -908,14 +1000,16 @@ class MirrorManager:
             self.stop(reason="timeout", archive=True, expected_timer=fired_timer)
         except MirrorError as error:
             if error.code not in ("mirror_not_active", "stale_timeout"):
-                log.error("[%s] Automatic mirror stop failed: %s", self.line, error.message)
+                log.error(
+                    "[%s] Automatic mirror stop failed: %s", self.line, error.message
+                )
 
     def _on_writer_fatal(self, writer: RecordingWriter, error: Exception) -> None:
         log.error("[%s] Fatal mirror writer error: %s", self.line, error)
         threading.Thread(
             target=self._stop_after_writer_error,
             args=(writer,),
-            name="console-mirror-writer-error-{}".format(self.line),
+            name=f"console-mirror-writer-error-{self.line}",
             daemon=True,
         ).start()
 
@@ -950,7 +1044,7 @@ class MirrorManager:
             self._write_idle_state()
 
 
-def _recv_exact(connection: socket.socket, size: int) -> Optional[bytes]:
+def _recv_exact(connection: socket.socket, size: int) -> bytes | None:
     chunks = []
     remaining = size
     while remaining:
@@ -961,7 +1055,8 @@ def _recv_exact(connection: socket.socket, size: int) -> Optional[bytes]:
         remaining -= len(chunk)
     return b"".join(chunks)
 
-def recv_message(connection: socket.socket) -> Optional[Dict[str, Any]]:
+
+def recv_message(connection: socket.socket) -> dict[str, Any] | None:
     """Receive one length-prefixed JSON object, or ``None`` after a clean EOF."""
     header = _recv_exact(connection, 4)
     if header is None:
@@ -980,10 +1075,14 @@ def recv_message(connection: socket.socket) -> Optional[Dict[str, Any]]:
         raise MirrorError("invalid_message", "Control message must be a JSON object")
     return message
 
-def send_message(connection: socket.socket, message: Dict[str, Any]) -> None:
+
+def send_message(connection: socket.socket, message: dict[str, Any]) -> None:
     """Send one JSON object using the control protocol's length prefix."""
-    payload = json.dumps(message, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    payload = json.dumps(message, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )
     connection.sendall(struct.pack("!I", len(payload)) + payload)
+
 
 class MirrorControlServer:
     """Serve root-only mirror control requests for one console line.
@@ -1007,12 +1106,12 @@ class MirrorControlServer:
         self.runtime_dir = runtime_dir
         self.archive_wait_seconds = archive_wait_seconds
         self.max_clients = max_clients
-        self.socket_path = os.path.join(runtime_dir, "line{}.sock".format(self.line))
-        self._socket: Optional[socket.socket] = None
-        self._thread: Optional[threading.Thread] = None
+        self.socket_path = os.path.join(runtime_dir, f"line{self.line}.sock")
+        self._socket: socket.socket | None = None
+        self._thread: threading.Thread | None = None
         self._running = threading.Event()
         self._clients = threading.Semaphore(max_clients)
-        self._client_threads: List[threading.Thread] = []
+        self._client_threads: list[threading.Thread] = []
 
     @staticmethod
     def _root_only(uid: int) -> bool:
@@ -1025,7 +1124,10 @@ class MirrorControlServer:
         try:
             info = os.lstat(self.socket_path)
             if not stat.S_ISSOCK(info.st_mode):
-                raise MirrorError("unsafe_socket_path", "Control socket path is occupied by a non-socket")
+                raise MirrorError(
+                    "unsafe_socket_path",
+                    "Control socket path is occupied by a non-socket",
+                )
             os.unlink(self.socket_path)
         except FileNotFoundError:
             pass
@@ -1047,16 +1149,17 @@ class MirrorControlServer:
         self._running.set()
         self._thread = threading.Thread(
             target=self._serve,
-            name="console-mirror-control-{}".format(self.line),
-            daemon=True
+            name=f"console-mirror-control-{self.line}",
+            daemon=True,
         )
         self._thread.start()
 
     def _serve(self) -> None:
         while self._running.is_set():
             try:
+                assert self._socket is not None
                 connection, _ = self._socket.accept()
-            except socket.timeout:
+            except TimeoutError:
                 continue
             except OSError:
                 break
@@ -1066,7 +1169,7 @@ class MirrorControlServer:
             thread = threading.Thread(
                 target=self._handle_and_release,
                 args=(connection,),
-                name="console-mirror-client-{}".format(self.line),
+                name=f"console-mirror-client-{self.line}",
                 daemon=True,
             )
             self._client_threads.append(thread)
@@ -1083,11 +1186,15 @@ class MirrorControlServer:
             except ValueError:
                 pass
 
-    def _peer_credentials(self, connection: socket.socket) -> Tuple[int, int, int]:
-        credentials = connection.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize("3i"))
+    def _peer_credentials(self, connection: socket.socket) -> tuple[int, int, int]:
+        credentials = connection.getsockopt(
+            socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize("3i")
+        )
         return struct.unpack("3i", credentials)
 
-    def _send_archive_completion(self, connection: socket.socket, handle: ArchiveHandle) -> None:
+    def _send_archive_completion(
+        self, connection: socket.socket, handle: ArchiveHandle
+    ) -> None:
         try:
             deadline = time.monotonic() + self.archive_wait_seconds
             while True:
@@ -1115,7 +1222,9 @@ class MirrorControlServer:
                     },
                 )
             else:
-                send_message(connection, {"status": "ok", "archive_path": result.archive_path})
+                send_message(
+                    connection, {"status": "ok", "archive_path": result.archive_path}
+                )
         except MirrorError as error:
             send_message(
                 connection,
@@ -1134,20 +1243,24 @@ class MirrorControlServer:
                 {
                     "status": "error",
                     "code": "archive_failed",
-                    "message": "Archive packaging failed: {}; original log parts were preserved".format(error),
+                    "message": f"Archive packaging failed: {error}; original log parts were preserved",
                 },
             )
 
     def _handle_client(self, connection: socket.socket) -> None:
         try:
-            pid, uid, gid = self._peer_credentials(connection)
+            pid, uid, _gid = self._peer_credentials(connection)
             if not self._root_only(uid):
-                raise MirrorError("permission_denied", "Mirror control requires root privileges")
+                raise MirrorError(
+                    "permission_denied", "Mirror control requires root privileges"
+                )
             request = recv_message(connection)
             if request is None:
                 return
             if str(request.get("line")) != self.line:
-                raise MirrorError("line_mismatch", "Requested line does not match this proxy")
+                raise MirrorError(
+                    "line_mismatch", "Requested line does not match this proxy"
+                )
             operation = request.get("op")
             if operation == "start":
                 username = request.get("started_by")
@@ -1172,9 +1285,13 @@ class MirrorControlServer:
             elif operation == "status":
                 send_message(connection, self.manager.status())
             elif operation == "timeout":
-                send_message(connection, self.manager.update_timeout(request.get("timeout")))
+                send_message(
+                    connection, self.manager.update_timeout(request.get("timeout"))
+                )
             else:
-                raise MirrorError("unsupported_operation", "Unsupported mirror operation")
+                raise MirrorError(
+                    "unsupported_operation", "Unsupported mirror operation"
+                )
         except MirrorError as error:
             response = {"status": "error", "code": error.code, "message": error.message}
             response.update(error.details)
@@ -1187,7 +1304,11 @@ class MirrorControlServer:
                 try:
                     send_message(
                         connection,
-                        {"status": "error", "code": "internal_error", "message": str(error)},
+                        {
+                            "status": "error",
+                            "code": "internal_error",
+                            "message": str(error),
+                        },
                     )
                 except OSError:
                     pass
@@ -1208,4 +1329,8 @@ class MirrorControlServer:
             os.unlink(self.socket_path)
         except OSError as error:
             if error.errno != errno.ENOENT:
-                log.warning("Failed to remove mirror control socket %s: %s", self.socket_path, error)
+                log.warning(
+                    "Failed to remove mirror control socket %s: %s",
+                    self.socket_path,
+                    error,
+                )

--- a/host_modules/console_mirror.py
+++ b/host_modules/console_mirror.py
@@ -456,14 +456,15 @@ class RecordingWriter:
         if self.on_fatal:
             self.on_fatal(self, error)
 
-    def close(self) -> None:
-        """Stop accepting records and wait boundedly for queued writes to finish."""
+    def close(self) -> bool:
+        """Stop accepting records and report whether the writer fully exited."""
         with self._lock:
             self._accepting = False
             self._shutdown_deadline = time.monotonic() + self.shutdown_timeout
             self._closing.set()
         if threading.current_thread() is not self._thread:
             self._thread.join(self.shutdown_timeout + 0.5)
+        return not self._thread.is_alive()
 
 
 @dataclass(frozen=True)
@@ -931,7 +932,7 @@ class MirrorManager:
             self._write_active_state()
             writer.submit_event({"event": "stop", "reason": reason})
 
-        writer.close()
+        writer_closed = writer.close()
 
         with self._lock:
             if self.writer is writer:
@@ -946,6 +947,12 @@ class MirrorManager:
                 "message": "Mirror stopped; recording files retained",
                 "recording_prefix": recording_prefix,
             }
+        if not writer_closed:
+            raise MirrorError(
+                "writer_shutdown_incomplete",
+                "Writer shutdown did not complete; archive was skipped and "
+                "source logs were preserved",
+            )
         assert start_timestamp is not None and direction is not None
         job = ArchiveJob(
             line=self.line,

--- a/host_modules/console_mirror.py
+++ b/host_modules/console_mirror.py
@@ -1,0 +1,931 @@
+import concurrent.futures
+import datetime
+import errno
+import json
+import logging
+import math
+import os
+import pwd
+import queue
+import re
+import select
+import socket
+import stat
+import struct
+import threading
+import time
+import zipfile
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+log = logging.getLogger("console-monitor.mirror")
+
+DEFAULT_TIMEOUT = "24h"
+DEFAULT_MAX_FILE_SIZE_MB = 64
+MAX_DELTA_MS = 999999999999  # 12 digits
+MAX_PART_NUMBER = 9999
+_DURATION_RE = re.compile(r"^([0-9]+)([smhd])$")
+MAX_CONTROL_MESSAGE = 64 * 1024
+ARCHIVE_WAIT_SECONDS = 10 * 60
+MIRROR_BASE_DIR = "/var/log/sonic/console-mirror"
+MIRROR_RUNTIME_DIR = "/run/console-monitor/mirror"
+VALID_DIRECTIONS = frozenset(("rx", "tx", "both"))
+
+
+class MirrorError(Exception):
+    """An error safe to return over the local control protocol."""
+
+    def __init__(self, code: str, message: str, **details: Any) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = details
+
+class ArchiveCancelled(Exception):
+    pass
+
+def parse_duration(value: Any) -> Tuple[str, int]:
+    """Parse a duration string into (orginal text, seconds) tuple. Accepts formats like '30m', '2h', '1d'."""
+    if not isinstance(value, str):
+        raise MirrorError("invalid_timeout",
+                          "Timeout must use the form <integer>[s|m|h|d]")
+    match = _DURATION_RE.match(value)
+    if not match:
+        raise MirrorError("invalid_timeout",
+                          "Timeout must use the form <integer>[s|m|h|d]")
+    amount, unit = match.groups()
+    amount = int(amount)
+    if amount <= 0:
+        raise MirrorError("invalid_timeout", "Timeout must be positive")
+    multipliers = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+    seconds = amount * multipliers[unit]
+    if seconds * 1000 > MAX_DELTA_MS:
+        raise MirrorError("invalid_timeout",
+                          "Timeout exceeds the SCM-Text delta range")
+    return value.strip(), seconds
+
+
+def validate_line(value: Any) -> str:
+    """Validate a line number string. Accepts formats like '1', '2', '3'."""
+    line = str(value).strip()
+    if not re.fullmatch(r"[0-9]+", line):
+        raise MirrorError(
+            "invalid_line", "Console line must contain decimal digits only")
+    return line
+
+
+def format_remaining(seconds: float) -> str:
+    """Format a duration in seconds into a human-readable string like '1d2h3m4s'."""
+    remaining = max(0, int(math.ceil(seconds)))
+    if remaining == 0:
+        return "0s"
+    parts = []
+    for suffix, unit in (("d", 86400), ("h", 3600), ("m", 60), ("s", 1)):
+        value, remaining = divmod(remaining, unit)
+        if value:
+            parts.append("{}{}".format(value, suffix))
+    return "".join(parts)
+
+
+def printable_escape(payload: bytes) -> str:
+    """Return a deterministic, terminal-safe representation of a bytes payload."""
+    def _escape_control_byte(byte: int) -> Optional[str]:
+        """Escape a single control byte"""
+        escaped = {
+            0x0A: r"\n",
+            0x0D: r"\r",
+            0x09: r"\t",
+            0x5C: r"\\",
+            0x1B: r"\x1b",
+        }.get(byte)
+        if escaped is not None:
+            return escaped
+        if byte < 0x20 or 0x7F <= byte <= 0x9F:
+            return r"\x{:02x}".format(byte)
+        return None
+    
+    def _utf8_width(byte: int) -> int:
+        if 0xC2 <= byte <= 0xDF:
+            return 2
+        if 0xE0 <= byte <= 0xEF:
+            return 3
+        if 0xF0 <= byte <= 0xF4:
+            return 4
+        return 1
+
+    def _decode_printable_utf8(payload: bytes, index: int) -> Optional[Tuple[str, int]]:
+        width = _utf8_width(payload[index])
+        chunk = payload[index:index + width]
+        try:
+            char = chunk.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+        if len(char) == 1 and char.isprintable():
+            return char, width
+        return None
+
+    def _escape_byte(payload: bytes, index: int) -> Tuple[str, int]:
+        """Escape one unit"""
+        byte = payload[index]
+        if escaped := _escape_control_byte(byte):
+            return escaped, 1
+        if byte < 0x80:
+            return chr(byte), 1
+        if decoded := _decode_printable_utf8(payload, index):
+            return decoded
+        return r"\x{:02x}".format(byte), 1
+
+    output: List[str] = []
+    index = 0
+    while index < len(payload):
+        escaped, consumed = _escape_byte(payload, index)
+        output.append(escaped)
+        index += consumed
+    return "".join(output)
+
+
+def _rfc3339_ms(timestamp: float) -> str:
+    dt = datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + "{:03d}Z".format(dt.microsecond // 1000)
+
+
+def _timestamp_token(timestamp: float) -> str:
+    dt = datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc)
+    return dt.strftime("%Y%m%dT%H%M%S") + "{:06d}Z".format(dt.microsecond)
+
+
+def _ensure_secure_directory(path: str) -> None:
+    """Ensure that the given path exists and is a secure directory (700 permissions)."""
+    os.makedirs(path, mode=0o700, exist_ok=True)
+    info = os.lstat(path)
+    if not stat.S_ISDIR(info.st_mode) or stat.S_ISLNK(info.st_mode):
+        raise MirrorError("unsafe_recording_path",
+                          "Recording directory is not a real directory: {}".format(path))
+    os.chmod(path, 0o700)
+    if os.geteuid() == 0:
+        os.chown(path, 0, 0)
+
+@dataclass(frozen=True)
+class WriterRecord:
+    direction: str
+    payload: bytes
+    timestamp: float
+    is_event: bool = False
+
+class RecordingWriter:
+    """Write one mirror session through a bounded background queue.
+
+    Pass the line, direction, timeout text, and per-part MB limit; optional
+    arguments configure storage, queue/shutdown limits, and callbacks.
+    Construction opens ``part0001`` and starts the worker immediately. Submit
+    records with :meth:`submit_data` or :meth:`submit_event`, update future-part
+    metadata with :meth:`update_timeout`, and always finish with :meth:`close`.
+
+    ``on_fatal(writer, error)`` reports writer failure; ``on_rotate(path)``
+    reports the newly active part. Public methods are thread-safe.
+    """
+
+    def __init__(
+        self,
+        line: str,
+        direction: str,
+        timeout_text: str,
+        max_file_size_mb: int,
+        base_dir: str = MIRROR_BASE_DIR,
+        queue_size: int = 4096,
+        shutdown_timeout: float = 5.0,
+        on_fatal: Optional[Callable[["RecordingWriter", Exception], None]] = None,
+        on_rotate: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        self.line = validate_line(line)
+        if direction not in VALID_DIRECTIONS:
+            raise MirrorError("invalid_direction", "Direction must be rx, tx, or both")
+        self.direction = direction
+        self.timeout_text = timeout_text
+        self.max_file_size = max_file_size_mb * 1024 * 1024
+        self.base_dir = base_dir
+        self.line_dir = os.path.join(base_dir, "line{}".format(line))
+        self.queue_size = queue_size
+        self.shutdown_timeout = shutdown_timeout
+        self.on_fatal = on_fatal
+        self.on_rotate = on_rotate
+
+        self.start_timestamp = time.time()
+        self.start_monotonic = time.monotonic()
+        self.timestamp_token = _timestamp_token(self.start_timestamp)
+        self.recording_prefix = ""
+        self.file_path = ""
+        self.part_number = 1
+        self._seq = 0
+        self._file = None
+        self._file_size = 0
+        self._part_has_records = False
+        self._queue: queue.Queue = queue.Queue(maxsize=queue_size + 4)
+        self._accepting = True
+        self._closing = threading.Event()
+        self._shutdown_deadline: Optional[float] = None
+        self._lock = threading.Lock()
+        self._fatal_reported = False
+
+        # Prepare the recording directory and open the first part file
+        self._prepare_paths_and_open()
+        # Start the background thread to process the queue
+        self._thread = threading.Thread(
+            target=self._run, name="console-mirror-writer-{}".format(line), daemon=True
+        )
+        self._thread.start()
+
+    def _prepare_paths_and_open(self) -> None:
+        _ensure_secure_directory(self.base_dir)
+        _ensure_secure_directory(self.line_dir)
+        # Try to create a unique recording file, retrying if it already exists
+        last_error = None
+        for _ in range(100):
+            self.start_timestamp = time.time()
+            self.start_monotonic = time.monotonic()
+            self.timestamp_token = _timestamp_token(self.start_timestamp)
+            basename = "console-mirror-line{}-{}-{}".format(
+                self.line, self.direction, self.timestamp_token
+            )
+            self.recording_prefix = os.path.join(self.line_dir, basename)
+            try:
+                self._open_part(1, exclusive=True)
+                return
+            except FileExistsError as error:
+                last_error = error
+                time.sleep(0.000001)
+        raise MirrorError("file_open_failed", "Could not create a unique recording file") from last_error
+
+    def _open_part(self, part_number: int, exclusive: bool = True) -> None:
+        path = "{}-part{:04d}.log".format(self.recording_prefix, part_number)
+        flags = os.O_WRONLY | os.O_CREAT # Write-only, create if not exists
+        if exclusive:
+            flags |= os.O_EXCL # Fail if the file already exists
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW # Do not follow symlinks
+        fd = os.open(path, flags, 0o600)
+        file_object = None
+        try:
+            os.fchmod(fd, 0o600)
+            if os.geteuid() == 0:
+                os.fchown(fd, 0, 0)
+            file_object = os.fdopen(fd, "w", encoding="utf-8", newline="\n")
+            fd = -1 # Mark fd as closed since we now have a file object
+            header = (
+                "# SONIC_CONSOLE_MIRROR_TEXT version=1\n"
+                "# line={} direction={} start_time={} timeout={} part=part{:04d} encoding=printable-escape\n"
+                "# fields=timestamp delta seq direction length payload\n"
+            ).format(
+                self.line,
+                self.direction,
+                _rfc3339_ms(self.start_timestamp),
+                self.timeout_text,
+                part_number,
+            )
+            file_object.write(header)
+            file_object.flush()
+            self._file = file_object
+            self._file_size = len(header.encode("utf-8"))
+            self._part_has_records = False
+            self.part_number = part_number
+            self.file_path = path
+        except Exception:
+            if fd >= 0:
+                os.close(fd)
+            elif file_object is not None:
+                try:
+                    file_object.close()
+                except Exception:
+                    pass
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            raise
+
+    def update_timeout(self, timeout_text: str) -> None:
+        """Set the timeout header value used by subsequently rotated parts."""
+        with self._lock:
+            self.timeout_text = timeout_text
+
+    def submit_data(self, direction: str, payload: bytes) -> bool:
+        """Non-blockingly enqueue RX/TX bytes; return whether they were accepted."""
+        return self._submit(
+            WriterRecord(direction.upper(), bytes(payload), time.time()),
+            priority=False,
+            nonblocking=True,
+        )
+
+    def submit_event(self, event: Dict[str, Any], nonblocking: bool = False) -> bool:
+        """Enqueue a JSON event; optionally avoid waiting for the state lock."""
+        payload = json.dumps(event, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        return self._submit(
+            WriterRecord("EVENT", payload, time.time(), is_event=True),
+            priority=True,
+            nonblocking=nonblocking,
+        )
+
+    def _submit(self, record: WriterRecord, priority: bool, nonblocking: bool) -> bool:
+        if not self._lock.acquire(blocking=not nonblocking):
+            return False
+        try:
+            if not self._accepting:
+                return False
+            # If the queue is full and this is not a priority record, reject it
+            if not priority and self._queue.qsize() >= self.queue_size:
+                return False
+            try:
+                self._queue.put_nowait(record)
+                return True
+            except queue.Full:
+                return False
+        finally:
+            self._lock.release()
+
+    def _render_record(self, record: WriterRecord, seq: int) -> bytes:
+        # Calculate the time delta in milliseconds
+        delta_ms = int(round((record.timestamp - self.start_timestamp) * 1000))
+        delta_ms: int = min(MAX_DELTA_MS, max(0, delta_ms))
+        # Decode the payload for display
+        payload_text: str = record.payload.decode("utf-8") if record.is_event else printable_escape(record.payload)
+        # Format the line
+        # timestamp delta seq direction length payload
+        # 2026-07-14T12:00:01.000Z +000000001000ms 00000002 RX 00000005 hello
+        line: str = "{} +{:012d}ms {:08d} {} {:08d} {}\n".format(
+            _rfc3339_ms(record.timestamp),
+            delta_ms,
+            seq,
+            record.direction,
+            len(record.payload),
+            payload_text,
+        )
+        return line.encode("utf-8")
+
+    def _rotate(self) -> None:
+        next_part = self.part_number + 1
+        if next_part > MAX_PART_NUMBER:
+            raise MirrorError("part_limit_exceeded", "Recording reached the maximum part count")
+        rotate = WriterRecord(
+            "EVENT",
+            json.dumps(
+                {"event": "rotate", "next_part": "part{:04d}".format(next_part)},
+                separators=(",", ":"),
+            ).encode("utf-8"),
+            time.time(),
+            is_event=True,
+        )
+        rotate_bytes = self._render_record(rotate, self._seq + 1)
+        # If the current part has enough space, write the rotate event to it before closing
+        if self._file_size + len(rotate_bytes) <= self.max_file_size:
+            self._file.write(rotate_bytes.decode("utf-8"))
+            self._file_size += len(rotate_bytes)
+            self._seq += 1
+        # Flush and close the current part, then open the next part
+        self._file.flush()
+        self._file.close()
+        self._file = None
+        self._open_part(next_part, exclusive=True)
+        # Notify the callback that a rotation has occurred
+        if self.on_rotate:
+            self.on_rotate(self.file_path)
+
+    def _write_record(self, record: WriterRecord) -> None:
+        encoded = self._render_record(record, self._seq + 1)
+        # Rotate if not the first record and exceeds the max file size
+        if self._part_has_records and self._file_size + len(encoded) > self.max_file_size:
+            self._rotate()
+            # Re-render the record after rotation to get the correct seq
+            encoded = self._render_record(record, self._seq + 1)
+        self._file.write(encoded.decode("utf-8"))
+        self._file_size += len(encoded)
+        self._part_has_records = True
+        self._seq += 1
+
+    def _run(self) -> None:
+        fatal_error = None
+        try:
+            while True:
+                if self._closing.is_set():
+                    if self._queue.empty():
+                        break
+                    if self._shutdown_deadline is not None and time.monotonic() >= self._shutdown_deadline:
+                        break
+                try:
+                    # Wait for a record to be available
+                    record = self._queue.get(timeout=0.05)
+                except queue.Empty:
+                    continue
+                try:
+                    self._write_record(record)
+                finally:
+                    self._queue.task_done()
+            self._file.flush()
+        except Exception as error:
+            fatal_error = error
+        finally:
+            if self._file is not None:
+                try:
+                    self._file.close()
+                except Exception as error:
+                    fatal_error = fatal_error or error
+                self._file = None
+            if fatal_error is not None:
+                self._report_fatal(fatal_error)
+
+    def _report_fatal(self, error: Exception) -> None:
+        with self._lock:
+            self._accepting = False
+            if self._fatal_reported:
+                return
+            self._fatal_reported = True
+        # Call the fatal callback if provided
+        if self.on_fatal:
+            self.on_fatal(self, error)
+
+    def close(self) -> None:
+        """Stop accepting records and wait boundedly for queued writes to finish."""
+        with self._lock:
+            self._accepting = False
+            self._shutdown_deadline = time.monotonic() + self.shutdown_timeout
+            self._closing.set()
+        if threading.current_thread() is not self._thread:
+            self._thread.join(self.shutdown_timeout + 0.5)
+
+
+@dataclass(frozen=True)
+class ArchiveJob:
+    line: str
+    direction: str
+    start_timestamp: float
+    recording_prefix: str
+    archive_path: str
+    stop_reason: str
+
+
+@dataclass(frozen=True)
+class ArchiveResult:
+    archive_path: str
+    undeleted_sources: Tuple[str, ...] = ()
+
+
+class ArchiveHandle:
+    """Caller-facing handle for waiting on or cancelling an archive job."""
+
+    def __init__(self, future: concurrent.futures.Future, cancel_event: threading.Event) -> None:
+        self.future = future
+        self.cancel_event = cancel_event
+
+    def result(self, timeout: Optional[float] = None) -> ArchiveResult:
+        """Wait for completion and return the result, subject to ``timeout``."""
+        return self.future.result(timeout=timeout)
+
+    def cancel(self) -> bool:
+        """Request cooperative cancellation; return whether the job was unfinished."""
+        self.cancel_event.set()
+        return self.future.cancel() or not self.future.done()
+
+
+class RecordingArchiver:
+    """Run immutable archive jobs on one background worker.
+
+    ``max_pending_jobs`` bounds running and queued jobs. Use :meth:`submit` to
+    obtain an :class:`ArchiveHandle`, then call :meth:`shutdown` during cleanup.
+    """
+
+    def __init__(self, max_pending_jobs: int = 8) -> None:
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="console-mirror-archiver"
+        )
+        self._lock = threading.Lock()
+        self._handles: List[ArchiveHandle] = []
+        self._pending_slots = threading.BoundedSemaphore(max_pending_jobs)
+
+    def submit(self, job: ArchiveJob) -> ArchiveHandle:
+        """Queue ``job`` without blocking; raise if capacity is exhausted."""
+        if not self._pending_slots.acquire(blocking=False):
+            raise MirrorError(
+                "archive_queue_full",
+                "Archive queue is full; source logs were preserved",
+            )
+        cancel_event = threading.Event()
+        try:
+            future = self._executor.submit(self._archive, job, cancel_event)
+        except Exception:
+            self._pending_slots.release()
+            raise
+        handle = ArchiveHandle(future, cancel_event)
+        with self._lock:
+            self._handles.append(handle)
+        future.add_done_callback(lambda _: self._discard(handle))
+        return handle
+
+    def _discard(self, handle: ArchiveHandle) -> None:
+        with self._lock:
+            if handle in self._handles:
+                self._handles.remove(handle)
+        self._pending_slots.release()
+
+    @staticmethod
+    def _archive(job: ArchiveJob, cancel_event: threading.Event) -> ArchiveResult:
+        # Search for all part files and open
+        line_dir = os.path.dirname(job.recording_prefix)
+        prefix_name = os.path.basename(job.recording_prefix)
+        # Eg: <prefix>-part0001.log
+        pattern = re.compile(r"^{}-part([0-9]{{4}})\.log$".format(re.escape(prefix_name)))
+        parts: List[Tuple[int, str]] = []
+        for entry in os.scandir(line_dir):
+            match = pattern.fullmatch(entry.name)
+            if match and entry.is_file(follow_symlinks=False):
+                parts.append((int(match.group(1)), entry.path))
+        parts.sort()
+        if not parts or [number for number, _ in parts] != list(range(1, len(parts) + 1)):
+            raise MirrorError("archive_failed", "Recording parts are missing or non-contiguous")
+        for _, path in parts:
+            with open(path, "rb"):
+                pass
+        
+        # Create a temporary archive file and write the parts into it
+        temporary_path = job.archive_path + ".tmp"
+        flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = -1
+        try:
+             # Create file
+            if cancel_event.is_set():
+                raise ArchiveCancelled()
+            fd = os.open(temporary_path, flags, 0o600)
+            os.fchmod(fd, 0o600)
+            if os.geteuid() == 0:
+                os.fchown(fd, 0, 0)
+
+            # Write parts
+            with os.fdopen(fd, "w+b") as archive_file:
+                fd = -1
+                with zipfile.ZipFile(archive_file, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+                    for _, source in parts:
+                        if cancel_event.is_set():
+                            raise ArchiveCancelled()
+                        archive.write(source, arcname=os.path.basename(source))
+                        
+            # Validate the archive by checking for any bad files and ensuring the number of files matches
+            if cancel_event.is_set():
+                raise ArchiveCancelled()
+            with zipfile.ZipFile(temporary_path, "r") as archive:
+                if archive.testzip() is not None or len(archive.infolist()) != len(parts):
+                    raise MirrorError("archive_failed", "ZIP validation failed")
+            os.replace(temporary_path, job.archive_path)
+
+            # Delete the source part files after successful archiving
+            if cancel_event.is_set():
+                raise ArchiveCancelled()
+            undeleted = []
+            for _, source in parts:
+                try:
+                    os.unlink(source)
+                except OSError:
+                    undeleted.append(source)
+
+            return ArchiveResult(job.archive_path, tuple(undeleted))
+        except ArchiveCancelled:
+            raise MirrorError("archive_cancelled", "Archive packaging was cancelled; source logs were preserved")
+        except MirrorError:
+            raise
+        except Exception as error:
+            raise MirrorError("archive_failed", "Archive packaging failed: {}".format(error))
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            try:
+                os.unlink(temporary_path)
+            except OSError as error:
+                if error.errno != errno.ENOENT:
+                    log.warning("Failed to remove temporary archive %s: %s", temporary_path, error)
+
+    def shutdown(self, timeout: float = 5.0) -> None:
+        """Wait boundedly, request cancellation, and stop accepting new jobs."""
+        with self._lock:
+            handles = list(self._handles)
+        if handles:
+            concurrent.futures.wait([handle.future for handle in handles], timeout=timeout)
+        for handle in handles:
+            if not handle.future.done():
+                handle.cancel()
+        self._executor.shutdown(wait=False)
+
+
+class MirrorManager:
+    """Thread-safe per-line mirror state machine."""
+
+    def __init__(
+        self,
+        line: str,
+        state_table: Any,
+        base_dir: str = MIRROR_BASE_DIR,
+        writer_factory: Callable[..., RecordingWriter] = RecordingWriter,
+        archiver: Optional[RecordingArchiver] = None,
+        writer_queue_size: int = 4096,
+    ) -> None:
+        self.line = validate_line(line)
+        self.state_table = state_table
+        self.base_dir = base_dir
+        self.writer_factory = writer_factory
+        self.archiver = archiver or RecordingArchiver()
+        self.writer_queue_size = writer_queue_size
+        self.state = "idle"
+        self.direction: Optional[str] = None
+        self.start_time: Optional[float] = None
+        self.timeout_text: Optional[str] = None
+        self.timeout_seconds: Optional[int] = None
+        self.deadline: Optional[float] = None
+        self.file_path: Optional[str] = None
+        self.writer: Optional[RecordingWriter] = None
+        self.timer: Optional[threading.Timer] = None
+        self.writer_drop_count = 0
+        self._owner_pid: Optional[int] = None
+        self._started_by: Optional[str] = None
+        self._lock = threading.RLock()
+        self._write_idle_state()
+
+    def _state_set(self, values: List[Tuple[str, str]]) -> None:
+        try:
+            self.state_table.set(self.line, values)
+        except Exception as error:
+            log.error("[%s] Failed to update mirror STATE_DB: %s", self.line, error)
+
+    def _state_delete_fields(self) -> None:
+        for field in ("owner_pid", "started_by", "start_time", "timeout", "file_path", "direction"):
+            try:
+                self.state_table.hdel(self.line, field)
+            except Exception as error:
+                log.error("[%s] Failed to clear mirror STATE_DB field %s: %s", self.line, field, error)
+
+    def _write_idle_state(self) -> None:
+        self._state_set([("state", "idle")])
+        self._state_delete_fields()
+
+    def _write_active_state(self) -> None:
+        values = [
+            ("state", self.state),
+            ("owner_pid", str(self._owner_pid)),
+            ("started_by", str(self._started_by)),
+            ("start_time", str(int(self.start_time))),
+            ("timeout", str(self.timeout_seconds)),
+            ("file_path", str(self.file_path)),
+            ("direction", str(self.direction)),
+        ]
+        self._state_set(values)
+
+    def start(self, options: Dict[str, Any]) -> Dict[str, Any]:
+        direction = options.get("direction", "both")
+        if not isinstance(direction, str) or direction not in VALID_DIRECTIONS:
+            raise MirrorError("invalid_direction", "Direction must be rx, tx, or both")
+        timeout_text, timeout_seconds = parse_duration(options.get("timeout", DEFAULT_TIMEOUT))
+        max_file_size = options.get("max_file_size", DEFAULT_MAX_FILE_SIZE_MB)
+        if isinstance(max_file_size, bool) or not isinstance(max_file_size, int) or max_file_size <= 0:
+            raise MirrorError("invalid_max_file_size", "max_file_size must be a positive integer in MB")
+
+        with self._lock:
+            if self.state != "idle":
+                raise MirrorError(
+                    "mirror_already_active",
+                    "Line {} already has an active mirror session".format(self.line),
+                )
+            try:
+                writer = self.writer_factory(
+                    line=self.line,
+                    direction=direction,
+                    timeout_text=timeout_text,
+                    max_file_size_mb=max_file_size,
+                    base_dir=self.base_dir,
+                    queue_size=self.writer_queue_size,
+                    on_fatal=self._on_writer_fatal,
+                    on_rotate=self._on_rotate,
+                )
+            except MirrorError:
+                raise
+            except Exception as error:
+                raise MirrorError("file_open_failed", "Failed to open recording file: {}".format(error))
+
+            timer = threading.Timer(
+                timeout_seconds, lambda: self._on_timeout(timer)
+            )
+            timer.daemon = True
+            self.writer = writer
+            self.direction = direction
+            self.start_time = writer.start_timestamp
+            self.timeout_text = timeout_text
+            self.timeout_seconds = timeout_seconds
+            self.deadline = time.monotonic() + timeout_seconds
+            self.file_path = writer.file_path
+            self._owner_pid = int(options.get("owner_pid", 0))
+            self._started_by = str(options.get("started_by", "root"))
+            self.writer_drop_count = 0
+            self.timer = timer
+            self.state = "active"
+            try:
+                timer.start()
+            except Exception as error:
+                self.state = "idle"
+                self.timer = None
+                self.writer = None
+                writer.close()
+                self._clear_runtime_fields()
+                self._write_idle_state()
+                raise MirrorError("timer_setup_failed", "Failed to arm mirror timeout: {}".format(error))
+            writer.submit_event({"event": "start"})
+            self._write_active_state()
+            return {
+                "status": "ok",
+                "file_path": self.file_path,
+                "timeout": timeout_text,
+                "remaining": timeout_text,
+            }
+
+    def _clear_runtime_fields(self) -> None:
+        self.direction = None
+        self.start_time = None
+        self.timeout_text = None
+        self.timeout_seconds = None
+        self.deadline = None
+        self.file_path = None
+        self._owner_pid = None
+        self._started_by = None
+        self.writer_drop_count = 0
+
+    def submit(self, direction: str, payload: bytes) -> None:
+        if direction not in ("rx", "tx") or not payload:
+            return
+        if not self._lock.acquire(blocking=False):
+            return
+        try:
+            if self.state != "active" or self.writer is None:
+                return
+            if self.direction not in (direction, "both"):
+                return
+            writer = self.writer
+            if self.writer_drop_count:
+                count = self.writer_drop_count
+                if not writer.submit_event(
+                    {"event": "drop", "reason": "writer_queue_full", "count": count},
+                    nonblocking=True,
+                ):
+                    self.writer_drop_count += 1
+                    return
+                self.writer_drop_count = 0
+            if not writer.submit_data(direction, payload):
+                self.writer_drop_count += 1
+        finally:
+            self._lock.release()
+
+    def update_timeout(self, timeout_value: Any) -> Dict[str, Any]:
+        timeout_text, timeout_seconds = parse_duration(timeout_value)
+        replacement = threading.Timer(
+            timeout_seconds, lambda: self._on_timeout(replacement)
+        )
+        replacement.daemon = True
+        with self._lock:
+            if self.state != "active" or self.writer is None:
+                raise MirrorError("mirror_not_active", "Line {} has no active mirror session".format(self.line))
+            elapsed_ms = max(0, int((time.time() - self.start_time) * 1000))
+            if elapsed_ms + timeout_seconds * 1000 > MAX_DELTA_MS:
+                raise MirrorError("invalid_timeout", "Elapsed time plus timeout exceeds the SCM-Text delta range")
+            previous_timer = self.timer
+            try:
+                replacement.start()
+            except Exception as error:
+                raise MirrorError("timer_setup_failed", "Failed to reset mirror timeout: {}".format(error))
+            self.timer = replacement
+            self.timeout_text = timeout_text
+            self.timeout_seconds = timeout_seconds
+            self.deadline = time.monotonic() + timeout_seconds
+            self.writer.update_timeout(timeout_text)
+            if previous_timer:
+                previous_timer.cancel()
+            self.writer.submit_event({"event": "timeout_update", "timeout": timeout_text})
+            self._write_active_state()
+            return {"status": "ok", "timeout": timeout_text, "remaining": timeout_text}
+
+    def stop(
+        self,
+        reason: str = "manual",
+        archive: bool = False,
+        expected_timer: Optional[threading.Timer] = None,
+    ) -> Dict[str, Any]:
+        with self._lock:
+            if self.state != "active" or self.writer is None:
+                raise MirrorError("mirror_not_active", "Line {} has no active mirror session".format(self.line))
+            if expected_timer is not None and self.timer is not expected_timer:
+                raise MirrorError("stale_timeout", "Superseded mirror timeout ignored")
+            self.state = "stopping"
+            timer = self.timer
+            self.timer = None
+            if timer:
+                timer.cancel()
+            writer = self.writer
+            direction = self.direction
+            start_timestamp = self.start_time
+            recording_prefix = writer.recording_prefix
+            archive_path = recording_prefix + ".zip"
+            self._write_active_state()
+            writer.submit_event({"event": "stop", "reason": reason})
+
+        writer.close()
+
+        with self._lock:
+            if self.writer is writer:
+                self.writer = None
+            self.state = "idle"
+            self._clear_runtime_fields()
+            self._write_idle_state()
+
+        if not archive:
+            return {
+                "status": "ok",
+                "message": "Mirror stopped; recording files retained",
+                "recording_prefix": recording_prefix,
+            }
+        job = ArchiveJob(
+            line=self.line,
+            direction=direction,
+            start_timestamp=start_timestamp,
+            recording_prefix=recording_prefix,
+            archive_path=archive_path,
+            stop_reason=reason,
+        )
+        try:
+            handle = self.archiver.submit(job)
+        except MirrorError:
+            raise
+        except Exception as error:
+            raise MirrorError(
+                "archive_failed",
+                "Could not submit archive job: {}; source logs were preserved".format(error),
+            )
+        return {
+            "status": "packaging",
+            "message": "Mirror stopped; packaging recording",
+            "archive_path": archive_path,
+            "archive_handle": handle,
+        }
+
+    def status(self) -> Dict[str, Any]:
+        with self._lock:
+            response: Dict[str, Any] = {"status": "ok", "state": self.state, "line": self.line}
+            if self.state in ("active", "stopping"):
+                remaining = 0 if self.deadline is None else self.deadline - time.monotonic()
+                response.update(
+                    {
+                        "start_time": _rfc3339_ms(self.start_time),
+                        "direction": self.direction,
+                        "timeout": self.timeout_text,
+                        "remaining": format_remaining(remaining),
+                        "file_path": self.file_path,
+                    }
+                )
+            return response
+
+    def _on_timeout(self, fired_timer: threading.Timer) -> None:
+        try:
+            self.stop(reason="timeout", archive=True, expected_timer=fired_timer)
+        except MirrorError as error:
+            if error.code not in ("mirror_not_active", "stale_timeout"):
+                log.error("[%s] Automatic mirror stop failed: %s", self.line, error.message)
+
+    def _on_writer_fatal(self, writer: RecordingWriter, error: Exception) -> None:
+        log.error("[%s] Fatal mirror writer error: %s", self.line, error)
+        threading.Thread(
+            target=self._stop_after_writer_error,
+            args=(writer,),
+            name="console-mirror-writer-error-{}".format(self.line),
+            daemon=True,
+        ).start()
+
+    def _stop_after_writer_error(self, failed_writer: RecordingWriter) -> None:
+        with self._lock:
+            if self.state != "active" or self.writer is not failed_writer:
+                return
+        try:
+            self.stop(reason="writer_error", archive=False)
+        except MirrorError:
+            pass
+
+    def _on_rotate(self, file_path: str) -> None:
+        with self._lock:
+            if self.state != "active":
+                return
+            self.file_path = file_path
+            self._write_active_state()
+
+    def shutdown(self, archive_timeout: float = 5.0) -> None:
+        with self._lock:
+            active = self.state == "active"
+        if active:
+            try:
+                self.stop(reason="proxy_shutdown", archive=False)
+            except MirrorError:
+                pass
+        self.archiver.shutdown(timeout=archive_timeout)
+        with self._lock:
+            self.state = "idle"
+            self._write_idle_state()

--- a/scripts/console-monitor
+++ b/scripts/console-monitor
@@ -37,6 +37,7 @@ from swsscommon.swsscommon import (
     Table,
     ConfigDBConnector,
 )
+from host_modules.console_mirror import MirrorControlServer, MirrorManager
 
 # ============================================================
 # Logging Configuration
@@ -569,6 +570,9 @@ class ProxyService:
         # Proxy resources
         self.state_db: Optional[DBConnector] = None
         self.state_table: Optional[Table] = None
+        self.mirror_state_table: Optional[Table] = None
+        self.mirror_manager: Optional[MirrorManager] = None
+        self.mirror_control_server: Optional[MirrorControlServer] = None
         self.ser_fd: int = -1
         self.ptm_fd: int = -1
         self.filter: Optional[FrameFilter] = None
@@ -698,6 +702,14 @@ class ProxyService:
                 on_user_data=self._on_user_data_received,
             )
 
+            # Initialize mirror manager and control server
+            self.mirror_state_table = Table(self.state_db, "CONSOLE_MIRROR")
+            self.mirror_manager = MirrorManager(self.link_id, self.mirror_state_table)
+            self.mirror_control_server = MirrorControlServer(
+                self.link_id, self.mirror_manager
+            )
+            self.mirror_control_server.start()
+
             self._last_heartbeat_time = time.monotonic()
             self._last_data_activity = time.monotonic()
 
@@ -706,6 +718,7 @@ class ProxyService:
 
         except Exception as e:
             log.error(f"[{self.link_id}] Failed to initialize: {e}")
+            self._cleanup()
             return False
 
     def _run_loop(self) -> None:
@@ -787,7 +800,9 @@ class ProxyService:
         try:
             data = os.read(self.ptm_fd, 4096)
             if data:
-                os.write(self.ser_fd, data)
+                written = os.write(self.ser_fd, data)
+                if written and self.mirror_manager:
+                    self.mirror_manager.submit("tx", data[:written])
         except (BlockingIOError, OSError):
             pass
 
@@ -804,7 +819,9 @@ class ProxyService:
         """User data callback"""
         if self.ptm_fd >= 0:
             try:
-                os.write(self.ptm_fd, data)
+                written = os.write(self.ptm_fd, data)
+                if written and self.mirror_manager:
+                    self.mirror_manager.submit("rx", data[:written])
             except OSError:
                 pass
 
@@ -855,6 +872,15 @@ class ProxyService:
 
     def _cleanup(self) -> None:
         """Cleanup all resources"""
+        # Stop accepting new control requests before closing the current
+        # writer.  Shutdown is bounded and leaves any unfinished source logs.
+        if self.mirror_control_server:
+            self.mirror_control_server.stop()
+            self.mirror_control_server = None
+        if self.mirror_manager:
+            self.mirror_manager.shutdown()
+            self.mirror_manager = None
+
         # Cleanup STATE_DB
         self._cleanup_state()
 

--- a/tests/console_monitor/console_mirror_test.py
+++ b/tests/console_monitor/console_mirror_test.py
@@ -85,7 +85,7 @@ class TestRecordingWriter(TestCase):
         self.assertTrue(
             writer.submit_event({"event": "stop", "reason": "manual", "text": "你好"})
         )
-        writer.close()
+        self.assertTrue(writer.close())
 
         self.assertFalse(writer.submit_data("rx", b"after close"))
         self.assertFalse(writer.submit_event({"event": "after-close"}))
@@ -337,7 +337,21 @@ class TestRecordingWriter(TestCase):
         writer.shutdown_timeout = 1
         writer._closing = threading.Event()
         writer._thread = threading.current_thread()
-        writer.close()
+        self.assertFalse(writer.close())
+        self.assertTrue(writer._closing.is_set())
+
+    def test_close_reports_incomplete_shutdown_when_writer_remains_alive(self):
+        writer = object.__new__(console_mirror.RecordingWriter)
+        writer._lock = threading.Lock()
+        writer._accepting = True
+        writer._closing = threading.Event()
+        writer.shutdown_timeout = 1
+        writer._thread = mock.Mock()
+        writer._thread.is_alive.return_value = True
+
+        self.assertFalse(writer.close())
+
+        writer._thread.join.assert_called_once_with(1.5)
         self.assertTrue(writer._closing.is_set())
 
 
@@ -656,6 +670,7 @@ class TestMirrorManager(TestCase):
         writer.recording_prefix = "/recordings/line1/session"
         writer.submit_event.return_value = True
         writer.submit_data.return_value = True
+        writer.close.return_value = True
         return writer
 
     def make_manager(self, **overrides):
@@ -1050,6 +1065,20 @@ class TestMirrorManager(TestCase):
         )
         self.assertIs(response["archive_handle"], handle)
         self.assertEqual(manager.state, "idle")
+
+    def test_stop_skips_archive_when_writer_shutdown_is_incomplete(self):
+        manager, _ = self.start_manager()
+        self.writer.close.return_value = False
+
+        error = self.assert_error(
+            "writer_shutdown_incomplete", lambda: manager.stop(archive=True)
+        )
+
+        self.assertIn("archive was skipped", error.message)
+        self.assertIn("source logs were preserved", error.message)
+        self.archiver.submit.assert_not_called()
+        self.assertEqual(manager.state, "idle")
+        self.assertIsNone(manager.writer)
 
     def test_stop_preserves_archive_errors_and_wraps_submission_failures(self):
         expected = console_mirror.MirrorError("archive_queue_full", "full")

--- a/tests/console_monitor/console_mirror_test.py
+++ b/tests/console_monitor/console_mirror_test.py
@@ -1,0 +1,539 @@
+"""Unit tests for the console mirror recording writer and archiver."""
+
+import concurrent.futures
+import errno
+import os
+import queue
+import stat
+import tempfile
+import threading
+import time
+import zipfile
+from unittest import TestCase, mock
+
+from host_modules import console_mirror
+
+
+class TestFormatting(TestCase):
+    def test_duration_validation_and_remaining_format(self):
+        self.assertEqual(console_mirror.parse_duration("2h"), ("2h", 7200))
+        self.assertEqual(console_mirror.format_remaining(44100), "12h15m")
+        self.assertEqual(console_mirror.format_remaining(-0.1), "0s")
+        for invalid in ("0s", "-1h", "1.5h", "forever", "1h30m", 123, "10x", "999999d"):
+            with self.assertRaises(
+                console_mirror.MirrorError,
+                msg="{} should be invalid".format(invalid),
+            ):
+                console_mirror.parse_duration(invalid)
+
+    def test_printable_escape_is_utf8_readable_and_terminal_safe(self):
+        payload = "SONiC é你好😀".encode("utf-8") + b"\n\r\t\\\x1b[31m\x00\xff\xfe\x80\x9f"
+        self.assertEqual(
+            console_mirror.printable_escape(payload),
+            r"SONiC é你好😀\n\r\t\\\x1b[31m\x00\xff\xfe\x80\x9f",
+        )
+        self.assertEqual(console_mirror.printable_escape("\u200b".encode("utf-8")), r"\xe2\x80\x8b")
+
+    def test_secure_directory_rejects_symbolic_link(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            target = os.path.join(tempdir, "target")
+            link = os.path.join(tempdir, "link")
+            os.mkdir(target)
+            os.symlink(target, link)
+            with self.assertRaises(console_mirror.MirrorError) as caught:
+                console_mirror._ensure_secure_directory(link)
+        self.assertEqual(caught.exception.code, "unsafe_recording_path")
+
+
+class TestRecordingWriter(TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.writers = []
+
+    def tearDown(self):
+        for writer in self.writers:
+            writer.close()
+        self.tempdir.cleanup()
+
+    def create_writer(self, **overrides):
+        options = {
+            "line": "1",
+            "direction": "both",
+            "timeout_text": "24h",
+            "max_file_size_mb": 64,
+            "base_dir": self.tempdir.name,
+            "queue_size": 8,
+            "shutdown_timeout": 1,
+        }
+        options.update(overrides)
+        writer = console_mirror.RecordingWriter(**options)
+        self.writers.append(writer)
+        return writer
+
+    def test_headers_records_permissions_and_close(self):
+        writer = self.create_writer()
+        path = writer.file_path
+        self.assertTrue(writer.submit_data("rx", b"Booting SONiC\n"))
+        self.assertTrue(writer.submit_data("tx", bytearray(b"\x1b[2Jshow\n")))
+        self.assertTrue(writer.submit_event({"event": "stop", "reason": "manual", "text": "你好"}))
+        writer.close()
+
+        self.assertFalse(writer.submit_data("rx", b"after close"))
+        self.assertFalse(writer.submit_event({"event": "after-close"}))
+        self.assertEqual(stat.S_IMODE(os.stat(self.tempdir.name).st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE(os.stat(os.path.dirname(path)).st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), 0o600)
+        with open(path, encoding="utf-8") as recording:
+            lines = recording.read().splitlines()
+        self.assertEqual(lines[0], "# SONIC_CONSOLE_MIRROR_TEXT version=1")
+        self.assertIn("line=1 direction=both", lines[1])
+        self.assertRegex(lines[3], r"^[^ ]+ \+[0-9]{12}ms 00000001 RX 00000014 Booting SONiC\\n$")
+        self.assertIn(r"TX 00000009 \x1b[2Jshow\n", lines[4])
+        self.assertTrue(lines[5].endswith(
+            'EVENT 00000050 {"event":"stop","reason":"manual","text":"你好"}'
+        ))
+
+    def test_rejects_invalid_line_and_direction(self):
+        with self.assertRaises(console_mirror.MirrorError) as caught:
+            self.create_writer(line="tty1")
+        self.assertEqual(caught.exception.code, "invalid_line")
+
+        with self.assertRaises(console_mirror.MirrorError) as caught:
+            self.create_writer(direction="sideways")
+        self.assertEqual(caught.exception.code, "invalid_direction")
+
+    def test_root_owned_directories_and_recording_file(self):
+        with mock.patch.object(console_mirror.os, "geteuid", return_value=0), \
+                mock.patch.object(console_mirror.os, "chown") as chown, \
+                mock.patch.object(console_mirror.os, "fchown") as fchown:
+            writer = self.create_writer(line="5", direction="tx")
+            writer.close()
+        self.assertEqual(chown.call_count, 2)
+        fchown.assert_called_once()
+
+    def test_rotation_updates_header_and_calls_callback(self):
+        on_rotate = mock.Mock()
+        writer = self.create_writer(line="2", direction="rx", on_rotate=on_rotate)
+        writer.max_file_size = 700
+        self.assertTrue(writer.submit_data("rx", b"a" * 200))
+        writer.update_timeout("30m")
+        self.assertTrue(writer.submit_data("rx", b"b" * 300))
+        writer.close()
+
+        parts = sorted(os.listdir(os.path.join(self.tempdir.name, "line2")))
+        self.assertEqual(len(parts), 2)
+        first_path = os.path.join(self.tempdir.name, "line2", parts[0])
+        second_path = os.path.join(self.tempdir.name, "line2", parts[1])
+        with open(first_path, encoding="utf-8") as first:
+            self.assertIn('{"event":"rotate","next_part":"part0002"}', first.read())
+        with open(second_path, encoding="utf-8") as second:
+            second_text = second.read()
+        self.assertIn("timeout=30m part=part0002", second_text)
+        self.assertIn("00000003 RX", second_text)
+        on_rotate.assert_called_once_with(second_path)
+
+    def test_rotation_omits_event_when_current_part_has_no_space(self):
+        writer = self.create_writer(line="3", direction="rx")
+        self.assertTrue(writer.submit_data("rx", b"first"))
+        writer._queue.join()
+        writer.max_file_size = writer._file_size
+        self.assertTrue(writer.submit_data("rx", b"second"))
+        writer.close()
+
+        part_paths = sorted(
+            os.path.join(writer.line_dir, name) for name in os.listdir(writer.line_dir)
+        )
+        self.assertEqual(len(part_paths), 2)
+        with open(part_paths[0], encoding="utf-8") as first:
+            self.assertNotIn('"event":"rotate"', first.read())
+        with open(part_paths[1], encoding="utf-8") as second:
+            self.assertIn("00000002 RX", second.read())
+
+    def test_rotation_rejects_excessive_part_number(self):
+        writer = self.create_writer(line="6", direction="tx")
+        writer.part_number = console_mirror.MAX_PART_NUMBER
+        with self.assertRaises(console_mirror.MirrorError) as caught:
+            writer._rotate()
+        self.assertEqual(caught.exception.code, "part_limit_exceeded")
+
+    def test_render_record_clamps_delta_and_handles_event_payload(self):
+        writer = self.create_writer()
+        before_start = console_mirror.WriterRecord("RX", b"\x00", writer.start_timestamp - 1)
+        far_future = console_mirror.WriterRecord(
+            "EVENT",
+            b'{"event":"future"}',
+            writer.start_timestamp + (console_mirror.MAX_DELTA_MS / 1000) + 10,
+            is_event=True,
+        )
+        self.assertIn(b"+000000000000ms", writer._render_record(before_start, 7))
+        rendered = writer._render_record(far_future, 8)
+        self.assertIn(b"+999999999999ms", rendered)
+        self.assertIn(b'00000008 EVENT 00000018 {"event":"future"}', rendered)
+
+    def test_submit_rejects_busy_lock_queue_limit_and_full_priority_queue(self):
+        writer = object.__new__(console_mirror.RecordingWriter)
+        writer._lock = mock.Mock()
+        writer._lock.acquire.return_value = False
+        self.assertFalse(writer._submit(mock.sentinel.record, priority=False, nonblocking=True))
+        writer._lock.release.assert_not_called()
+
+        writer._lock = threading.Lock()
+        writer._accepting = True
+        writer.queue_size = 0
+        writer._queue = queue.Queue(maxsize=1)
+        self.assertFalse(writer._submit(mock.sentinel.record, priority=False, nonblocking=False))
+        writer._queue.put_nowait(mock.sentinel.queued)
+        self.assertFalse(writer._submit(mock.sentinel.record, priority=True, nonblocking=False))
+
+    def test_prepare_paths_retries_collision_and_reports_exhaustion(self):
+        writer = object.__new__(console_mirror.RecordingWriter)
+        writer.base_dir = self.tempdir.name
+        writer.line_dir = os.path.join(self.tempdir.name, "line4")
+        writer.line = "4"
+        writer.direction = "both"
+        writer._open_part = mock.Mock(side_effect=[FileExistsError(), None])
+        with mock.patch.object(console_mirror, "_ensure_secure_directory"), \
+                mock.patch.object(console_mirror.time, "sleep") as sleep:
+            writer._prepare_paths_and_open()
+        self.assertEqual(writer._open_part.call_count, 2)
+        sleep.assert_called_once_with(0.000001)
+
+        writer._open_part = mock.Mock(side_effect=FileExistsError("collision"))
+        with mock.patch.object(console_mirror, "_ensure_secure_directory"), \
+                mock.patch.object(console_mirror.time, "sleep"), \
+                self.assertRaises(console_mirror.MirrorError) as caught:
+            writer._prepare_paths_and_open()
+        self.assertEqual(caught.exception.code, "file_open_failed")
+        self.assertIsInstance(caught.exception.__cause__, FileExistsError)
+        self.assertEqual(writer._open_part.call_count, 100)
+
+    def test_open_part_cleans_up_descriptor_when_setup_fails(self):
+        writer = object.__new__(console_mirror.RecordingWriter)
+        writer.recording_prefix = os.path.join(self.tempdir.name, "recording")
+        with mock.patch.object(console_mirror.os, "open", return_value=42), \
+                mock.patch.object(console_mirror.os, "fchmod", side_effect=OSError("chmod")), \
+                mock.patch.object(console_mirror.os, "close") as close, \
+                mock.patch.object(console_mirror.os, "unlink") as unlink, \
+                self.assertRaisesRegex(OSError, "chmod"):
+            writer._open_part(1)
+        close.assert_called_once_with(42)
+        unlink.assert_called_once_with(writer.recording_prefix + "-part0001.log")
+
+    def test_open_part_cleans_up_file_object_even_if_close_and_unlink_fail(self):
+        broken_file = mock.Mock()
+        broken_file.write.side_effect = OSError("write")
+        broken_file.close.side_effect = OSError("close")
+        writer = object.__new__(console_mirror.RecordingWriter)
+        writer.recording_prefix = os.path.join(self.tempdir.name, "recording")
+        writer.line = "1"
+        writer.direction = "rx"
+        writer.start_timestamp = 0
+        writer.timeout_text = "1h"
+        with mock.patch.object(console_mirror.os, "open", return_value=42), \
+                mock.patch.object(console_mirror.os, "fchmod"), \
+                mock.patch.object(console_mirror.os, "geteuid", return_value=1000), \
+                mock.patch.object(console_mirror.os, "fdopen", return_value=broken_file), \
+                mock.patch.object(console_mirror.os, "unlink", side_effect=OSError("unlink")), \
+                self.assertRaisesRegex(OSError, "write"):
+            writer._open_part(1, exclusive=False)
+        broken_file.close.assert_called_once_with()
+
+    def test_run_handles_empty_poll_shutdown_deadline_and_write_failure(self):
+        class EmptyOnceQueue:
+            def __init__(self, closing):
+                self.closing = closing
+
+            def empty(self):
+                return True
+
+            def get(self, timeout):
+                self.closing.set()
+                raise queue.Empty()
+
+        writer = object.__new__(console_mirror.RecordingWriter)
+        writer._closing = threading.Event()
+        writer._queue = EmptyOnceQueue(writer._closing)
+        writer._file = mock.Mock()
+        recording = writer._file
+        writer._run()
+        recording.flush.assert_called_once_with()
+        recording.close.assert_called_once_with()
+        self.assertIsNone(writer._file)
+
+        writer = object.__new__(console_mirror.RecordingWriter)
+        writer._closing = threading.Event()
+        writer._closing.set()
+        writer._queue = mock.Mock()
+        writer._queue.empty.return_value = False
+        writer._shutdown_deadline = 0
+        writer._file = mock.Mock()
+        writer._run()
+        writer._queue.get.assert_not_called()
+
+        writer = object.__new__(console_mirror.RecordingWriter)
+        writer._closing = threading.Event()
+        writer._closing.set()
+        writer._shutdown_deadline = None
+        writer._queue = mock.Mock()
+        writer._queue.empty.side_effect = [False]
+        writer._queue.get.return_value = mock.sentinel.record
+        writer._write_record = mock.Mock(side_effect=OSError("disk full"))
+        writer._file = mock.Mock()
+        writer._file.close.side_effect = OSError("close too")
+        writer._lock = threading.Lock()
+        writer._accepting = True
+        writer._fatal_reported = False
+        writer.on_fatal = mock.Mock()
+        writer._run()
+        writer._queue.task_done.assert_called_once_with()
+        writer.on_fatal.assert_called_once()
+        self.assertEqual(str(writer.on_fatal.call_args.args[1]), "disk full")
+
+    def test_report_fatal_is_idempotent_and_close_from_worker_does_not_join(self):
+        writer = object.__new__(console_mirror.RecordingWriter)
+        writer._lock = threading.Lock()
+        writer._accepting = True
+        writer._fatal_reported = False
+        writer.on_fatal = None
+        writer._report_fatal(OSError("first"))
+        writer._report_fatal(OSError("second"))
+        self.assertFalse(writer._accepting)
+
+        writer.shutdown_timeout = 1
+        writer._closing = threading.Event()
+        writer._thread = threading.current_thread()
+        writer.close()
+        self.assertTrue(writer._closing.is_set())
+
+
+class TestRecordingArchiver(TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.archivers = []
+
+    def tearDown(self):
+        for archiver in self.archivers:
+            archiver.shutdown(timeout=1)
+        self.tempdir.cleanup()
+
+    def create_archiver(self, **options):
+        archiver = console_mirror.RecordingArchiver(**options)
+        self.archivers.append(archiver)
+        return archiver
+
+    def make_job(self, part_numbers=(1,), prefix_name="console-mirror-line1-both-session"):
+        line_dir = os.path.join(self.tempdir.name, "line1")
+        os.makedirs(line_dir, exist_ok=True)
+        prefix = os.path.join(line_dir, prefix_name)
+        sources = []
+        for number in part_numbers:
+            source = "{}-part{:04d}.log".format(prefix, number)
+            with open(source, "wb") as stream:
+                stream.write("part{}".format(number).encode("ascii"))
+            sources.append(source)
+        job = console_mirror.ArchiveJob(
+            "1", "both", time.time(), prefix, prefix + ".zip", "manual"
+        )
+        return job, sources
+
+    def assert_mirror_error(self, code, operation):
+        with self.assertRaises(console_mirror.MirrorError) as caught:
+            operation()
+        self.assertEqual(caught.exception.code, code)
+        return caught.exception
+
+    def test_archive_is_valid_and_sources_are_removed_after_success(self):
+        job, sources = self.make_job((1, 2))
+        os.mkdir(job.recording_prefix + "-part0003.log")
+        with open(job.recording_prefix + "-notes.txt", "w") as stream:
+            stream.write("ignore me")
+
+        archiver = self.create_archiver()
+        result = archiver.submit(job).result(timeout=3)
+
+        self.assertEqual(result, console_mirror.ArchiveResult(job.archive_path))
+        self.assertTrue(all(not os.path.exists(source) for source in sources))
+        self.assertEqual(stat.S_IMODE(os.stat(result.archive_path).st_mode), 0o600)
+        with zipfile.ZipFile(result.archive_path) as archive:
+            self.assertIsNone(archive.testzip())
+            self.assertEqual(archive.namelist(), [os.path.basename(path) for path in sources])
+
+    def test_archive_file_is_root_owned_when_running_as_root(self):
+        job, _ = self.make_job((1,), "root-owned")
+        with mock.patch.object(console_mirror.os, "geteuid", return_value=0), \
+                mock.patch.object(console_mirror.os, "fchown") as fchown:
+            result = console_mirror.RecordingArchiver._archive(job, threading.Event())
+        self.assertEqual(result.archive_path, job.archive_path)
+        fchown.assert_called_once()
+
+    def test_missing_and_noncontiguous_parts_are_rejected(self):
+        for part_numbers in ((), (2,), (1, 3)):
+            job, sources = self.make_job(part_numbers, "session-{}".format(len(part_numbers)))
+            self.assert_mirror_error(
+                "archive_failed",
+                lambda job=job: console_mirror.RecordingArchiver._archive(job, threading.Event()),
+            )
+            self.assertTrue(all(os.path.exists(source) for source in sources))
+            self.assertFalse(os.path.exists(job.archive_path))
+
+    def test_archive_queue_is_bounded_and_slot_is_released(self):
+        gate = threading.Event()
+        archiver = self.create_archiver(max_pending_jobs=1)
+        archiver._archive = lambda job, cancel: (
+            gate.wait(2) and console_mirror.ArchiveResult(job.archive_path)
+        )
+        job, _ = self.make_job()
+        first = archiver.submit(job)
+        self.assert_mirror_error("archive_queue_full", lambda: archiver.submit(job))
+        gate.set()
+        self.assertEqual(first.result(timeout=2).archive_path, job.archive_path)
+
+        deadline = time.time() + 2
+        while archiver._handles and time.time() < deadline:
+            time.sleep(0.001)
+        second = archiver.submit(job)
+        self.assertEqual(second.result(timeout=2).archive_path, job.archive_path)
+
+    def test_submit_releases_slot_when_executor_rejects_job(self):
+        archiver = self.create_archiver(max_pending_jobs=1)
+        archiver._executor.submit = mock.Mock(side_effect=RuntimeError("shut down"))
+        job, _ = self.make_job()
+        with self.assertRaisesRegex(RuntimeError, "shut down"):
+            archiver.submit(job)
+        self.assertTrue(archiver._pending_slots.acquire(blocking=False))
+        archiver._pending_slots.release()
+
+    def test_discard_tolerates_handle_already_removed(self):
+        archiver = self.create_archiver(max_pending_jobs=1)
+        self.assertTrue(archiver._pending_slots.acquire(blocking=False))
+        future = concurrent.futures.Future()
+        future.set_result(console_mirror.ArchiveResult("archive.zip"))
+        handle = console_mirror.ArchiveHandle(future, threading.Event())
+        archiver._discard(handle)
+
+    def test_archive_handle_result_and_cancel_outcomes(self):
+        future = concurrent.futures.Future()
+        expected = console_mirror.ArchiveResult("archive.zip")
+        future.set_result(expected)
+        handle = console_mirror.ArchiveHandle(future, threading.Event())
+        self.assertEqual(handle.result(timeout=0), expected)
+        self.assertFalse(handle.cancel())
+        self.assertTrue(handle.cancel_event.is_set())
+
+        pending = concurrent.futures.Future()
+        pending_handle = console_mirror.ArchiveHandle(pending, threading.Event())
+        self.assertTrue(pending_handle.cancel())
+
+    def test_cancelled_at_each_archive_checkpoint_preserves_sources(self):
+        class SequencedEvent:
+            def __init__(self, values):
+                self.values = iter(values)
+
+            def is_set(self):
+                return next(self.values)
+
+        checkpoints = (
+            [True],
+            [False, True],
+            [False, False, True],
+            [False, False, False, True],
+        )
+        for index, sequence in enumerate(checkpoints):
+            job, sources = self.make_job((1,), "cancel-{}".format(index))
+            self.assert_mirror_error(
+                "archive_cancelled",
+                lambda job=job, sequence=sequence: console_mirror.RecordingArchiver._archive(
+                    job, SequencedEvent(sequence)
+                ),
+            )
+            self.assertTrue(os.path.exists(sources[0]))
+            self.assertFalse(os.path.exists(job.archive_path + ".tmp"))
+
+    def test_zip_validation_rejects_corruption_and_wrong_entry_count(self):
+        real_zip_file = console_mirror.zipfile.ZipFile
+        validation_results = (("bad-entry", [mock.sentinel.info]), (None, []))
+        for index, (bad_entry, infos) in enumerate(validation_results):
+            job, sources = self.make_job((1,), "invalid-zip-{}".format(index))
+            invalid_archive = mock.MagicMock()
+            invalid_archive.__enter__.return_value.testzip.return_value = bad_entry
+            invalid_archive.__enter__.return_value.infolist.return_value = infos
+
+            def zip_file(file, mode="r", *args, **kwargs):
+                if mode == "r":
+                    return invalid_archive
+                return real_zip_file(file, mode, *args, **kwargs)
+
+            with mock.patch.object(console_mirror.zipfile, "ZipFile", side_effect=zip_file):
+                self.assert_mirror_error(
+                    "archive_failed",
+                    lambda job=job: console_mirror.RecordingArchiver._archive(
+                        job, threading.Event()
+                    ),
+                )
+            self.assertTrue(os.path.exists(sources[0]))
+            self.assertFalse(os.path.exists(job.archive_path))
+            self.assertFalse(os.path.exists(job.archive_path + ".tmp"))
+
+    def test_archive_reports_undeleted_sources(self):
+        job, sources = self.make_job((1, 2))
+        real_unlink = os.unlink
+
+        def unlink(path):
+            if path == sources[0]:
+                raise OSError(errno.EACCES, "permission denied")
+            return real_unlink(path)
+
+        with mock.patch.object(console_mirror.os, "unlink", side_effect=unlink):
+            result = console_mirror.RecordingArchiver._archive(job, threading.Event())
+        self.assertEqual(result.undeleted_sources, (sources[0],))
+        self.assertTrue(os.path.exists(sources[0]))
+        self.assertFalse(os.path.exists(sources[1]))
+
+    def test_archive_wraps_creation_errors_and_closes_unwrapped_descriptor(self):
+        job, sources = self.make_job((1,), "open-failure")
+        with mock.patch.object(console_mirror.os, "open", side_effect=OSError("no space")):
+            error = self.assert_mirror_error(
+                "archive_failed",
+                lambda: console_mirror.RecordingArchiver._archive(job, threading.Event()),
+            )
+        self.assertIn("no space", error.message)
+        self.assertTrue(os.path.exists(sources[0]))
+
+        job, _ = self.make_job((1,), "fdopen-failure")
+        real_close = os.close
+        with mock.patch.object(console_mirror.os, "fdopen", side_effect=OSError("fdopen")), \
+                mock.patch.object(console_mirror.os, "close", wraps=real_close) as close:
+            self.assert_mirror_error(
+                "archive_failed",
+                lambda: console_mirror.RecordingArchiver._archive(job, threading.Event()),
+            )
+        close.assert_called_once()
+        self.assertFalse(os.path.exists(job.archive_path + ".tmp"))
+
+    def test_temporary_cleanup_failure_is_logged(self):
+        job, _ = self.make_job((1,), "cleanup-failure")
+        cleanup_error = OSError(errno.EACCES, "permission denied")
+        with mock.patch.object(console_mirror.os, "open", side_effect=OSError("create")), \
+                mock.patch.object(console_mirror.os, "unlink", side_effect=cleanup_error), \
+                mock.patch.object(console_mirror.log, "warning") as warning:
+            self.assert_mirror_error(
+                "archive_failed",
+                lambda: console_mirror.RecordingArchiver._archive(job, threading.Event()),
+            )
+        warning.assert_called_once_with(
+            "Failed to remove temporary archive %s: %s",
+            job.archive_path + ".tmp",
+            cleanup_error,
+        )
+
+    def test_shutdown_cancels_unfinished_handles(self):
+        archiver = object.__new__(console_mirror.RecordingArchiver)
+        archiver._lock = threading.Lock()
+        future = concurrent.futures.Future()
+        handle = console_mirror.ArchiveHandle(future, threading.Event())
+        archiver._handles = [handle]
+        archiver._executor = mock.Mock()
+        archiver.shutdown(timeout=0)
+        self.assertTrue(handle.cancel_event.is_set())
+        self.assertTrue(future.cancelled())
+        archiver._executor.shutdown.assert_called_once_with(wait=False)

--- a/tests/console_monitor/console_mirror_test.py
+++ b/tests/console_monitor/console_mirror_test.py
@@ -1,10 +1,13 @@
-"""Unit tests for the console mirror recording writer and archiver."""
+"""Unit tests for console mirror recording and control components."""
 
 import concurrent.futures
 import errno
+import json
 import os
 import queue
+import socket
 import stat
+import struct
 import tempfile
 import threading
 import time
@@ -537,3 +540,1028 @@ class TestRecordingArchiver(TestCase):
         self.assertTrue(handle.cancel_event.is_set())
         self.assertTrue(future.cancelled())
         archiver._executor.shutdown.assert_called_once_with(wait=False)
+
+
+class FakeTimer:
+    """Deterministic stand-in for threading.Timer used by manager tests."""
+
+    def __init__(self, interval, callback, start_error=None):
+        self.interval = interval
+        self.callback = callback
+        self.start_error = start_error
+        self.daemon = False
+        self.started = False
+        self.cancelled = False
+
+    def start(self):
+        if self.start_error is not None:
+            raise self.start_error
+        self.started = True
+
+    def cancel(self):
+        self.cancelled = True
+
+    def fire(self):
+        self.callback()
+
+
+class TestMirrorManager(TestCase):
+    def setUp(self):
+        self.state_table = mock.Mock()
+        self.archiver = mock.Mock()
+        self.writer = self.make_writer()
+        self.writer_factory = mock.Mock(return_value=self.writer)
+        self.timers = []
+        self.next_timer_error = None
+
+        def make_timer(interval, callback):
+            timer = FakeTimer(interval, callback, self.next_timer_error)
+            self.next_timer_error = None
+            self.timers.append(timer)
+            return timer
+
+        self.timer_patch = mock.patch.object(console_mirror.threading, "Timer", side_effect=make_timer)
+        self.timer_patch.start()
+
+    def tearDown(self):
+        self.timer_patch.stop()
+
+    @staticmethod
+    def make_writer():
+        writer = mock.Mock()
+        writer.start_timestamp = 1_700_000_000.25
+        writer.file_path = "/recordings/line1/session-part0001.log"
+        writer.recording_prefix = "/recordings/line1/session"
+        writer.submit_event.return_value = True
+        writer.submit_data.return_value = True
+        return writer
+
+    def make_manager(self, **overrides):
+        options = {
+            "line": "1",
+            "state_table": self.state_table,
+            "base_dir": "/recordings",
+            "writer_factory": self.writer_factory,
+            "archiver": self.archiver,
+            "writer_queue_size": 17,
+        }
+        options.update(overrides)
+        return console_mirror.MirrorManager(**options)
+
+    def start_manager(self, manager=None, **options):
+        manager = manager or self.make_manager()
+        defaults = {
+            "direction": "both",
+            "timeout": "2h",
+            "max_file_size": 8,
+            "owner_pid": 1234,
+            "started_by": "admin",
+        }
+        defaults.update(options)
+        response = manager.start(defaults)
+        return manager, response
+
+    def assert_error(self, code, operation):
+        with self.assertRaises(console_mirror.MirrorError) as caught:
+            operation()
+        self.assertEqual(caught.exception.code, code)
+        return caught.exception
+
+    def test_initialization_writes_idle_state_and_tolerates_state_db_errors(self):
+        manager = self.make_manager(line=" 7 ")
+        self.assertEqual(manager.line, "7")
+        self.state_table.set.assert_called_once_with("7", [("state", "idle")])
+        self.assertEqual(
+            [call.args for call in self.state_table.hdel.call_args_list],
+            [("7", field) for field in (
+                "owner_pid", "started_by", "start_time", "timeout", "file_path", "direction"
+            )],
+        )
+
+        broken_table = mock.Mock()
+        broken_table.set.side_effect = RuntimeError("set failed")
+        broken_table.hdel.side_effect = RuntimeError("delete failed")
+        with mock.patch.object(console_mirror.log, "error") as log_error:
+            self.make_manager(line="8", state_table=broken_table)
+        self.assertEqual(log_error.call_count, 7)
+
+    def test_start_sets_runtime_timer_writer_and_state_db_metadata(self):
+        manager, response = self.start_manager()
+
+        self.writer_factory.assert_called_once_with(
+            line="1",
+            direction="both",
+            timeout_text="2h",
+            max_file_size_mb=8,
+            base_dir="/recordings",
+            queue_size=17,
+            on_fatal=manager._on_writer_fatal,
+            on_rotate=manager._on_rotate,
+        )
+        timer = self.timers[-1]
+        self.assertEqual(timer.interval, 7200)
+        self.assertTrue(timer.daemon)
+        self.assertTrue(timer.started)
+        self.writer.submit_event.assert_called_once_with({"event": "start"})
+        self.assertEqual(manager.state, "active")
+        self.assertIs(manager.writer, self.writer)
+        self.assertEqual(manager.direction, "both")
+        self.assertEqual(manager.timeout_seconds, 7200)
+        self.assertEqual(manager._owner_pid, 1234)
+        self.assertEqual(manager._started_by, "admin")
+        self.assertEqual(
+            response,
+            {
+                "status": "ok",
+                "file_path": self.writer.file_path,
+                "timeout": "2h",
+                "remaining": "2h",
+            },
+        )
+        self.state_table.set.assert_called_with(
+            "1",
+            [
+                ("state", "active"),
+                ("owner_pid", "1234"),
+                ("started_by", "admin"),
+                ("start_time", "1700000000"),
+                ("timeout", "7200"),
+                ("file_path", self.writer.file_path),
+                ("direction", "both"),
+            ],
+        )
+
+        with mock.patch.object(manager, "_on_timeout") as on_timeout:
+            timer.fire()
+        on_timeout.assert_called_once_with(timer)
+
+    def test_start_uses_defaults_and_rejects_invalid_options_or_active_session(self):
+        manager = self.make_manager()
+        manager.start({"owner_pid": 1234})
+        self.writer_factory.assert_called_once_with(
+            line="1",
+            direction="both",
+            timeout_text=console_mirror.DEFAULT_TIMEOUT,
+            max_file_size_mb=console_mirror.DEFAULT_MAX_FILE_SIZE_MB,
+            base_dir="/recordings",
+            queue_size=17,
+            on_fatal=manager._on_writer_fatal,
+            on_rotate=manager._on_rotate,
+        )
+        self.assertEqual(manager._owner_pid, 1234)
+        self.assertEqual(manager._started_by, "root")
+        self.assert_error("mirror_already_active", lambda: manager.start({"owner_pid": 1234}))
+
+        for direction in ("sideways", 1):
+            fresh = self.make_manager()
+            self.assert_error("invalid_direction", lambda direction=direction: fresh.start({"direction": direction}))
+        for size in (True, "8", 0, -1):
+            fresh = self.make_manager()
+            self.assert_error(
+                "invalid_max_file_size",
+                lambda size=size: fresh.start({"max_file_size": size}),
+            )
+
+    def test_start_rejects_invalid_owner_pid_before_creating_writer(self):
+        for owner_pid in (None, True, False, 0, -1, "1234", "not-a-pid"):
+            writer_factory = mock.Mock(return_value=self.make_writer())
+            manager = self.make_manager(writer_factory=writer_factory)
+
+            self.assert_error(
+                "invalid_owner_pid",
+                lambda owner_pid=owner_pid, manager=manager: manager.start(
+                    {"owner_pid": owner_pid}
+                ),
+            )
+
+            writer_factory.assert_not_called()
+            self.assertEqual(manager.state, "idle")
+            self.assertIsNone(manager.writer)
+            self.assertIsNone(manager.timer)
+
+    def test_start_preserves_mirror_errors_and_wraps_writer_open_errors(self):
+        expected = console_mirror.MirrorError("unsafe_recording_path", "unsafe")
+        manager = self.make_manager(writer_factory=mock.Mock(side_effect=expected))
+        self.assertIs(
+            self.assert_error(
+                "unsafe_recording_path", lambda: manager.start({"owner_pid": 1234})
+            ),
+            expected,
+        )
+
+        manager = self.make_manager(writer_factory=mock.Mock(side_effect=OSError("disk error")))
+        error = self.assert_error(
+            "file_open_failed", lambda: manager.start({"owner_pid": 1234})
+        )
+        self.assertIn("disk error", error.message)
+
+    def test_start_timer_failure_closes_writer_and_restores_idle_state(self):
+        self.next_timer_error = RuntimeError("timer unavailable")
+        manager = self.make_manager()
+        error = self.assert_error(
+            "timer_setup_failed",
+            lambda: manager.start({"timeout": "1m", "owner_pid": 1234}),
+        )
+
+        self.assertIn("timer unavailable", error.message)
+        self.writer.close.assert_called_once_with()
+        self.assertEqual(manager.state, "idle")
+        self.assertIsNone(manager.writer)
+        self.assertIsNone(manager.timer)
+        self.assertIsNone(manager.direction)
+        self.assertIsNone(manager.start_time)
+        self.assertIsNone(manager.timeout_text)
+        self.assertIsNone(manager.timeout_seconds)
+        self.assertIsNone(manager.deadline)
+        self.assertIsNone(manager.file_path)
+        self.assertIsNone(manager._owner_pid)
+        self.assertIsNone(manager._started_by)
+        self.assertEqual(manager.writer_drop_count, 0)
+        self.state_table.set.assert_called_with("1", [("state", "idle")])
+
+    def test_submit_is_nonblocking_filters_data_and_tracks_queue_drops(self):
+        manager = self.make_manager()
+        manager.submit("bad", b"data")
+        manager.submit("rx", b"")
+        manager.submit("rx", b"idle")
+        self.writer.submit_data.assert_not_called()
+
+        busy_lock = mock.Mock()
+        busy_lock.acquire.return_value = False
+        manager._lock = busy_lock
+        manager.submit("rx", b"busy")
+        busy_lock.acquire.assert_called_once_with(blocking=False)
+        busy_lock.release.assert_not_called()
+
+        manager._lock = threading.RLock()
+        manager.state = "active"
+        manager.writer = None
+        manager.submit("rx", b"no writer")
+        manager.writer = self.writer
+        manager.direction = "tx"
+        manager.submit("rx", b"filtered")
+        self.writer.submit_data.assert_not_called()
+
+        manager.direction = "both"
+        self.writer.submit_data.return_value = False
+        manager.submit("rx", b"first drop")
+        self.assertEqual(manager.writer_drop_count, 1)
+
+        self.writer.submit_event.return_value = False
+        manager.submit("tx", b"event drop")
+        self.assertEqual(manager.writer_drop_count, 2)
+        self.writer.submit_data.assert_called_once_with("rx", b"first drop")
+
+        self.writer.submit_event.return_value = True
+        self.writer.submit_data.return_value = True
+        manager.submit("tx", b"recovered")
+        self.writer.submit_event.assert_called_with(
+            {"event": "drop", "reason": "writer_queue_full", "count": 2},
+            nonblocking=True,
+        )
+        self.writer.submit_data.assert_called_with("tx", b"recovered")
+        self.assertEqual(manager.writer_drop_count, 0)
+
+    def test_update_timeout_rejects_inactive_and_delta_overflow(self):
+        manager = self.make_manager()
+        self.assert_error("mirror_not_active", lambda: manager.update_timeout("1m"))
+
+        manager.state = "active"
+        manager.writer = None
+        self.assert_error("mirror_not_active", lambda: manager.update_timeout("1m"))
+
+        manager.writer = self.writer
+        manager.start_time = 0
+        with mock.patch.object(console_mirror.time, "time", return_value=console_mirror.MAX_DELTA_MS / 1000):
+            self.assert_error("invalid_timeout", lambda: manager.update_timeout("1s"))
+
+    def test_update_timeout_replaces_timer_and_updates_writer_and_state(self):
+        manager, _ = self.start_manager()
+        previous = manager.timer
+        manager.start_time = 100.0
+        with mock.patch.object(console_mirror.time, "time", return_value=99.0), \
+                mock.patch.object(console_mirror.time, "monotonic", return_value=500.0):
+            response = manager.update_timeout("30m")
+
+        replacement = manager.timer
+        self.assertIsNot(replacement, previous)
+        self.assertTrue(replacement.started)
+        self.assertTrue(previous.cancelled)
+        self.assertEqual(manager.timeout_text, "30m")
+        self.assertEqual(manager.timeout_seconds, 1800)
+        self.assertEqual(manager.deadline, 2300.0)
+        self.writer.update_timeout.assert_called_once_with("30m")
+        self.writer.submit_event.assert_called_with({"event": "timeout_update", "timeout": "30m"})
+        self.assertEqual(response, {"status": "ok", "timeout": "30m", "remaining": "30m"})
+
+        with mock.patch.object(manager, "_on_timeout") as on_timeout:
+            replacement.fire()
+        on_timeout.assert_called_once_with(replacement)
+
+        manager.timer = None
+        with mock.patch.object(console_mirror.time, "time", return_value=100.0):
+            manager.update_timeout("1m")
+        self.assertTrue(manager.timer.started)
+
+    def test_update_timeout_timer_failure_keeps_previous_configuration(self):
+        manager, _ = self.start_manager()
+        previous = manager.timer
+        previous_deadline = manager.deadline
+        self.next_timer_error = RuntimeError("cannot start")
+        error = self.assert_error("timer_setup_failed", lambda: manager.update_timeout("30m"))
+
+        self.assertIn("cannot start", error.message)
+        self.assertIs(manager.timer, previous)
+        self.assertFalse(previous.cancelled)
+        self.assertEqual(manager.timeout_text, "2h")
+        self.assertEqual(manager.timeout_seconds, 7200)
+        self.assertEqual(manager.deadline, previous_deadline)
+        self.writer.update_timeout.assert_not_called()
+
+    def test_stop_without_archive_transitions_through_stopping_and_retains_files(self):
+        manager, _ = self.start_manager()
+        timer = manager.timer
+        states_seen = []
+        def capture_state(line, values):
+            states_seen.append(dict(values)["state"])
+
+        self.state_table.set.side_effect = capture_state
+        response = manager.stop(reason="manual", archive=False)
+
+        self.assertTrue(timer.cancelled)
+        self.writer.submit_event.assert_called_with({"event": "stop", "reason": "manual"})
+        self.writer.close.assert_called_once_with()
+        self.assertEqual(states_seen, ["stopping", "idle"])
+        self.assertEqual(manager.state, "idle")
+        self.assertIsNone(manager.writer)
+        self.assertEqual(
+            response,
+            {
+                "status": "ok",
+                "message": "Mirror stopped; recording files retained",
+                "recording_prefix": self.writer.recording_prefix,
+            },
+        )
+
+    def test_stop_validates_state_and_expected_timer(self):
+        manager = self.make_manager()
+        self.assert_error("mirror_not_active", manager.stop)
+
+        manager.state = "active"
+        manager.writer = None
+        self.assert_error("mirror_not_active", manager.stop)
+
+        manager, _ = self.start_manager(self.make_manager())
+        self.assert_error("stale_timeout", lambda: manager.stop(expected_timer=FakeTimer(1, lambda: None)))
+        self.assertEqual(manager.state, "active")
+
+        manager.timer = None
+        response = manager.stop()
+        self.assertEqual(response["status"], "ok")
+
+    def test_stop_does_not_clear_a_writer_replaced_while_old_writer_closes(self):
+        manager, _ = self.start_manager()
+        replacement_writer = mock.Mock()
+        self.writer.close.side_effect = lambda: setattr(manager, "writer", replacement_writer)
+
+        manager.stop()
+
+        self.assertIs(manager.writer, replacement_writer)
+        self.assertEqual(manager.state, "idle")
+
+    def test_stop_archives_an_immutable_session_snapshot(self):
+        handle = mock.sentinel.archive_handle
+        self.archiver.submit.return_value = handle
+        manager, _ = self.start_manager(direction="rx")
+        response = manager.stop(reason="timeout", archive=True, expected_timer=manager.timer)
+
+        job = self.archiver.submit.call_args.args[0]
+        self.assertEqual(
+            job,
+            console_mirror.ArchiveJob(
+                line="1",
+                direction="rx",
+                start_timestamp=self.writer.start_timestamp,
+                recording_prefix=self.writer.recording_prefix,
+                archive_path=self.writer.recording_prefix + ".zip",
+                stop_reason="timeout",
+            ),
+        )
+        self.assertEqual(response["status"], "packaging")
+        self.assertEqual(response["archive_path"], self.writer.recording_prefix + ".zip")
+        self.assertIs(response["archive_handle"], handle)
+        self.assertEqual(manager.state, "idle")
+
+    def test_stop_preserves_archive_errors_and_wraps_submission_failures(self):
+        expected = console_mirror.MirrorError("archive_queue_full", "full")
+        self.archiver.submit.side_effect = expected
+        manager, _ = self.start_manager()
+        self.assertIs(self.assert_error("archive_queue_full", lambda: manager.stop(archive=True)), expected)
+        self.assertEqual(manager.state, "idle")
+
+        self.archiver.submit.side_effect = RuntimeError("executor stopped")
+        manager, _ = self.start_manager(self.make_manager())
+        error = self.assert_error("archive_failed", lambda: manager.stop(archive=True))
+        self.assertIn("executor stopped", error.message)
+        self.assertIn("source logs were preserved", error.message)
+
+    def test_status_reports_idle_active_stopping_and_clamps_remaining(self):
+        manager = self.make_manager()
+        self.assertEqual(manager.status(), {"status": "ok", "state": "idle", "line": "1"})
+
+        manager, _ = self.start_manager(manager, direction="tx", timeout="1m")
+        manager.deadline = 101.2
+        with mock.patch.object(console_mirror.time, "monotonic", return_value=100.0):
+            active = manager.status()
+        self.assertEqual(active["state"], "active")
+        self.assertEqual(active["start_time"], "2023-11-14T22:13:20.250Z")
+        self.assertEqual(active["direction"], "tx")
+        self.assertEqual(active["timeout"], "1m")
+        self.assertEqual(active["remaining"], "2s")
+        self.assertEqual(active["file_path"], self.writer.file_path)
+
+        manager.state = "stopping"
+        manager.deadline = None
+        self.assertEqual(manager.status()["remaining"], "0s")
+
+    def test_timeout_callback_ignores_expected_races_and_logs_other_errors(self):
+        manager = self.make_manager()
+        timer = FakeTimer(1, lambda: None)
+        manager.stop = mock.Mock()
+        manager._on_timeout(timer)
+        manager.stop.assert_called_once_with(reason="timeout", archive=True, expected_timer=timer)
+
+        for code in ("mirror_not_active", "stale_timeout"):
+            manager.stop.side_effect = console_mirror.MirrorError(code, code)
+            with mock.patch.object(console_mirror.log, "error") as log_error:
+                manager._on_timeout(timer)
+            log_error.assert_not_called()
+
+        manager.stop.side_effect = console_mirror.MirrorError("archive_failed", "broken archive")
+        with mock.patch.object(console_mirror.log, "error") as log_error:
+            manager._on_timeout(timer)
+        log_error.assert_called_once_with(
+            "[%s] Automatic mirror stop failed: %s", "1", "broken archive"
+        )
+
+    def test_writer_fatal_callback_starts_named_daemon_stop_thread(self):
+        manager = self.make_manager()
+        thread = mock.Mock()
+        with mock.patch.object(console_mirror.threading, "Thread", return_value=thread) as thread_type, \
+                mock.patch.object(console_mirror.log, "error") as log_error:
+            manager._on_writer_fatal(self.writer, OSError("disk full"))
+        log_error.assert_called_once()
+        thread_type.assert_called_once_with(
+            target=manager._stop_after_writer_error,
+            args=(self.writer,),
+            name="console-mirror-writer-error-1",
+            daemon=True,
+        )
+        thread.start.assert_called_once_with()
+
+    def test_stop_after_writer_error_only_stops_matching_active_writer(self):
+        manager = self.make_manager()
+        manager.stop = mock.Mock()
+        manager._stop_after_writer_error(self.writer)
+        manager.stop.assert_not_called()
+
+        manager.state = "active"
+        manager.writer = mock.Mock()
+        manager._stop_after_writer_error(self.writer)
+        manager.stop.assert_not_called()
+
+        manager.writer = self.writer
+        manager._stop_after_writer_error(self.writer)
+        manager.stop.assert_called_once_with(reason="writer_error", archive=False)
+
+        manager.stop.side_effect = console_mirror.MirrorError("mirror_not_active", "raced")
+        manager._stop_after_writer_error(self.writer)
+
+    def test_rotate_updates_only_an_active_session(self):
+        manager = self.make_manager()
+        manager._on_rotate("ignored.log")
+        self.assertIsNone(manager.file_path)
+
+        manager, _ = self.start_manager(manager)
+        manager._on_rotate("part0002.log")
+        self.assertEqual(manager.file_path, "part0002.log")
+        self.state_table.set.assert_called_with(
+            "1",
+            [
+                ("state", "active"),
+                ("owner_pid", "1234"),
+                ("started_by", "admin"),
+                ("start_time", "1700000000"),
+                ("timeout", "7200"),
+                ("file_path", "part0002.log"),
+                ("direction", "both"),
+            ],
+        )
+
+    def test_shutdown_stops_active_session_and_always_shuts_down_archiver(self):
+        manager, _ = self.start_manager()
+        manager.shutdown(archive_timeout=2.5)
+        self.writer.submit_event.assert_called_with({"event": "stop", "reason": "proxy_shutdown"})
+        self.archiver.shutdown.assert_called_once_with(timeout=2.5)
+        self.assertEqual(manager.state, "idle")
+
+        manager = self.make_manager()
+        manager.stop = mock.Mock(side_effect=console_mirror.MirrorError("raced", "raced"))
+        manager.state = "active"
+        manager.shutdown(archive_timeout=1)
+        manager.stop.assert_called_once_with(reason="proxy_shutdown", archive=False)
+        self.archiver.shutdown.assert_called_with(timeout=1)
+
+        manager = self.make_manager()
+        manager.shutdown(archive_timeout=0)
+        self.archiver.shutdown.assert_called_with(timeout=0)
+
+
+class TestControlMessageProtocol(TestCase):
+    @staticmethod
+    def frame(value):
+        payload = json.dumps(value).encode("utf-8")
+        return struct.pack("!I", len(payload)) + payload
+
+    @staticmethod
+    def connection_for(data, chunk_size=None):
+        connection = mock.Mock()
+        chunks = []
+        if chunk_size is None:
+            chunks = [data]
+        else:
+            chunks = [data[index:index + chunk_size] for index in range(0, len(data), chunk_size)]
+        connection.recv.side_effect = chunks
+        return connection
+
+    def assert_message_error(self, code, connection):
+        with self.assertRaises(console_mirror.MirrorError) as caught:
+            console_mirror.recv_message(connection)
+        self.assertEqual(caught.exception.code, code)
+        return caught.exception
+
+    def test_recv_exact_handles_partial_reads_and_clean_eof(self):
+        connection = mock.Mock()
+        connection.recv.side_effect = [b"ab", b"c", b"d"]
+        self.assertEqual(console_mirror._recv_exact(connection, 4), b"abcd")
+        self.assertEqual(
+            [call.args for call in connection.recv.call_args_list],
+            [(4,), (2,), (1,)],
+        )
+
+        connection = mock.Mock()
+        connection.recv.return_value = b""
+        self.assertIsNone(console_mirror._recv_exact(connection, 4))
+
+    def test_recv_message_decodes_framed_json_object(self):
+        framed = self.frame({"op": "status", "line": "1", "text": "你好"})
+        connection = self.connection_for(framed, chunk_size=2)
+        self.assertEqual(
+            console_mirror.recv_message(connection),
+            {"op": "status", "line": "1", "text": "你好"},
+        )
+
+        connection = mock.Mock()
+        connection.recv.return_value = b""
+        self.assertIsNone(console_mirror.recv_message(connection))
+
+    def test_recv_message_rejects_invalid_lengths_and_truncated_payload(self):
+        for length in (0, console_mirror.MAX_CONTROL_MESSAGE + 1):
+            connection = mock.Mock()
+            connection.recv.return_value = struct.pack("!I", length)
+            self.assert_message_error("invalid_message", connection)
+
+        connection = mock.Mock()
+        connection.recv.side_effect = [struct.pack("!I", 3), b""]
+        error = self.assert_message_error("invalid_message", connection)
+        self.assertEqual(error.message, "Truncated control message")
+
+    def test_recv_message_rejects_bad_json_encoding_and_non_object_values(self):
+        invalid_payloads = (b"\xff", b"{", b"[]")
+        for payload in invalid_payloads:
+            connection = mock.Mock()
+            connection.recv.side_effect = [struct.pack("!I", len(payload)), payload]
+            self.assert_message_error("invalid_message", connection)
+
+    def test_send_message_uses_compact_utf8_length_framing(self):
+        connection = mock.Mock()
+        console_mirror.send_message(connection, {"status": "ok", "text": "你好"})
+
+        framed = connection.sendall.call_args.args[0]
+        length = struct.unpack("!I", framed[:4])[0]
+        self.assertEqual(length, len(framed[4:]))
+        self.assertEqual(json.loads(framed[4:].decode("utf-8")), {"status": "ok", "text": "你好"})
+        self.assertNotIn(b" ", framed[4:])
+
+
+class TestMirrorControlServer(TestCase):
+    def setUp(self):
+        self.manager = mock.Mock()
+        self.server = console_mirror.MirrorControlServer(
+            line="1",
+            manager=self.manager,
+            runtime_dir="/runtime/mirror",
+            archive_wait_seconds=3,
+            max_clients=2,
+        )
+
+    def assert_error_response(self, send, code):
+        response = send.call_args.args[1]
+        self.assertEqual(response["status"], "error")
+        self.assertEqual(response["code"], code)
+        return response
+
+    def handle_request(self, request, credentials=(4321, 0, 0)):
+        connection = mock.Mock()
+        with mock.patch.object(self.server, "_peer_credentials", return_value=credentials), \
+                mock.patch.object(console_mirror, "recv_message", return_value=request), \
+                mock.patch.object(console_mirror, "send_message") as send:
+            self.server._handle_client(connection)
+        return connection, send
+
+    def test_initialization_validates_line_and_builds_socket_path(self):
+        self.assertEqual(self.server.line, "1")
+        self.assertEqual(self.server.socket_path, "/runtime/mirror/line1.sock")
+        self.assertEqual(self.server.max_clients, 2)
+        self.assertTrue(self.server._root_only(0))
+        self.assertFalse(self.server._root_only(1000))
+
+        with self.assertRaises(console_mirror.MirrorError) as caught:
+            console_mirror.MirrorControlServer("tty1", self.manager)
+        self.assertEqual(caught.exception.code, "invalid_line")
+
+    def test_start_replaces_stale_socket_and_starts_daemon_server_thread(self):
+        server_socket = mock.Mock()
+        worker = mock.Mock()
+        socket_info = mock.Mock(st_mode=stat.S_IFSOCK)
+        with mock.patch.object(console_mirror, "_ensure_secure_directory") as secure, \
+                mock.patch.object(console_mirror.os, "lstat", return_value=socket_info), \
+                mock.patch.object(console_mirror.os, "unlink") as unlink, \
+                mock.patch.object(console_mirror.socket, "socket", return_value=server_socket) as socket_type, \
+                mock.patch.object(console_mirror.threading, "Thread", return_value=worker) as thread_type:
+            self.server.start()
+
+        secure.assert_called_once_with("/runtime/mirror")
+        unlink.assert_called_once_with(self.server.socket_path)
+        socket_type.assert_called_once_with(socket.AF_UNIX, socket.SOCK_STREAM)
+        server_socket.bind.assert_called_once_with(self.server.socket_path)
+        server_socket.listen.assert_called_once_with(2)
+        server_socket.settimeout.assert_called_once_with(0.2)
+        self.assertIs(self.server._socket, server_socket)
+        self.assertTrue(self.server._running.is_set())
+        thread_type.assert_called_once_with(
+            target=self.server._serve,
+            name="console-mirror-control-1",
+            daemon=True,
+        )
+        worker.start.assert_called_once_with()
+
+    def test_start_accepts_missing_socket_path_and_rejects_occupied_path(self):
+        server_socket = mock.Mock()
+        with mock.patch.object(console_mirror, "_ensure_secure_directory"), \
+                mock.patch.object(console_mirror.os, "lstat", side_effect=FileNotFoundError), \
+                mock.patch.object(console_mirror.socket, "socket", return_value=server_socket), \
+                mock.patch.object(console_mirror.threading, "Thread", return_value=mock.Mock()):
+            self.server.start()
+        self.assertIs(self.server._socket, server_socket)
+
+        with mock.patch.object(console_mirror, "_ensure_secure_directory"), \
+                mock.patch.object(console_mirror.os, "lstat", return_value=mock.Mock(st_mode=stat.S_IFREG)), \
+                self.assertRaises(console_mirror.MirrorError) as caught:
+            self.server.start()
+        self.assertEqual(caught.exception.code, "unsafe_socket_path")
+
+    def test_start_closes_socket_and_cleans_path_when_setup_fails(self):
+        server_socket = mock.Mock()
+        server_socket.bind.side_effect = OSError("bind failed")
+        with mock.patch.object(console_mirror, "_ensure_secure_directory"), \
+                mock.patch.object(console_mirror.os, "lstat", side_effect=FileNotFoundError), \
+                mock.patch.object(console_mirror.os, "unlink", side_effect=OSError("missing")), \
+                mock.patch.object(console_mirror.socket, "socket", return_value=server_socket), \
+                self.assertRaisesRegex(OSError, "bind failed"):
+            self.server.start()
+        server_socket.close.assert_called_once_with()
+
+    def test_serve_handles_timeouts_capacity_limit_clients_and_socket_close(self):
+        rejected = mock.Mock()
+        accepted = mock.Mock()
+        self.server._socket = mock.Mock()
+        self.server._socket.accept.side_effect = [
+            socket.timeout(),
+            (rejected, None),
+            (accepted, None),
+            OSError("closed"),
+        ]
+        self.server._running = mock.Mock()
+        self.server._running.is_set.side_effect = [True, True, True, True]
+        self.server._clients = mock.Mock()
+        self.server._clients.acquire.side_effect = [False, True]
+        worker = mock.Mock()
+
+        with mock.patch.object(console_mirror.threading, "Thread", return_value=worker) as thread_type:
+            self.server._serve()
+
+        rejected.close.assert_called_once_with()
+        thread_type.assert_called_once_with(
+            target=self.server._handle_and_release,
+            args=(accepted,),
+            name="console-mirror-client-1",
+            daemon=True,
+        )
+        self.assertEqual(self.server._client_threads, [worker])
+        worker.start.assert_called_once_with()
+
+        self.server._running.is_set.side_effect = None
+        self.server._running.is_set.return_value = False
+        self.server._socket.accept.reset_mock()
+        self.server._serve()
+        self.server._socket.accept.assert_not_called()
+
+    def test_handle_and_release_always_closes_releases_and_removes_worker(self):
+        connection = mock.Mock()
+        current = threading.current_thread()
+        self.server._client_threads = [current]
+        self.server._clients = mock.Mock()
+        self.server._handle_client = mock.Mock()
+        self.server._handle_and_release(connection)
+        connection.close.assert_called_once_with()
+        self.server._clients.release.assert_called_once_with()
+        self.assertEqual(self.server._client_threads, [])
+
+        connection = mock.Mock()
+        self.server._client_threads = []
+        self.server._clients.reset_mock()
+        self.server._handle_client.side_effect = RuntimeError("handler failed")
+        with self.assertRaisesRegex(RuntimeError, "handler failed"):
+            self.server._handle_and_release(connection)
+        connection.close.assert_called_once_with()
+        self.server._clients.release.assert_called_once_with()
+
+    def test_peer_credentials_decodes_linux_socket_credentials(self):
+        connection = mock.Mock()
+        connection.getsockopt.return_value = struct.pack("3i", 123, 456, 789)
+        self.assertEqual(self.server._peer_credentials(connection), (123, 456, 789))
+        connection.getsockopt.assert_called_once_with(
+            socket.SOL_SOCKET,
+            socket.SO_PEERCRED,
+            struct.calcsize("3i"),
+        )
+
+    def test_archive_completion_sends_success_and_cleanup_failure(self):
+        connection = mock.Mock()
+        handle = mock.Mock()
+        handle.result.return_value = console_mirror.ArchiveResult("session.zip")
+        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]), \
+                mock.patch.object(console_mirror, "send_message") as send:
+            self.server._send_archive_completion(connection, handle)
+        send.assert_called_once_with(connection, {"status": "ok", "archive_path": "session.zip"})
+
+        handle.result.return_value = console_mirror.ArchiveResult(
+            "session.zip", ("part0001.log", "part0002.log")
+        )
+        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]), \
+                mock.patch.object(console_mirror, "send_message") as send:
+            self.server._send_archive_completion(connection, handle)
+        self.assertEqual(
+            send.call_args.args[1],
+            {
+                "status": "error",
+                "code": "archive_cleanup_failed",
+                "message": "Archive is valid but some source logs could not be deleted",
+                "archive_path": "session.zip",
+                "source_paths": ["part0001.log", "part0002.log"],
+            },
+        )
+
+    def test_archive_completion_cancels_after_server_wait_budget(self):
+        connection = mock.Mock()
+        handle = mock.Mock()
+        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 14]), \
+                mock.patch.object(console_mirror, "send_message") as send:
+            self.server._send_archive_completion(connection, handle)
+        handle.cancel.assert_called_once_with()
+        handle.result.assert_not_called()
+        send.assert_not_called()
+
+    def test_archive_completion_polls_and_returns_when_client_disconnects(self):
+        connection = mock.Mock()
+        connection.recv.return_value = b""
+        handle = mock.Mock()
+        handle.result.side_effect = concurrent.futures.TimeoutError
+        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]), \
+                mock.patch.object(console_mirror.select, "select", return_value=([connection], [], [])), \
+                mock.patch.object(console_mirror, "send_message") as send:
+            self.server._send_archive_completion(connection, handle)
+        connection.recv.assert_called_once_with(1, socket.MSG_PEEK)
+        handle.cancel.assert_not_called()
+        send.assert_not_called()
+
+    def test_archive_completion_keeps_waiting_while_client_is_connected(self):
+        connection = mock.Mock()
+        connection.recv.return_value = b"x"
+        handle = mock.Mock()
+        result = console_mirror.ArchiveResult("session.zip")
+        handle.result.side_effect = [concurrent.futures.TimeoutError, result]
+        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10, 10]), \
+                mock.patch.object(console_mirror.select, "select", return_value=([connection], [], [])), \
+                mock.patch.object(console_mirror, "send_message") as send:
+            self.server._send_archive_completion(connection, handle)
+        self.assertEqual(handle.result.call_count, 2)
+        send.assert_called_once_with(connection, {"status": "ok", "archive_path": "session.zip"})
+
+        handle.reset_mock()
+        handle.result.side_effect = [concurrent.futures.TimeoutError, result]
+        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10, 10]), \
+                mock.patch.object(console_mirror.select, "select", return_value=([], [], [])), \
+                mock.patch.object(console_mirror, "send_message"):
+            self.server._send_archive_completion(connection, handle)
+        self.assertEqual(handle.result.call_count, 2)
+
+    def test_archive_completion_reports_archive_and_unexpected_failures(self):
+        connection = mock.Mock()
+        handle = mock.Mock()
+        handle.result.side_effect = console_mirror.MirrorError("archive_failed", "zip failed")
+        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]), \
+                mock.patch.object(console_mirror, "send_message") as send:
+            self.server._send_archive_completion(connection, handle)
+        self.assertEqual(
+            send.call_args.args[1],
+            {
+                "status": "error",
+                "code": "archive_failed",
+                "message": "zip failed; original log parts were preserved",
+            },
+        )
+
+        handle.result.side_effect = RuntimeError("worker crashed")
+        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]), \
+                mock.patch.object(console_mirror, "send_message") as send:
+            self.server._send_archive_completion(connection, handle)
+        self.assertEqual(send.call_args.args[1]["code"], "archive_failed")
+        self.assertIn("worker crashed", send.call_args.args[1]["message"])
+
+    def test_archive_completion_ignores_disconnected_response_socket(self):
+        connection = mock.Mock()
+        handle = mock.Mock()
+        handle.result.return_value = console_mirror.ArchiveResult("session.zip")
+        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]), \
+                mock.patch.object(console_mirror, "send_message", side_effect=OSError("disconnected")):
+            self.server._send_archive_completion(connection, handle)
+
+    def test_handle_client_dispatches_start_with_authenticated_audit_metadata(self):
+        self.manager.start.return_value = {"status": "ok", "file_path": "part.log"}
+        request = {
+            "op": "start",
+            "line": "1",
+            "direction": "both",
+            "started_by": "admin",
+            "owner_pid": 999,
+        }
+        connection, send = self.handle_request(request)
+
+        options = self.manager.start.call_args.args[0]
+        self.assertEqual(options["owner_pid"], 4321)
+        self.assertEqual(options["started_by"], "admin")
+        send.assert_called_once_with(connection, {"status": "ok", "file_path": "part.log"})
+
+    def test_handle_client_falls_back_to_peer_username_or_uid(self):
+        self.manager.start.return_value = {"status": "ok"}
+        invalid_names = (None, "", "x" * 257)
+        for name in invalid_names:
+            self.manager.start.reset_mock()
+            with mock.patch.object(console_mirror.pwd, "getpwuid", return_value=mock.Mock(pw_name="root")):
+                self.handle_request({"op": "start", "line": "1", "started_by": name})
+            self.assertEqual(self.manager.start.call_args.args[0]["started_by"], "root")
+
+        with mock.patch.object(console_mirror.pwd, "getpwuid", side_effect=KeyError):
+            self.handle_request({"op": "start", "line": "1"})
+        self.assertEqual(self.manager.start.call_args.args[0]["started_by"], "0")
+
+    def test_handle_client_dispatches_stop_status_and_timeout(self):
+        handle = mock.sentinel.archive_handle
+        self.manager.stop.return_value = {
+            "status": "packaging",
+            "archive_path": "session.zip",
+            "archive_handle": handle,
+        }
+        with mock.patch.object(self.server, "_send_archive_completion") as completion:
+            connection, send = self.handle_request({"op": "stop", "line": "1", "archive": True})
+        self.manager.stop.assert_called_once_with(reason="manual", archive=True)
+        send.assert_called_once_with(
+            connection, {"status": "packaging", "archive_path": "session.zip"}
+        )
+        completion.assert_called_once_with(connection, handle)
+
+        self.manager.stop.reset_mock()
+        self.manager.stop.return_value = {"status": "ok"}
+        with mock.patch.object(self.server, "_send_archive_completion") as completion:
+            self.handle_request({"op": "stop", "line": "1"})
+        self.manager.stop.assert_called_once_with(reason="manual", archive=False)
+        completion.assert_not_called()
+
+        self.manager.status.return_value = {"status": "ok", "state": "idle"}
+        connection, send = self.handle_request({"op": "status", "line": "1"})
+        send.assert_called_once_with(connection, self.manager.status.return_value)
+
+        self.manager.update_timeout.return_value = {"status": "ok", "timeout": "2h"}
+        connection, send = self.handle_request({"op": "timeout", "line": "1", "timeout": "2h"})
+        self.manager.update_timeout.assert_called_once_with("2h")
+        send.assert_called_once_with(connection, self.manager.update_timeout.return_value)
+
+    def test_handle_client_rejects_unauthorized_mismatched_and_invalid_requests(self):
+        connection, send = self.handle_request(
+            {"op": "status", "line": "1"}, credentials=(1, 1000, 1000)
+        )
+        self.assert_error_response(send, "permission_denied")
+
+        _, send = self.handle_request({"op": "status", "line": "2"})
+        self.assert_error_response(send, "line_mismatch")
+
+        _, send = self.handle_request({"op": "stop", "line": "1", "archive": "yes"})
+        self.assert_error_response(send, "invalid_archive")
+
+        _, send = self.handle_request({"op": "unknown", "line": "1"})
+        self.assert_error_response(send, "unsupported_operation")
+
+        connection = mock.Mock()
+        with mock.patch.object(self.server, "_peer_credentials", return_value=(1, 0, 0)), \
+                mock.patch.object(console_mirror, "recv_message", return_value=None), \
+                mock.patch.object(console_mirror, "send_message") as send:
+            self.server._handle_client(connection)
+        send.assert_not_called()
+
+    def test_handle_client_returns_manager_error_details_and_tolerates_disconnect(self):
+        self.manager.status.side_effect = console_mirror.MirrorError(
+            "status_failed", "failed", retry_after=3
+        )
+        connection, send = self.handle_request({"op": "status", "line": "1"})
+        self.assertEqual(
+            send.call_args.args[1],
+            {
+                "status": "error",
+                "code": "status_failed",
+                "message": "failed",
+                "retry_after": 3,
+            },
+        )
+
+        with mock.patch.object(self.server, "_peer_credentials", return_value=(1, 1000, 1000)), \
+                mock.patch.object(console_mirror, "send_message", side_effect=OSError("closed")):
+            self.server._handle_client(connection)
+
+    def test_handle_client_reports_unexpected_error_while_sending_error_response(self):
+        connection = mock.Mock()
+        with mock.patch.object(self.server, "_peer_credentials", return_value=(1, 1000, 1000)), \
+                mock.patch.object(console_mirror, "send_message", side_effect=[ValueError("encode"), None]) as send, \
+                mock.patch.object(console_mirror.log, "exception") as log_exception:
+            self.server._handle_client(connection)
+        log_exception.assert_called_once_with("[%s] Unexpected mirror control error", "1")
+        self.assertEqual(send.call_args_list[1].args[1]["code"], "internal_error")
+
+        with mock.patch.object(self.server, "_peer_credentials", return_value=(1, 1000, 1000)), \
+                mock.patch.object(
+                    console_mirror,
+                    "send_message",
+                    side_effect=[ValueError("encode"), OSError("closed")],
+                ):
+            self.server._handle_client(connection)
+
+    def test_stop_closes_server_joins_workers_and_removes_socket(self):
+        server_socket = mock.Mock()
+        server_thread = mock.Mock()
+        alive_client = mock.Mock()
+        alive_client.is_alive.return_value = True
+        finished_client = mock.Mock()
+        finished_client.is_alive.return_value = False
+        self.server._socket = server_socket
+        self.server._thread = server_thread
+        self.server._running.set()
+        self.server._client_threads = [alive_client, finished_client]
+
+        with mock.patch.object(console_mirror.os, "unlink") as unlink:
+            self.server.stop()
+        self.assertFalse(self.server._running.is_set())
+        server_socket.close.assert_called_once_with()
+        self.assertIsNone(self.server._socket)
+        server_thread.join.assert_called_once_with(1.0)
+        self.assertIsNone(self.server._thread)
+        alive_client.join.assert_called_once_with(0.1)
+        finished_client.join.assert_not_called()
+        unlink.assert_called_once_with(self.server.socket_path)
+
+    def test_stop_handles_missing_socket_and_logs_other_cleanup_errors(self):
+        missing = OSError(errno.ENOENT, "missing")
+        with mock.patch.object(console_mirror.os, "unlink", side_effect=missing), \
+                mock.patch.object(console_mirror.log, "warning") as warning:
+            self.server.stop()
+        warning.assert_not_called()
+
+        denied = OSError(errno.EACCES, "denied")
+        with mock.patch.object(console_mirror.os, "unlink", side_effect=denied), \
+                mock.patch.object(console_mirror.log, "warning") as warning:
+            self.server.stop()
+        warning.assert_called_once_with(
+            "Failed to remove mirror control socket %s: %s",
+            self.server.socket_path,
+            denied,
+        )

--- a/tests/console_monitor/console_mirror_test.py
+++ b/tests/console_monitor/console_mirror_test.py
@@ -25,17 +25,21 @@ class TestFormatting(TestCase):
         for invalid in ("0s", "-1h", "1.5h", "forever", "1h30m", 123, "10x", "999999d"):
             with self.assertRaises(
                 console_mirror.MirrorError,
-                msg="{} should be invalid".format(invalid),
+                msg=f"{invalid} should be invalid",
             ):
                 console_mirror.parse_duration(invalid)
 
     def test_printable_escape_is_utf8_readable_and_terminal_safe(self):
-        payload = "SONiC é你好😀".encode("utf-8") + b"\n\r\t\\\x1b[31m\x00\xff\xfe\x80\x9f"
+        payload = (
+            "SONiC é你好😀".encode("utf-8") + b"\n\r\t\\\x1b[31m\x00\xff\xfe\x80\x9f"
+        )
         self.assertEqual(
             console_mirror.printable_escape(payload),
             r"SONiC é你好😀\n\r\t\\\x1b[31m\x00\xff\xfe\x80\x9f",
         )
-        self.assertEqual(console_mirror.printable_escape("\u200b".encode("utf-8")), r"\xe2\x80\x8b")
+        self.assertEqual(
+            console_mirror.printable_escape("\u200b".encode("utf-8")), r"\xe2\x80\x8b"
+        )
 
     def test_secure_directory_rejects_symbolic_link(self):
         with tempfile.TemporaryDirectory() as tempdir:
@@ -78,7 +82,9 @@ class TestRecordingWriter(TestCase):
         path = writer.file_path
         self.assertTrue(writer.submit_data("rx", b"Booting SONiC\n"))
         self.assertTrue(writer.submit_data("tx", bytearray(b"\x1b[2Jshow\n")))
-        self.assertTrue(writer.submit_event({"event": "stop", "reason": "manual", "text": "你好"}))
+        self.assertTrue(
+            writer.submit_event({"event": "stop", "reason": "manual", "text": "你好"})
+        )
         writer.close()
 
         self.assertFalse(writer.submit_data("rx", b"after close"))
@@ -90,11 +96,15 @@ class TestRecordingWriter(TestCase):
             lines = recording.read().splitlines()
         self.assertEqual(lines[0], "# SONIC_CONSOLE_MIRROR_TEXT version=1")
         self.assertIn("line=1 direction=both", lines[1])
-        self.assertRegex(lines[3], r"^[^ ]+ \+[0-9]{12}ms 00000001 RX 00000014 Booting SONiC\\n$")
+        self.assertRegex(
+            lines[3], r"^[^ ]+ \+[0-9]{12}ms 00000001 RX 00000014 Booting SONiC\\n$"
+        )
         self.assertIn(r"TX 00000009 \x1b[2Jshow\n", lines[4])
-        self.assertTrue(lines[5].endswith(
-            'EVENT 00000050 {"event":"stop","reason":"manual","text":"你好"}'
-        ))
+        self.assertTrue(
+            lines[5].endswith(
+                'EVENT 00000050 {"event":"stop","reason":"manual","text":"你好"}'
+            )
+        )
 
     def test_rejects_invalid_line_and_direction(self):
         with self.assertRaises(console_mirror.MirrorError) as caught:
@@ -106,9 +116,11 @@ class TestRecordingWriter(TestCase):
         self.assertEqual(caught.exception.code, "invalid_direction")
 
     def test_root_owned_directories_and_recording_file(self):
-        with mock.patch.object(console_mirror.os, "geteuid", return_value=0), \
-                mock.patch.object(console_mirror.os, "chown") as chown, \
-                mock.patch.object(console_mirror.os, "fchown") as fchown:
+        with (
+            mock.patch.object(console_mirror.os, "geteuid", return_value=0),
+            mock.patch.object(console_mirror.os, "chown") as chown,
+            mock.patch.object(console_mirror.os, "fchown") as fchown,
+        ):
             writer = self.create_writer(line="5", direction="tx")
             writer.close()
         self.assertEqual(chown.call_count, 2)
@@ -161,7 +173,9 @@ class TestRecordingWriter(TestCase):
 
     def test_render_record_clamps_delta_and_handles_event_payload(self):
         writer = self.create_writer()
-        before_start = console_mirror.WriterRecord("RX", b"\x00", writer.start_timestamp - 1)
+        before_start = console_mirror.WriterRecord(
+            "RX", b"\x00", writer.start_timestamp - 1
+        )
         far_future = console_mirror.WriterRecord(
             "EVENT",
             b'{"event":"future"}',
@@ -177,16 +191,22 @@ class TestRecordingWriter(TestCase):
         writer = object.__new__(console_mirror.RecordingWriter)
         writer._lock = mock.Mock()
         writer._lock.acquire.return_value = False
-        self.assertFalse(writer._submit(mock.sentinel.record, priority=False, nonblocking=True))
+        self.assertFalse(
+            writer._submit(mock.sentinel.record, priority=False, nonblocking=True)
+        )
         writer._lock.release.assert_not_called()
 
         writer._lock = threading.Lock()
         writer._accepting = True
         writer.queue_size = 0
         writer._queue = queue.Queue(maxsize=1)
-        self.assertFalse(writer._submit(mock.sentinel.record, priority=False, nonblocking=False))
+        self.assertFalse(
+            writer._submit(mock.sentinel.record, priority=False, nonblocking=False)
+        )
         writer._queue.put_nowait(mock.sentinel.queued)
-        self.assertFalse(writer._submit(mock.sentinel.record, priority=True, nonblocking=False))
+        self.assertFalse(
+            writer._submit(mock.sentinel.record, priority=True, nonblocking=False)
+        )
 
     def test_prepare_paths_retries_collision_and_reports_exhaustion(self):
         writer = object.__new__(console_mirror.RecordingWriter)
@@ -195,16 +215,20 @@ class TestRecordingWriter(TestCase):
         writer.line = "4"
         writer.direction = "both"
         writer._open_part = mock.Mock(side_effect=[FileExistsError(), None])
-        with mock.patch.object(console_mirror, "_ensure_secure_directory"), \
-                mock.patch.object(console_mirror.time, "sleep") as sleep:
+        with (
+            mock.patch.object(console_mirror, "_ensure_secure_directory"),
+            mock.patch.object(console_mirror.time, "sleep") as sleep,
+        ):
             writer._prepare_paths_and_open()
         self.assertEqual(writer._open_part.call_count, 2)
         sleep.assert_called_once_with(0.000001)
 
         writer._open_part = mock.Mock(side_effect=FileExistsError("collision"))
-        with mock.patch.object(console_mirror, "_ensure_secure_directory"), \
-                mock.patch.object(console_mirror.time, "sleep"), \
-                self.assertRaises(console_mirror.MirrorError) as caught:
+        with (
+            mock.patch.object(console_mirror, "_ensure_secure_directory"),
+            mock.patch.object(console_mirror.time, "sleep"),
+            self.assertRaises(console_mirror.MirrorError) as caught,
+        ):
             writer._prepare_paths_and_open()
         self.assertEqual(caught.exception.code, "file_open_failed")
         self.assertIsInstance(caught.exception.__cause__, FileExistsError)
@@ -213,11 +237,15 @@ class TestRecordingWriter(TestCase):
     def test_open_part_cleans_up_descriptor_when_setup_fails(self):
         writer = object.__new__(console_mirror.RecordingWriter)
         writer.recording_prefix = os.path.join(self.tempdir.name, "recording")
-        with mock.patch.object(console_mirror.os, "open", return_value=42), \
-                mock.patch.object(console_mirror.os, "fchmod", side_effect=OSError("chmod")), \
-                mock.patch.object(console_mirror.os, "close") as close, \
-                mock.patch.object(console_mirror.os, "unlink") as unlink, \
-                self.assertRaisesRegex(OSError, "chmod"):
+        with (
+            mock.patch.object(console_mirror.os, "open", return_value=42),
+            mock.patch.object(
+                console_mirror.os, "fchmod", side_effect=OSError("chmod")
+            ),
+            mock.patch.object(console_mirror.os, "close") as close,
+            mock.patch.object(console_mirror.os, "unlink") as unlink,
+            self.assertRaisesRegex(OSError, "chmod"),
+        ):
             writer._open_part(1)
         close.assert_called_once_with(42)
         unlink.assert_called_once_with(writer.recording_prefix + "-part0001.log")
@@ -232,12 +260,16 @@ class TestRecordingWriter(TestCase):
         writer.direction = "rx"
         writer.start_timestamp = 0
         writer.timeout_text = "1h"
-        with mock.patch.object(console_mirror.os, "open", return_value=42), \
-                mock.patch.object(console_mirror.os, "fchmod"), \
-                mock.patch.object(console_mirror.os, "geteuid", return_value=1000), \
-                mock.patch.object(console_mirror.os, "fdopen", return_value=broken_file), \
-                mock.patch.object(console_mirror.os, "unlink", side_effect=OSError("unlink")), \
-                self.assertRaisesRegex(OSError, "write"):
+        with (
+            mock.patch.object(console_mirror.os, "open", return_value=42),
+            mock.patch.object(console_mirror.os, "fchmod"),
+            mock.patch.object(console_mirror.os, "geteuid", return_value=1000),
+            mock.patch.object(console_mirror.os, "fdopen", return_value=broken_file),
+            mock.patch.object(
+                console_mirror.os, "unlink", side_effect=OSError("unlink")
+            ),
+            self.assertRaisesRegex(OSError, "write"),
+        ):
             writer._open_part(1, exclusive=False)
         broken_file.close.assert_called_once_with()
 
@@ -324,15 +356,17 @@ class TestRecordingArchiver(TestCase):
         self.archivers.append(archiver)
         return archiver
 
-    def make_job(self, part_numbers=(1,), prefix_name="console-mirror-line1-both-session"):
+    def make_job(
+        self, part_numbers=(1,), prefix_name="console-mirror-line1-both-session"
+    ):
         line_dir = os.path.join(self.tempdir.name, "line1")
         os.makedirs(line_dir, exist_ok=True)
         prefix = os.path.join(line_dir, prefix_name)
         sources = []
         for number in part_numbers:
-            source = "{}-part{:04d}.log".format(prefix, number)
+            source = f"{prefix}-part{number:04d}.log"
             with open(source, "wb") as stream:
-                stream.write("part{}".format(number).encode("ascii"))
+                stream.write(f"part{number}".encode("ascii"))
             sources.append(source)
         job = console_mirror.ArchiveJob(
             "1", "both", time.time(), prefix, prefix + ".zip", "manual"
@@ -359,22 +393,30 @@ class TestRecordingArchiver(TestCase):
         self.assertEqual(stat.S_IMODE(os.stat(result.archive_path).st_mode), 0o600)
         with zipfile.ZipFile(result.archive_path) as archive:
             self.assertIsNone(archive.testzip())
-            self.assertEqual(archive.namelist(), [os.path.basename(path) for path in sources])
+            self.assertEqual(
+                archive.namelist(), [os.path.basename(path) for path in sources]
+            )
 
     def test_archive_file_is_root_owned_when_running_as_root(self):
         job, _ = self.make_job((1,), "root-owned")
-        with mock.patch.object(console_mirror.os, "geteuid", return_value=0), \
-                mock.patch.object(console_mirror.os, "fchown") as fchown:
+        with (
+            mock.patch.object(console_mirror.os, "geteuid", return_value=0),
+            mock.patch.object(console_mirror.os, "fchown") as fchown,
+        ):
             result = console_mirror.RecordingArchiver._archive(job, threading.Event())
         self.assertEqual(result.archive_path, job.archive_path)
         fchown.assert_called_once()
 
     def test_missing_and_noncontiguous_parts_are_rejected(self):
         for part_numbers in ((), (2,), (1, 3)):
-            job, sources = self.make_job(part_numbers, "session-{}".format(len(part_numbers)))
+            job, sources = self.make_job(
+                part_numbers, f"session-{len(part_numbers)}"
+            )
             self.assert_mirror_error(
                 "archive_failed",
-                lambda job=job: console_mirror.RecordingArchiver._archive(job, threading.Event()),
+                lambda job=job: console_mirror.RecordingArchiver._archive(
+                    job, threading.Event()
+                ),
             )
             self.assertTrue(all(os.path.exists(source) for source in sources))
             self.assertFalse(os.path.exists(job.archive_path))
@@ -442,11 +484,13 @@ class TestRecordingArchiver(TestCase):
             [False, False, False, True],
         )
         for index, sequence in enumerate(checkpoints):
-            job, sources = self.make_job((1,), "cancel-{}".format(index))
+            job, sources = self.make_job((1,), f"cancel-{index}")
             self.assert_mirror_error(
                 "archive_cancelled",
-                lambda job=job, sequence=sequence: console_mirror.RecordingArchiver._archive(
-                    job, SequencedEvent(sequence)
+                lambda job=job, sequence=sequence: (
+                    console_mirror.RecordingArchiver._archive(
+                        job, SequencedEvent(sequence)
+                    )
                 ),
             )
             self.assertTrue(os.path.exists(sources[0]))
@@ -456,7 +500,7 @@ class TestRecordingArchiver(TestCase):
         real_zip_file = console_mirror.zipfile.ZipFile
         validation_results = (("bad-entry", [mock.sentinel.info]), (None, []))
         for index, (bad_entry, infos) in enumerate(validation_results):
-            job, sources = self.make_job((1,), "invalid-zip-{}".format(index))
+            job, sources = self.make_job((1,), f"invalid-zip-{index}")
             invalid_archive = mock.MagicMock()
             invalid_archive.__enter__.return_value.testzip.return_value = bad_entry
             invalid_archive.__enter__.return_value.infolist.return_value = infos
@@ -466,7 +510,9 @@ class TestRecordingArchiver(TestCase):
                     return invalid_archive
                 return real_zip_file(file, mode, *args, **kwargs)
 
-            with mock.patch.object(console_mirror.zipfile, "ZipFile", side_effect=zip_file):
+            with mock.patch.object(
+                console_mirror.zipfile, "ZipFile", side_effect=zip_file
+            ):
                 self.assert_mirror_error(
                     "archive_failed",
                     lambda job=job: console_mirror.RecordingArchiver._archive(
@@ -494,21 +540,31 @@ class TestRecordingArchiver(TestCase):
 
     def test_archive_wraps_creation_errors_and_closes_unwrapped_descriptor(self):
         job, sources = self.make_job((1,), "open-failure")
-        with mock.patch.object(console_mirror.os, "open", side_effect=OSError("no space")):
+        with mock.patch.object(
+            console_mirror.os, "open", side_effect=OSError("no space")
+        ):
             error = self.assert_mirror_error(
                 "archive_failed",
-                lambda: console_mirror.RecordingArchiver._archive(job, threading.Event()),
+                lambda: console_mirror.RecordingArchiver._archive(
+                    job, threading.Event()
+                ),
             )
         self.assertIn("no space", error.message)
         self.assertTrue(os.path.exists(sources[0]))
 
         job, _ = self.make_job((1,), "fdopen-failure")
         real_close = os.close
-        with mock.patch.object(console_mirror.os, "fdopen", side_effect=OSError("fdopen")), \
-                mock.patch.object(console_mirror.os, "close", wraps=real_close) as close:
+        with (
+            mock.patch.object(
+                console_mirror.os, "fdopen", side_effect=OSError("fdopen")
+            ),
+            mock.patch.object(console_mirror.os, "close", wraps=real_close) as close,
+        ):
             self.assert_mirror_error(
                 "archive_failed",
-                lambda: console_mirror.RecordingArchiver._archive(job, threading.Event()),
+                lambda: console_mirror.RecordingArchiver._archive(
+                    job, threading.Event()
+                ),
             )
         close.assert_called_once()
         self.assertFalse(os.path.exists(job.archive_path + ".tmp"))
@@ -516,12 +572,16 @@ class TestRecordingArchiver(TestCase):
     def test_temporary_cleanup_failure_is_logged(self):
         job, _ = self.make_job((1,), "cleanup-failure")
         cleanup_error = OSError(errno.EACCES, "permission denied")
-        with mock.patch.object(console_mirror.os, "open", side_effect=OSError("create")), \
-                mock.patch.object(console_mirror.os, "unlink", side_effect=cleanup_error), \
-                mock.patch.object(console_mirror.log, "warning") as warning:
+        with (
+            mock.patch.object(console_mirror.os, "open", side_effect=OSError("create")),
+            mock.patch.object(console_mirror.os, "unlink", side_effect=cleanup_error),
+            mock.patch.object(console_mirror.log, "warning") as warning,
+        ):
             self.assert_mirror_error(
                 "archive_failed",
-                lambda: console_mirror.RecordingArchiver._archive(job, threading.Event()),
+                lambda: console_mirror.RecordingArchiver._archive(
+                    job, threading.Event()
+                ),
             )
         warning.assert_called_once_with(
             "Failed to remove temporary archive %s: %s",
@@ -580,7 +640,9 @@ class TestMirrorManager(TestCase):
             self.timers.append(timer)
             return timer
 
-        self.timer_patch = mock.patch.object(console_mirror.threading, "Timer", side_effect=make_timer)
+        self.timer_patch = mock.patch.object(
+            console_mirror.threading, "Timer", side_effect=make_timer
+        )
         self.timer_patch.start()
 
     def tearDown(self):
@@ -633,9 +695,17 @@ class TestMirrorManager(TestCase):
         self.state_table.set.assert_called_once_with("7", [("state", "idle")])
         self.assertEqual(
             [call.args for call in self.state_table.hdel.call_args_list],
-            [("7", field) for field in (
-                "owner_pid", "started_by", "start_time", "timeout", "file_path", "direction"
-            )],
+            [
+                ("7", field)
+                for field in (
+                    "owner_pid",
+                    "started_by",
+                    "start_time",
+                    "timeout",
+                    "file_path",
+                    "direction",
+                )
+            ],
         )
 
         broken_table = mock.Mock()
@@ -710,11 +780,16 @@ class TestMirrorManager(TestCase):
         )
         self.assertEqual(manager._owner_pid, 1234)
         self.assertEqual(manager._started_by, "root")
-        self.assert_error("mirror_already_active", lambda: manager.start({"owner_pid": 1234}))
+        self.assert_error(
+            "mirror_already_active", lambda: manager.start({"owner_pid": 1234})
+        )
 
         for direction in ("sideways", 1):
             fresh = self.make_manager()
-            self.assert_error("invalid_direction", lambda direction=direction: fresh.start({"direction": direction}))
+            self.assert_error(
+                "invalid_direction",
+                lambda direction=direction: fresh.start({"direction": direction}),
+            )
         for size in (True, "8", 0, -1):
             fresh = self.make_manager()
             self.assert_error(
@@ -749,7 +824,9 @@ class TestMirrorManager(TestCase):
             expected,
         )
 
-        manager = self.make_manager(writer_factory=mock.Mock(side_effect=OSError("disk error")))
+        manager = self.make_manager(
+            writer_factory=mock.Mock(side_effect=OSError("disk error"))
+        )
         error = self.assert_error(
             "file_open_failed", lambda: manager.start({"owner_pid": 1234})
         )
@@ -832,15 +909,19 @@ class TestMirrorManager(TestCase):
 
         manager.writer = self.writer
         manager.start_time = 0
-        with mock.patch.object(console_mirror.time, "time", return_value=console_mirror.MAX_DELTA_MS / 1000):
+        with mock.patch.object(
+            console_mirror.time, "time", return_value=console_mirror.MAX_DELTA_MS / 1000
+        ):
             self.assert_error("invalid_timeout", lambda: manager.update_timeout("1s"))
 
     def test_update_timeout_replaces_timer_and_updates_writer_and_state(self):
         manager, _ = self.start_manager()
         previous = manager.timer
         manager.start_time = 100.0
-        with mock.patch.object(console_mirror.time, "time", return_value=99.0), \
-                mock.patch.object(console_mirror.time, "monotonic", return_value=500.0):
+        with (
+            mock.patch.object(console_mirror.time, "time", return_value=99.0),
+            mock.patch.object(console_mirror.time, "monotonic", return_value=500.0),
+        ):
             response = manager.update_timeout("30m")
 
         replacement = manager.timer
@@ -851,8 +932,12 @@ class TestMirrorManager(TestCase):
         self.assertEqual(manager.timeout_seconds, 1800)
         self.assertEqual(manager.deadline, 2300.0)
         self.writer.update_timeout.assert_called_once_with("30m")
-        self.writer.submit_event.assert_called_with({"event": "timeout_update", "timeout": "30m"})
-        self.assertEqual(response, {"status": "ok", "timeout": "30m", "remaining": "30m"})
+        self.writer.submit_event.assert_called_with(
+            {"event": "timeout_update", "timeout": "30m"}
+        )
+        self.assertEqual(
+            response, {"status": "ok", "timeout": "30m", "remaining": "30m"}
+        )
 
         with mock.patch.object(manager, "_on_timeout") as on_timeout:
             replacement.fire()
@@ -868,7 +953,9 @@ class TestMirrorManager(TestCase):
         previous = manager.timer
         previous_deadline = manager.deadline
         self.next_timer_error = RuntimeError("cannot start")
-        error = self.assert_error("timer_setup_failed", lambda: manager.update_timeout("30m"))
+        error = self.assert_error(
+            "timer_setup_failed", lambda: manager.update_timeout("30m")
+        )
 
         self.assertIn("cannot start", error.message)
         self.assertIs(manager.timer, previous)
@@ -882,6 +969,7 @@ class TestMirrorManager(TestCase):
         manager, _ = self.start_manager()
         timer = manager.timer
         states_seen = []
+
         def capture_state(line, values):
             states_seen.append(dict(values)["state"])
 
@@ -889,7 +977,9 @@ class TestMirrorManager(TestCase):
         response = manager.stop(reason="manual", archive=False)
 
         self.assertTrue(timer.cancelled)
-        self.writer.submit_event.assert_called_with({"event": "stop", "reason": "manual"})
+        self.writer.submit_event.assert_called_with(
+            {"event": "stop", "reason": "manual"}
+        )
         self.writer.close.assert_called_once_with()
         self.assertEqual(states_seen, ["stopping", "idle"])
         self.assertEqual(manager.state, "idle")
@@ -912,7 +1002,10 @@ class TestMirrorManager(TestCase):
         self.assert_error("mirror_not_active", manager.stop)
 
         manager, _ = self.start_manager(self.make_manager())
-        self.assert_error("stale_timeout", lambda: manager.stop(expected_timer=FakeTimer(1, lambda: None)))
+        self.assert_error(
+            "stale_timeout",
+            lambda: manager.stop(expected_timer=FakeTimer(1, lambda: None)),
+        )
         self.assertEqual(manager.state, "active")
 
         manager.timer = None
@@ -922,7 +1015,9 @@ class TestMirrorManager(TestCase):
     def test_stop_does_not_clear_a_writer_replaced_while_old_writer_closes(self):
         manager, _ = self.start_manager()
         replacement_writer = mock.Mock()
-        self.writer.close.side_effect = lambda: setattr(manager, "writer", replacement_writer)
+        self.writer.close.side_effect = lambda: setattr(
+            manager, "writer", replacement_writer
+        )
 
         manager.stop()
 
@@ -933,7 +1028,9 @@ class TestMirrorManager(TestCase):
         handle = mock.sentinel.archive_handle
         self.archiver.submit.return_value = handle
         manager, _ = self.start_manager(direction="rx")
-        response = manager.stop(reason="timeout", archive=True, expected_timer=manager.timer)
+        response = manager.stop(
+            reason="timeout", archive=True, expected_timer=manager.timer
+        )
 
         job = self.archiver.submit.call_args.args[0]
         self.assertEqual(
@@ -948,7 +1045,9 @@ class TestMirrorManager(TestCase):
             ),
         )
         self.assertEqual(response["status"], "packaging")
-        self.assertEqual(response["archive_path"], self.writer.recording_prefix + ".zip")
+        self.assertEqual(
+            response["archive_path"], self.writer.recording_prefix + ".zip"
+        )
         self.assertIs(response["archive_handle"], handle)
         self.assertEqual(manager.state, "idle")
 
@@ -956,7 +1055,10 @@ class TestMirrorManager(TestCase):
         expected = console_mirror.MirrorError("archive_queue_full", "full")
         self.archiver.submit.side_effect = expected
         manager, _ = self.start_manager()
-        self.assertIs(self.assert_error("archive_queue_full", lambda: manager.stop(archive=True)), expected)
+        self.assertIs(
+            self.assert_error("archive_queue_full", lambda: manager.stop(archive=True)),
+            expected,
+        )
         self.assertEqual(manager.state, "idle")
 
         self.archiver.submit.side_effect = RuntimeError("executor stopped")
@@ -967,7 +1069,9 @@ class TestMirrorManager(TestCase):
 
     def test_status_reports_idle_active_stopping_and_clamps_remaining(self):
         manager = self.make_manager()
-        self.assertEqual(manager.status(), {"status": "ok", "state": "idle", "line": "1"})
+        self.assertEqual(
+            manager.status(), {"status": "ok", "state": "idle", "line": "1"}
+        )
 
         manager, _ = self.start_manager(manager, direction="tx", timeout="1m")
         manager.deadline = 101.2
@@ -989,7 +1093,9 @@ class TestMirrorManager(TestCase):
         timer = FakeTimer(1, lambda: None)
         manager.stop = mock.Mock()
         manager._on_timeout(timer)
-        manager.stop.assert_called_once_with(reason="timeout", archive=True, expected_timer=timer)
+        manager.stop.assert_called_once_with(
+            reason="timeout", archive=True, expected_timer=timer
+        )
 
         for code in ("mirror_not_active", "stale_timeout"):
             manager.stop.side_effect = console_mirror.MirrorError(code, code)
@@ -997,7 +1103,9 @@ class TestMirrorManager(TestCase):
                 manager._on_timeout(timer)
             log_error.assert_not_called()
 
-        manager.stop.side_effect = console_mirror.MirrorError("archive_failed", "broken archive")
+        manager.stop.side_effect = console_mirror.MirrorError(
+            "archive_failed", "broken archive"
+        )
         with mock.patch.object(console_mirror.log, "error") as log_error:
             manager._on_timeout(timer)
         log_error.assert_called_once_with(
@@ -1007,8 +1115,12 @@ class TestMirrorManager(TestCase):
     def test_writer_fatal_callback_starts_named_daemon_stop_thread(self):
         manager = self.make_manager()
         thread = mock.Mock()
-        with mock.patch.object(console_mirror.threading, "Thread", return_value=thread) as thread_type, \
-                mock.patch.object(console_mirror.log, "error") as log_error:
+        with (
+            mock.patch.object(
+                console_mirror.threading, "Thread", return_value=thread
+            ) as thread_type,
+            mock.patch.object(console_mirror.log, "error") as log_error,
+        ):
             manager._on_writer_fatal(self.writer, OSError("disk full"))
         log_error.assert_called_once()
         thread_type.assert_called_once_with(
@@ -1034,7 +1146,9 @@ class TestMirrorManager(TestCase):
         manager._stop_after_writer_error(self.writer)
         manager.stop.assert_called_once_with(reason="writer_error", archive=False)
 
-        manager.stop.side_effect = console_mirror.MirrorError("mirror_not_active", "raced")
+        manager.stop.side_effect = console_mirror.MirrorError(
+            "mirror_not_active", "raced"
+        )
         manager._stop_after_writer_error(self.writer)
 
     def test_rotate_updates_only_an_active_session(self):
@@ -1061,12 +1175,16 @@ class TestMirrorManager(TestCase):
     def test_shutdown_stops_active_session_and_always_shuts_down_archiver(self):
         manager, _ = self.start_manager()
         manager.shutdown(archive_timeout=2.5)
-        self.writer.submit_event.assert_called_with({"event": "stop", "reason": "proxy_shutdown"})
+        self.writer.submit_event.assert_called_with(
+            {"event": "stop", "reason": "proxy_shutdown"}
+        )
         self.archiver.shutdown.assert_called_once_with(timeout=2.5)
         self.assertEqual(manager.state, "idle")
 
         manager = self.make_manager()
-        manager.stop = mock.Mock(side_effect=console_mirror.MirrorError("raced", "raced"))
+        manager.stop = mock.Mock(
+            side_effect=console_mirror.MirrorError("raced", "raced")
+        )
         manager.state = "active"
         manager.shutdown(archive_timeout=1)
         manager.stop.assert_called_once_with(reason="proxy_shutdown", archive=False)
@@ -1090,7 +1208,10 @@ class TestControlMessageProtocol(TestCase):
         if chunk_size is None:
             chunks = [data]
         else:
-            chunks = [data[index:index + chunk_size] for index in range(0, len(data), chunk_size)]
+            chunks = [
+                data[index : index + chunk_size]
+                for index in range(0, len(data), chunk_size)
+            ]
         connection.recv.side_effect = chunks
         return connection
 
@@ -1150,7 +1271,9 @@ class TestControlMessageProtocol(TestCase):
         framed = connection.sendall.call_args.args[0]
         length = struct.unpack("!I", framed[:4])[0]
         self.assertEqual(length, len(framed[4:]))
-        self.assertEqual(json.loads(framed[4:].decode("utf-8")), {"status": "ok", "text": "你好"})
+        self.assertEqual(
+            json.loads(framed[4:].decode("utf-8")), {"status": "ok", "text": "你好"}
+        )
         self.assertNotIn(b" ", framed[4:])
 
 
@@ -1173,9 +1296,13 @@ class TestMirrorControlServer(TestCase):
 
     def handle_request(self, request, credentials=(4321, 0, 0)):
         connection = mock.Mock()
-        with mock.patch.object(self.server, "_peer_credentials", return_value=credentials), \
-                mock.patch.object(console_mirror, "recv_message", return_value=request), \
-                mock.patch.object(console_mirror, "send_message") as send:
+        with (
+            mock.patch.object(
+                self.server, "_peer_credentials", return_value=credentials
+            ),
+            mock.patch.object(console_mirror, "recv_message", return_value=request),
+            mock.patch.object(console_mirror, "send_message") as send,
+        ):
             self.server._handle_client(connection)
         return connection, send
 
@@ -1194,11 +1321,17 @@ class TestMirrorControlServer(TestCase):
         server_socket = mock.Mock()
         worker = mock.Mock()
         socket_info = mock.Mock(st_mode=stat.S_IFSOCK)
-        with mock.patch.object(console_mirror, "_ensure_secure_directory") as secure, \
-                mock.patch.object(console_mirror.os, "lstat", return_value=socket_info), \
-                mock.patch.object(console_mirror.os, "unlink") as unlink, \
-                mock.patch.object(console_mirror.socket, "socket", return_value=server_socket) as socket_type, \
-                mock.patch.object(console_mirror.threading, "Thread", return_value=worker) as thread_type:
+        with (
+            mock.patch.object(console_mirror, "_ensure_secure_directory") as secure,
+            mock.patch.object(console_mirror.os, "lstat", return_value=socket_info),
+            mock.patch.object(console_mirror.os, "unlink") as unlink,
+            mock.patch.object(
+                console_mirror.socket, "socket", return_value=server_socket
+            ) as socket_type,
+            mock.patch.object(
+                console_mirror.threading, "Thread", return_value=worker
+            ) as thread_type,
+        ):
             self.server.start()
 
         secure.assert_called_once_with("/runtime/mirror")
@@ -1218,27 +1351,47 @@ class TestMirrorControlServer(TestCase):
 
     def test_start_accepts_missing_socket_path_and_rejects_occupied_path(self):
         server_socket = mock.Mock()
-        with mock.patch.object(console_mirror, "_ensure_secure_directory"), \
-                mock.patch.object(console_mirror.os, "lstat", side_effect=FileNotFoundError), \
-                mock.patch.object(console_mirror.socket, "socket", return_value=server_socket), \
-                mock.patch.object(console_mirror.threading, "Thread", return_value=mock.Mock()):
+        with (
+            mock.patch.object(console_mirror, "_ensure_secure_directory"),
+            mock.patch.object(
+                console_mirror.os, "lstat", side_effect=FileNotFoundError
+            ),
+            mock.patch.object(
+                console_mirror.socket, "socket", return_value=server_socket
+            ),
+            mock.patch.object(
+                console_mirror.threading, "Thread", return_value=mock.Mock()
+            ),
+        ):
             self.server.start()
         self.assertIs(self.server._socket, server_socket)
 
-        with mock.patch.object(console_mirror, "_ensure_secure_directory"), \
-                mock.patch.object(console_mirror.os, "lstat", return_value=mock.Mock(st_mode=stat.S_IFREG)), \
-                self.assertRaises(console_mirror.MirrorError) as caught:
+        with (
+            mock.patch.object(console_mirror, "_ensure_secure_directory"),
+            mock.patch.object(
+                console_mirror.os, "lstat", return_value=mock.Mock(st_mode=stat.S_IFREG)
+            ),
+            self.assertRaises(console_mirror.MirrorError) as caught,
+        ):
             self.server.start()
         self.assertEqual(caught.exception.code, "unsafe_socket_path")
 
     def test_start_closes_socket_and_cleans_path_when_setup_fails(self):
         server_socket = mock.Mock()
         server_socket.bind.side_effect = OSError("bind failed")
-        with mock.patch.object(console_mirror, "_ensure_secure_directory"), \
-                mock.patch.object(console_mirror.os, "lstat", side_effect=FileNotFoundError), \
-                mock.patch.object(console_mirror.os, "unlink", side_effect=OSError("missing")), \
-                mock.patch.object(console_mirror.socket, "socket", return_value=server_socket), \
-                self.assertRaisesRegex(OSError, "bind failed"):
+        with (
+            mock.patch.object(console_mirror, "_ensure_secure_directory"),
+            mock.patch.object(
+                console_mirror.os, "lstat", side_effect=FileNotFoundError
+            ),
+            mock.patch.object(
+                console_mirror.os, "unlink", side_effect=OSError("missing")
+            ),
+            mock.patch.object(
+                console_mirror.socket, "socket", return_value=server_socket
+            ),
+            self.assertRaisesRegex(OSError, "bind failed"),
+        ):
             self.server.start()
         server_socket.close.assert_called_once_with()
 
@@ -1247,7 +1400,7 @@ class TestMirrorControlServer(TestCase):
         accepted = mock.Mock()
         self.server._socket = mock.Mock()
         self.server._socket.accept.side_effect = [
-            socket.timeout(),
+            TimeoutError(),
             (rejected, None),
             (accepted, None),
             OSError("closed"),
@@ -1258,7 +1411,9 @@ class TestMirrorControlServer(TestCase):
         self.server._clients.acquire.side_effect = [False, True]
         worker = mock.Mock()
 
-        with mock.patch.object(console_mirror.threading, "Thread", return_value=worker) as thread_type:
+        with mock.patch.object(
+            console_mirror.threading, "Thread", return_value=worker
+        ) as thread_type:
             self.server._serve()
 
         rejected.close.assert_called_once_with()
@@ -1311,16 +1466,22 @@ class TestMirrorControlServer(TestCase):
         connection = mock.Mock()
         handle = mock.Mock()
         handle.result.return_value = console_mirror.ArchiveResult("session.zip")
-        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]), \
-                mock.patch.object(console_mirror, "send_message") as send:
+        with (
+            mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]),
+            mock.patch.object(console_mirror, "send_message") as send,
+        ):
             self.server._send_archive_completion(connection, handle)
-        send.assert_called_once_with(connection, {"status": "ok", "archive_path": "session.zip"})
+        send.assert_called_once_with(
+            connection, {"status": "ok", "archive_path": "session.zip"}
+        )
 
         handle.result.return_value = console_mirror.ArchiveResult(
             "session.zip", ("part0001.log", "part0002.log")
         )
-        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]), \
-                mock.patch.object(console_mirror, "send_message") as send:
+        with (
+            mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]),
+            mock.patch.object(console_mirror, "send_message") as send,
+        ):
             self.server._send_archive_completion(connection, handle)
         self.assertEqual(
             send.call_args.args[1],
@@ -1336,8 +1497,10 @@ class TestMirrorControlServer(TestCase):
     def test_archive_completion_cancels_after_server_wait_budget(self):
         connection = mock.Mock()
         handle = mock.Mock()
-        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 14]), \
-                mock.patch.object(console_mirror, "send_message") as send:
+        with (
+            mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 14]),
+            mock.patch.object(console_mirror, "send_message") as send,
+        ):
             self.server._send_archive_completion(connection, handle)
         handle.cancel.assert_called_once_with()
         handle.result.assert_not_called()
@@ -1348,9 +1511,13 @@ class TestMirrorControlServer(TestCase):
         connection.recv.return_value = b""
         handle = mock.Mock()
         handle.result.side_effect = concurrent.futures.TimeoutError
-        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]), \
-                mock.patch.object(console_mirror.select, "select", return_value=([connection], [], [])), \
-                mock.patch.object(console_mirror, "send_message") as send:
+        with (
+            mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]),
+            mock.patch.object(
+                console_mirror.select, "select", return_value=([connection], [], [])
+            ),
+            mock.patch.object(console_mirror, "send_message") as send,
+        ):
             self.server._send_archive_completion(connection, handle)
         connection.recv.assert_called_once_with(1, socket.MSG_PEEK)
         handle.cancel.assert_not_called()
@@ -1362,27 +1529,45 @@ class TestMirrorControlServer(TestCase):
         handle = mock.Mock()
         result = console_mirror.ArchiveResult("session.zip")
         handle.result.side_effect = [concurrent.futures.TimeoutError, result]
-        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10, 10]), \
-                mock.patch.object(console_mirror.select, "select", return_value=([connection], [], [])), \
-                mock.patch.object(console_mirror, "send_message") as send:
+        with (
+            mock.patch.object(
+                console_mirror.time, "monotonic", side_effect=[10, 10, 10]
+            ),
+            mock.patch.object(
+                console_mirror.select, "select", return_value=([connection], [], [])
+            ),
+            mock.patch.object(console_mirror, "send_message") as send,
+        ):
             self.server._send_archive_completion(connection, handle)
         self.assertEqual(handle.result.call_count, 2)
-        send.assert_called_once_with(connection, {"status": "ok", "archive_path": "session.zip"})
+        send.assert_called_once_with(
+            connection, {"status": "ok", "archive_path": "session.zip"}
+        )
 
         handle.reset_mock()
         handle.result.side_effect = [concurrent.futures.TimeoutError, result]
-        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10, 10]), \
-                mock.patch.object(console_mirror.select, "select", return_value=([], [], [])), \
-                mock.patch.object(console_mirror, "send_message"):
+        with (
+            mock.patch.object(
+                console_mirror.time, "monotonic", side_effect=[10, 10, 10]
+            ),
+            mock.patch.object(
+                console_mirror.select, "select", return_value=([], [], [])
+            ),
+            mock.patch.object(console_mirror, "send_message"),
+        ):
             self.server._send_archive_completion(connection, handle)
         self.assertEqual(handle.result.call_count, 2)
 
     def test_archive_completion_reports_archive_and_unexpected_failures(self):
         connection = mock.Mock()
         handle = mock.Mock()
-        handle.result.side_effect = console_mirror.MirrorError("archive_failed", "zip failed")
-        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]), \
-                mock.patch.object(console_mirror, "send_message") as send:
+        handle.result.side_effect = console_mirror.MirrorError(
+            "archive_failed", "zip failed"
+        )
+        with (
+            mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]),
+            mock.patch.object(console_mirror, "send_message") as send,
+        ):
             self.server._send_archive_completion(connection, handle)
         self.assertEqual(
             send.call_args.args[1],
@@ -1394,8 +1579,10 @@ class TestMirrorControlServer(TestCase):
         )
 
         handle.result.side_effect = RuntimeError("worker crashed")
-        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]), \
-                mock.patch.object(console_mirror, "send_message") as send:
+        with (
+            mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]),
+            mock.patch.object(console_mirror, "send_message") as send,
+        ):
             self.server._send_archive_completion(connection, handle)
         self.assertEqual(send.call_args.args[1]["code"], "archive_failed")
         self.assertIn("worker crashed", send.call_args.args[1]["message"])
@@ -1404,8 +1591,12 @@ class TestMirrorControlServer(TestCase):
         connection = mock.Mock()
         handle = mock.Mock()
         handle.result.return_value = console_mirror.ArchiveResult("session.zip")
-        with mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]), \
-                mock.patch.object(console_mirror, "send_message", side_effect=OSError("disconnected")):
+        with (
+            mock.patch.object(console_mirror.time, "monotonic", side_effect=[10, 10]),
+            mock.patch.object(
+                console_mirror, "send_message", side_effect=OSError("disconnected")
+            ),
+        ):
             self.server._send_archive_completion(connection, handle)
 
     def test_handle_client_dispatches_start_with_authenticated_audit_metadata(self):
@@ -1422,14 +1613,18 @@ class TestMirrorControlServer(TestCase):
         options = self.manager.start.call_args.args[0]
         self.assertEqual(options["owner_pid"], 4321)
         self.assertEqual(options["started_by"], "admin")
-        send.assert_called_once_with(connection, {"status": "ok", "file_path": "part.log"})
+        send.assert_called_once_with(
+            connection, {"status": "ok", "file_path": "part.log"}
+        )
 
     def test_handle_client_falls_back_to_peer_username_or_uid(self):
         self.manager.start.return_value = {"status": "ok"}
         invalid_names = (None, "", "x" * 257)
         for name in invalid_names:
             self.manager.start.reset_mock()
-            with mock.patch.object(console_mirror.pwd, "getpwuid", return_value=mock.Mock(pw_name="root")):
+            with mock.patch.object(
+                console_mirror.pwd, "getpwuid", return_value=mock.Mock(pw_name="root")
+            ):
                 self.handle_request({"op": "start", "line": "1", "started_by": name})
             self.assertEqual(self.manager.start.call_args.args[0]["started_by"], "root")
 
@@ -1445,7 +1640,9 @@ class TestMirrorControlServer(TestCase):
             "archive_handle": handle,
         }
         with mock.patch.object(self.server, "_send_archive_completion") as completion:
-            connection, send = self.handle_request({"op": "stop", "line": "1", "archive": True})
+            connection, send = self.handle_request(
+                {"op": "stop", "line": "1", "archive": True}
+            )
         self.manager.stop.assert_called_once_with(reason="manual", archive=True)
         send.assert_called_once_with(
             connection, {"status": "packaging", "archive_path": "session.zip"}
@@ -1464,9 +1661,13 @@ class TestMirrorControlServer(TestCase):
         send.assert_called_once_with(connection, self.manager.status.return_value)
 
         self.manager.update_timeout.return_value = {"status": "ok", "timeout": "2h"}
-        connection, send = self.handle_request({"op": "timeout", "line": "1", "timeout": "2h"})
+        connection, send = self.handle_request(
+            {"op": "timeout", "line": "1", "timeout": "2h"}
+        )
         self.manager.update_timeout.assert_called_once_with("2h")
-        send.assert_called_once_with(connection, self.manager.update_timeout.return_value)
+        send.assert_called_once_with(
+            connection, self.manager.update_timeout.return_value
+        )
 
     def test_handle_client_rejects_unauthorized_mismatched_and_invalid_requests(self):
         connection, send = self.handle_request(
@@ -1484,9 +1685,11 @@ class TestMirrorControlServer(TestCase):
         self.assert_error_response(send, "unsupported_operation")
 
         connection = mock.Mock()
-        with mock.patch.object(self.server, "_peer_credentials", return_value=(1, 0, 0)), \
-                mock.patch.object(console_mirror, "recv_message", return_value=None), \
-                mock.patch.object(console_mirror, "send_message") as send:
+        with (
+            mock.patch.object(self.server, "_peer_credentials", return_value=(1, 0, 0)),
+            mock.patch.object(console_mirror, "recv_message", return_value=None),
+            mock.patch.object(console_mirror, "send_message") as send,
+        ):
             self.server._handle_client(connection)
         send.assert_not_called()
 
@@ -1505,25 +1708,43 @@ class TestMirrorControlServer(TestCase):
             },
         )
 
-        with mock.patch.object(self.server, "_peer_credentials", return_value=(1, 1000, 1000)), \
-                mock.patch.object(console_mirror, "send_message", side_effect=OSError("closed")):
+        with (
+            mock.patch.object(
+                self.server, "_peer_credentials", return_value=(1, 1000, 1000)
+            ),
+            mock.patch.object(
+                console_mirror, "send_message", side_effect=OSError("closed")
+            ),
+        ):
             self.server._handle_client(connection)
 
     def test_handle_client_reports_unexpected_error_while_sending_error_response(self):
         connection = mock.Mock()
-        with mock.patch.object(self.server, "_peer_credentials", return_value=(1, 1000, 1000)), \
-                mock.patch.object(console_mirror, "send_message", side_effect=[ValueError("encode"), None]) as send, \
-                mock.patch.object(console_mirror.log, "exception") as log_exception:
+        with (
+            mock.patch.object(
+                self.server, "_peer_credentials", return_value=(1, 1000, 1000)
+            ),
+            mock.patch.object(
+                console_mirror, "send_message", side_effect=[ValueError("encode"), None]
+            ) as send,
+            mock.patch.object(console_mirror.log, "exception") as log_exception,
+        ):
             self.server._handle_client(connection)
-        log_exception.assert_called_once_with("[%s] Unexpected mirror control error", "1")
+        log_exception.assert_called_once_with(
+            "[%s] Unexpected mirror control error", "1"
+        )
         self.assertEqual(send.call_args_list[1].args[1]["code"], "internal_error")
 
-        with mock.patch.object(self.server, "_peer_credentials", return_value=(1, 1000, 1000)), \
-                mock.patch.object(
-                    console_mirror,
-                    "send_message",
-                    side_effect=[ValueError("encode"), OSError("closed")],
-                ):
+        with (
+            mock.patch.object(
+                self.server, "_peer_credentials", return_value=(1, 1000, 1000)
+            ),
+            mock.patch.object(
+                console_mirror,
+                "send_message",
+                side_effect=[ValueError("encode"), OSError("closed")],
+            ),
+        ):
             self.server._handle_client(connection)
 
     def test_stop_closes_server_joins_workers_and_removes_socket(self):
@@ -1551,14 +1772,18 @@ class TestMirrorControlServer(TestCase):
 
     def test_stop_handles_missing_socket_and_logs_other_cleanup_errors(self):
         missing = OSError(errno.ENOENT, "missing")
-        with mock.patch.object(console_mirror.os, "unlink", side_effect=missing), \
-                mock.patch.object(console_mirror.log, "warning") as warning:
+        with (
+            mock.patch.object(console_mirror.os, "unlink", side_effect=missing),
+            mock.patch.object(console_mirror.log, "warning") as warning,
+        ):
             self.server.stop()
         warning.assert_not_called()
 
         denied = OSError(errno.EACCES, "denied")
-        with mock.patch.object(console_mirror.os, "unlink", side_effect=denied), \
-                mock.patch.object(console_mirror.log, "warning") as warning:
+        with (
+            mock.patch.object(console_mirror.os, "unlink", side_effect=denied),
+            mock.patch.object(console_mirror.log, "warning") as warning,
+        ):
             self.server.stop()
         warning.assert_called_once_with(
             "Failed to remove mirror control socket %s: %s",

--- a/tests/console_monitor/console_monitor_test.py
+++ b/tests/console_monitor/console_monitor_test.py
@@ -17,6 +17,7 @@ import sys
 import time
 import copy
 import termios
+import types
 from unittest import TestCase, mock
 from parameterized import parameterized
 
@@ -308,7 +309,7 @@ class TestDCEService(TestCase):
         with mock.patch.object(service, '_sync') as mock_sync:
             service.console_port_handler("1", "SET", {"baud_rate": "9600"})
             mock_sync.assert_called_once()
-    
+
     def test_dce_console_switch_handler_triggers_sync(self):
         """Test console_switch_handler triggers _sync on feature toggle."""
         MockConfigDb.set_config_db(DCE_3_LINKS_ENABLED_CONFIG_DB)
@@ -349,6 +350,33 @@ class TestDCEService(TestCase):
         self.assertEqual(len(received_frames), 1)  # Now we should have one frame
         self.assertTrue(received_frames[0].is_heartbeat())
         self.assertEqual(received_frames[0].seq, 10)
+
+
+class TestProxyMirrorHooks(TestCase):
+    """The proxy mirrors only bytes successfully forwarded on each path."""
+
+    def test_ptm_bytes_are_submitted_as_tx(self):
+        service = console_monitor.ProxyService("1")
+        service.running = True
+        service.ptm_fd = 10
+        service.ser_fd = 11
+        service.mirror_manager = mock.Mock()
+
+        with mock.patch.object(console_monitor.os, "read", return_value=b"show\n"), \
+                mock.patch.object(console_monitor.os, "write", return_value=5):
+            service._on_ptm_read()
+
+        service.mirror_manager.submit.assert_called_once_with("tx", b"show\n")
+
+    def test_filtered_serial_bytes_are_submitted_as_rx(self):
+        service = console_monitor.ProxyService("1")
+        service.ptm_fd = 10
+        service.mirror_manager = mock.Mock()
+
+        with mock.patch.object(console_monitor.os, "write", return_value=4):
+            service._on_user_data_received(b"boot")
+
+        service.mirror_manager.submit.assert_called_once_with("rx", b"boot")
 
 
 # ============================================================
@@ -2036,6 +2064,8 @@ class TestProxyServicePhases(TestCase):
             
             self.assertFalse(result)
     
+    @mock.patch.object(console_monitor, 'MirrorControlServer')
+    @mock.patch.object(console_monitor, 'MirrorManager')
     @mock.patch.object(console_monitor, 'configure_serial')
     @mock.patch.object(console_monitor, 'set_nonblocking')
     @mock.patch('os.open', return_value=12)


### PR DESCRIPTION
#### What I did

Implemented the host-service component of the Console Mirror feature described
in [HLD](https://github.com/sonic-net/SONiC/pull/2388).

#### Why I did it

Operators need an on-device way to record console traffic for troubleshooting
without interrupting the existing serial forwarding path.

#### How I did it

- Added `host_modules/console_mirror.py`:
- Updated `console-monitor proxy` to:
  - create a mirror manager and control server for each proxy instance
  - submit RX and TX payloads after successful forwarding