### PR TITLE
Remove pmon.service from gnoi-shutdown.service Wants dependency

### DIFF
--- a/data/debian/sonic-host-services-data.gnoi-shutdown.service
+++ b/data/debian/sonic-host-services-data.gnoi-shutdown.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=gNOI based DPU Graceful Shutdown Daemon
 Requires=database.service
-Wants=network-online.target gnmi.service pmon.service
+Wants=network-online.target gnmi.service
 After=network-online.target database.service gnmi.service pmon.service
 
 [Service]


### PR DESCRIPTION
gnoi-shutdown.service has WantedBy=multi-user.target, so its Wants=pmon.service (added by #343) causes systemd to pull pmon into the boot sequence. This bypasses featured's delayed startup gating for pmon, allowing xcvrd to start before orchagent completes warm restart port reconciliation. When orchagent bounces admin_state to re-apply FEC/serdes settings, the host_tx_ready toggle triggers xcvrd to disable/enable TX lanes on optics ports, causing MAC_REMOTE_FAULT link flaps.

Keep pmon.service in After= to preserve startup ordering without forcing pmon to start. This is consistent with the original wait-for-sonic-core.sh (removed by #343) which treated pmon as advisory.

Fixes: https://github.com/sonic-net/sonic-buildimage/issues/28758

#### Which release branch to backport (provide reason below if selected)
- [x] 202605

#### Tested branch
- [x] 202605

#### Test result
202605: upgrade_path/test_upgrade_path.py passed on DUT with optics ports