### PR TITLE
[ci] Use new sonic-slave image tag format

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ stages:
       vmImage: ubuntu-24.04
 
     container:
-      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm-amd64:$(BUILD_BRANCH)
+      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)-amd64
 
     steps:
     - checkout: self


### PR DESCRIPTION
#### Why I did it
The sonic-slave image naming strategy was updated by sonic-net/sonic-buildimage#24922. Architecture is now part of the image tag rather than the image name.
#### How I did it
Updated the Azure Pipeline container image from:
`sonic-slave-bookworm-amd64:$(BUILD_BRANCH)`
to:
`sonic-slave-bookworm:$(BUILD_BRANCH)-amd64`
#### How to verify it
Confirm the Azure Pipeline starts successfully using the new amd64 sonic-slave image tag.