### PR TITLE
gnoi-shutdown: use TLS for DPU calls

### DIFF
--- a/scripts/gnoi_shutdown_daemon.py
+++ b/scripts/gnoi_shutdown_daemon.py
@@ -246,7 +246,7 @@ class GnoiRebootHandler:
         reboot_cmd = [
             "docker", "exec", "gnmi", "gnoi_client",
             f"-target={dpu_ip}:{port}",
-            "-logtostderr", "-notls",
+            "-logtostderr", "-insecure",
             "-module", "System",
             "-rpc", "Reboot",
             "-jsonin", json.dumps({"method": REBOOT_METHOD_HALT, "message": "Triggered by SmartSwitch graceful shutdown"})
@@ -263,7 +263,7 @@ class GnoiRebootHandler:
         status_cmd = [
             "docker", "exec", "gnmi", "gnoi_client",
             f"-target={dpu_ip}:{port}",
-            "-logtostderr", "-notls",
+            "-logtostderr", "-insecure",
             "-module", "System",
             "-rpc", "RebootStatus"
         ]

--- a/scripts/gnoi_shutdown_daemon.py
+++ b/scripts/gnoi_shutdown_daemon.py
@@ -25,7 +25,7 @@ HALT_IN_PROGRESS_POLL_INTERVAL_SEC = 5  # delay between halt_in_progress checks
 STATUS_RPC_TIMEOUT_SEC = 10  # per RebootStatus RPC timeout
 REBOOT_METHOD_HALT = 3  # gNOI System.Reboot method: HALT
 CONFIG_DB_INDEX = 4
-DEFAULT_GNMI_PORT = "8080"  # Default GNMI port for DPU
+COMMON_GNMI_PORTS = ("8080", "50052")
 
 SYSLOG_IDENTIFIER = "gnoi-shutdown-daemon"
 logger = syslogger.SysLogger(SYSLOG_IDENTIFIER)
@@ -88,9 +88,10 @@ def get_dpu_ip(config_db, dpu_name: str) -> str:
     return None
 
 
-def get_dpu_gnmi_port(config_db, dpu_name: str) -> str:
-    """Retrieve GNMI port from CONFIG_DB DPU table, default to 8080."""
+def get_dpu_gnmi_ports(config_db, dpu_name: str):
+    """Return configured and common DPU gNMI ports in preference order."""
     dpu_name_lower = dpu_name.lower()
+    configured_port = None
 
     try:
         for k in [dpu_name_lower, dpu_name.upper(), dpu_name]:
@@ -99,12 +100,16 @@ def get_dpu_gnmi_port(config_db, dpu_name: str) -> str:
             if gnmi_port:
                 if isinstance(gnmi_port, bytes):
                     gnmi_port = gnmi_port.decode('utf-8')
-                return str(gnmi_port)
+                configured_port = str(gnmi_port)
+                break
     except (AttributeError, KeyError, TypeError) as e:
-        logger.log_warning(f"{dpu_name}: Error getting gNMI port, using default: {e}")
+        logger.log_warning(f"{dpu_name}: Error getting configured gNMI port: {e}")
 
-    logger.log_info(f"{dpu_name}: gNMI port not found, using default {DEFAULT_GNMI_PORT}")
-    return DEFAULT_GNMI_PORT
+    ports = []
+    for port in (configured_port, *COMMON_GNMI_PORTS):
+        if port and port not in ports:
+            ports.append(port)
+    return ports
 
 # ###############
 # gNOI Reboot Handler
@@ -188,13 +193,19 @@ class GnoiRebootHandler:
         dpu_ip = None
         try:
             dpu_ip = get_dpu_ip(config_db, dpu_name)
-            port = get_dpu_gnmi_port(config_db, dpu_name)
+            ports = get_dpu_gnmi_ports(config_db, dpu_name)
             if not dpu_ip:
                 logger.log_error(f"{dpu_name}: IP not found in DHCP_SERVER_IPV4_PORT table (key: bridge-midplane|{dpu_name.lower()}), cannot proceed")
                 self._clear_halt_flag(dpu_name)
                 return False
         except Exception as e:
             logger.log_error(f"{dpu_name}: Failed to get configuration: {e}")
+            self._clear_halt_flag(dpu_name)
+            return False
+
+        port = self._find_working_port(dpu_name, dpu_ip, ports)
+        if port is None:
+            logger.log_error(f"{dpu_name}: No reachable gNMI port found")
             self._clear_halt_flag(dpu_name)
             return False
 
@@ -241,8 +252,24 @@ class GnoiRebootHandler:
 
         return False
 
+    def _find_working_port(self, dpu_name: str, dpu_ip: str, ports):
+        """Return the first DPU port that responds to side-effect-free System.Time."""
+        for port in ports:
+            probe_cmd = [
+                "docker", "exec", "gnmi", "gnoi_client",
+                f"-target={dpu_ip}:{port}",
+                "-logtostderr", "-insecure",
+                "-module", "System",
+                "-rpc", "Time",
+            ]
+            rc, out, err = execute_command(probe_cmd, timeout_sec=STATUS_RPC_TIMEOUT_SEC)
+            if rc == 0:
+                return port
+            logger.log_warning(f"{dpu_name}: gNMI probe failed (rc={rc}, target={dpu_ip}:{port}): {err}")
+        return None
+
     def _send_reboot_command(self, dpu_name: str, dpu_ip: str, port: str) -> bool:
-        """Send gNOI Reboot HALT command to the DPU."""
+        """Send one gNOI Reboot HALT command to the selected DPU port."""
         reboot_cmd = [
             "docker", "exec", "gnmi", "gnoi_client",
             f"-target={dpu_ip}:{port}",

--- a/scripts/gnoi_shutdown_daemon.py
+++ b/scripts/gnoi_shutdown_daemon.py
@@ -253,7 +253,11 @@ class GnoiRebootHandler:
         return False
 
     def _find_working_port(self, dpu_name: str, dpu_ip: str, ports):
-        """Return the first DPU port that responds to side-effect-free System.Time."""
+        """Return the first port that responds to System.Time.
+
+        Each probe can block for STATUS_RPC_TIMEOUT_SEC, so probing two
+        unreachable ports can add up to 20 seconds to graceful shutdown.
+        """
         for port in ports:
             probe_cmd = [
                 "docker", "exec", "gnmi", "gnoi_client",

--- a/tests/gnoi_shutdown_daemon_test.py
+++ b/tests/gnoi_shutdown_daemon_test.py
@@ -166,7 +166,7 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
     @patch('gnoi_shutdown_daemon._get_halt_timeout', return_value=60)
     @patch('gnoi_shutdown_daemon.get_dpu_ip')
-    @patch('gnoi_shutdown_daemon.get_dpu_gnmi_port')
+    @patch('gnoi_shutdown_daemon.get_dpu_gnmi_ports')
     @patch('gnoi_shutdown_daemon.execute_command')
     @patch('gnoi_shutdown_daemon.time.sleep')
     @patch('gnoi_shutdown_daemon.time.monotonic')
@@ -178,7 +178,7 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
         # Mock return values
         mock_get_dpu_ip.return_value = "10.0.0.1"
-        mock_get_gnmi_port.return_value = "8080"
+        mock_get_gnmi_port.return_value = ["8080", "50052"]
 
         # Mock table.get() for gnoi_halt_in_progress check
         mock_table = MagicMock()
@@ -190,8 +190,9 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
             2, 3   # For _poll_reboot_status
         ]
 
-        # Reboot command success, RebootStatus success
+        # Port probe, Reboot command, RebootStatus success
         mock_execute_command.side_effect = [
+            (0, "time", ""),
             (0, "reboot sent", ""),
             (0, "reboot complete", "")
         ]
@@ -208,11 +209,11 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
         self.assertTrue(result)
         mock_module.clear_module_gnoi_halt_in_progress.assert_called_once()
-        self.assertEqual(mock_execute_command.call_count, 2)
+        self.assertEqual(mock_execute_command.call_count, 3)
 
     @patch('gnoi_shutdown_daemon._get_halt_timeout', return_value=60)
     @patch('gnoi_shutdown_daemon.get_dpu_ip')
-    @patch('gnoi_shutdown_daemon.get_dpu_gnmi_port')
+    @patch('gnoi_shutdown_daemon.get_dpu_gnmi_ports')
     @patch('gnoi_shutdown_daemon.time.sleep')
     @patch('gnoi_shutdown_daemon.time.monotonic')
     @patch('gnoi_shutdown_daemon.execute_command')
@@ -223,7 +224,7 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
         mock_chassis = MagicMock()
 
         mock_get_dpu_ip.return_value = "10.0.0.1"
-        mock_get_gnmi_port.return_value = "8080"
+        mock_get_gnmi_port.return_value = ["8080", "50052"]
 
         # Mock table.get() to never return True (simulates timeout in wait)
         mock_table = MagicMock()
@@ -237,8 +238,9 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
             0, 1
         ]
 
-        # Reboot command and status succeed
+        # Port probe, Reboot command, and status succeed
         mock_execute_command.side_effect = [
+            (0, "time", ""),
             (0, "reboot sent", ""),
             (0, "reboot complete", "")
         ]
@@ -271,19 +273,19 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
         mock_config = MagicMock()
         mock_config.hget.return_value = "12345"
 
-        port = gnoi_shutdown_daemon.get_dpu_gnmi_port(mock_config, "DPU0")
-        self.assertEqual(port, "12345")
+        ports = gnoi_shutdown_daemon.get_dpu_gnmi_ports(mock_config, "DPU0")
+        self.assertEqual(ports, ["12345", "8080", "50052"])
 
         # Test port fallback
         mock_config = MagicMock()
         mock_config.hget.return_value = None
 
-        port = gnoi_shutdown_daemon.get_dpu_gnmi_port(mock_config, "DPU0")
-        self.assertEqual(port, "8080")
+        ports = gnoi_shutdown_daemon.get_dpu_gnmi_ports(mock_config, "DPU0")
+        self.assertEqual(ports, ["8080", "50052"])
 
     @patch('gnoi_shutdown_daemon._get_halt_timeout', return_value=60)
     @patch('gnoi_shutdown_daemon.get_dpu_ip', return_value=None)
-    @patch('gnoi_shutdown_daemon.get_dpu_gnmi_port', return_value="8080")
+    @patch('gnoi_shutdown_daemon.get_dpu_gnmi_ports', return_value=["8080", "50052"])
     def test_handle_transition_ip_failure(self, mock_get_gnmi_port, mock_get_dpu_ip, mock_get_halt_timeout):
         """Test handle_transition failure on DPU IP retrieval."""
         mock_db = MagicMock()
@@ -308,15 +310,16 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
         mock_module.clear_module_gnoi_halt_in_progress.assert_called_once()
 
     @patch('gnoi_shutdown_daemon.get_dpu_ip', return_value="10.0.0.1")
-    @patch('gnoi_shutdown_daemon.get_dpu_gnmi_port', return_value="8080")
+    @patch('gnoi_shutdown_daemon.get_dpu_gnmi_ports', return_value=["8080", "50052"])
     @patch('gnoi_shutdown_daemon.execute_command', return_value=(-1, "", "error"))
     def test_send_reboot_command_failure(self, mock_execute, mock_get_port, mock_get_ip):
         """Test failure of _send_reboot_command."""
         handler = gnoi_shutdown_daemon.GnoiRebootHandler(MagicMock(), MagicMock(), MagicMock())
-        result = handler._send_reboot_command("DPU0", "10.0.0.1", "8080")
+        result = handler._send_reboot_command("DPU0", "10.0.0.1", "50052")
         self.assertFalse(result)
+        self.assertEqual(mock_execute.call_count, 1)
 
-    def test_get_dpu_gnmi_port_variants(self):
+    def test_get_dpu_gnmi_ports_variants(self):
         """Test DPU gNMI port retrieval with name variants."""
         mock_config = MagicMock()
         mock_config.hget.side_effect = [
@@ -325,8 +328,8 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
             "12345"  # DPU0 succeeds
         ]
 
-        port = gnoi_shutdown_daemon.get_dpu_gnmi_port(mock_config, "DPU0")
-        self.assertEqual(port, "12345")
+        ports = gnoi_shutdown_daemon.get_dpu_gnmi_ports(mock_config, "DPU0")
+        self.assertEqual(ports, ["12345", "8080", "50052"])
         self.assertEqual(mock_config.hget.call_count, 3)
 
     @patch('gnoi_shutdown_daemon.daemon_base.db_connect')
@@ -491,27 +494,42 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
         ip = gnoi_shutdown_daemon.get_dpu_ip(mock_config, "DPU1")
         self.assertIsNone(ip)
 
-    def test_get_dpu_gnmi_port_exception(self):
-        """Test get_dpu_gnmi_port when exception occurs."""
+    def test_get_dpu_gnmi_ports_exception(self):
+        """Test get_dpu_gnmi_ports when exception occurs."""
         mock_config = MagicMock()
         mock_config.hget.side_effect = AttributeError("Database error")
 
-        port = gnoi_shutdown_daemon.get_dpu_gnmi_port(mock_config, "DPU1")
-        self.assertEqual(port, "8080")
+        ports = gnoi_shutdown_daemon.get_dpu_gnmi_ports(mock_config, "DPU1")
+        self.assertEqual(ports, ["8080", "50052"])
 
     def test_send_reboot_command_success(self):
         """Test successful _send_reboot_command."""
         with patch('gnoi_shutdown_daemon.execute_command', return_value=(0, "success", "")) as mock_execute_command:
             handler = gnoi_shutdown_daemon.GnoiRebootHandler(MagicMock(), MagicMock(), MagicMock())
-            result = handler._send_reboot_command("DPU0", "10.0.0.1", "8080")
+            result = handler._send_reboot_command("DPU0", "10.0.0.1", "50052")
             self.assertTrue(result)
             reboot_cmd = mock_execute_command.call_args.args[0]
             self.assertIn("-insecure", reboot_cmd)
             self.assertNotIn("-notls", reboot_cmd)
 
+    def test_find_working_port_falls_back_to_native_port(self):
+        """Test that a failed configured port probe falls back to native gNMI."""
+        with patch('gnoi_shutdown_daemon.execute_command', side_effect=[
+            (-1, "", "unavailable"),
+            (0, "success", ""),
+        ]) as mock_execute_command:
+            handler = gnoi_shutdown_daemon.GnoiRebootHandler(MagicMock(), MagicMock(), MagicMock())
+            result = handler._find_working_port("DPU0", "10.0.0.1", ["8080", "50052"])
+
+        self.assertEqual(result, "50052")
+        commands = [call.args[0] for call in mock_execute_command.call_args_list]
+        self.assertIn("-target=10.0.0.1:8080", commands[0])
+        self.assertIn("-target=10.0.0.1:50052", commands[1])
+        self.assertTrue(all("Reboot" not in command for command in commands))
+
     @patch('gnoi_shutdown_daemon._get_halt_timeout', return_value=60)
     @patch('gnoi_shutdown_daemon.get_dpu_ip', return_value="10.0.0.1")
-    @patch('gnoi_shutdown_daemon.get_dpu_gnmi_port', side_effect=Exception("Port lookup failed"))
+    @patch('gnoi_shutdown_daemon.get_dpu_gnmi_ports', side_effect=Exception("Port lookup failed"))
     def test_handle_transition_config_exception(self, mock_get_port, mock_get_ip, mock_get_halt_timeout):
         """Test handle_transition when configuration lookup raises exception."""
         mock_db = MagicMock()
@@ -652,12 +670,13 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
         # Mock remaining methods to prevent actual gNOI calls
         handler._wait_for_gnoi_halt_in_progress = MagicMock(return_value=True)
+        handler._find_working_port = MagicMock(return_value="8080")
         handler._send_reboot_command = MagicMock(return_value=True)
         handler._poll_reboot_status = MagicMock(return_value=True)
         handler._clear_halt_flag = MagicMock(return_value=True)
 
         with patch('gnoi_shutdown_daemon.get_dpu_ip', return_value="10.0.0.1"), \
-             patch('gnoi_shutdown_daemon.get_dpu_gnmi_port', return_value="8080"):
+             patch('gnoi_shutdown_daemon.get_dpu_gnmi_ports', return_value=["8080", "50052"]):
             result = handler._handle_transition("DPU0")
 
         # Should proceed with shutdown for Fault state
@@ -700,12 +719,13 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
         # Mock remaining methods to prevent actual gNOI calls
         handler._wait_for_gnoi_halt_in_progress = MagicMock(return_value=True)
+        handler._find_working_port = MagicMock(return_value="8080")
         handler._send_reboot_command = MagicMock(return_value=True)
         handler._poll_reboot_status = MagicMock(return_value=True)
         handler._clear_halt_flag = MagicMock(return_value=True)
 
         with patch('gnoi_shutdown_daemon.get_dpu_ip', return_value="10.0.0.1"), \
-             patch('gnoi_shutdown_daemon.get_dpu_gnmi_port', return_value="8080"):
+             patch('gnoi_shutdown_daemon.get_dpu_gnmi_ports', return_value=["8080", "50052"]):
             result = handler._handle_transition("DPU0")
 
         # Should proceed with shutdown despite oper_status check failure

--- a/tests/gnoi_shutdown_daemon_test.py
+++ b/tests/gnoi_shutdown_daemon_test.py
@@ -537,6 +537,23 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
         self.assertIn("-target=10.0.0.1:50052", commands[1])
         self.assertTrue(all("Reboot" not in command for command in commands))
 
+    def test_handle_transition_clears_halt_flag_when_all_ports_fail(self):
+        """Test cleanup when no configured or common gNMI port responds."""
+        handler = gnoi_shutdown_daemon.GnoiRebootHandler(MagicMock(), MagicMock(), MagicMock())
+        handler._should_skip_gnoi_shutdown = MagicMock(return_value=False)
+        handler._wait_for_gnoi_halt_in_progress = MagicMock(return_value=True)
+        handler._find_working_port = MagicMock(return_value=None)
+        handler._clear_halt_flag = MagicMock(return_value=True)
+
+        with patch('gnoi_shutdown_daemon.get_dpu_ip', return_value="10.0.0.1"), \
+                patch('gnoi_shutdown_daemon.get_dpu_gnmi_ports', return_value=["8080", "50052"]):
+            result = handler._handle_transition("DPU0")
+
+        self.assertFalse(result)
+        handler._find_working_port.assert_called_once_with(
+            "DPU0", "10.0.0.1", ["8080", "50052"])
+        handler._clear_halt_flag.assert_called_once_with("DPU0")
+
     @patch('gnoi_shutdown_daemon._get_halt_timeout', return_value=60)
     @patch('gnoi_shutdown_daemon.get_dpu_ip', return_value="10.0.0.1")
     @patch('gnoi_shutdown_daemon.get_dpu_gnmi_ports', side_effect=Exception("Port lookup failed"))

--- a/tests/gnoi_shutdown_daemon_test.py
+++ b/tests/gnoi_shutdown_daemon_test.py
@@ -419,6 +419,9 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
         with patch('gnoi_shutdown_daemon.time.monotonic', side_effect=[0, 1, 61]):
             result = handler._poll_reboot_status("DPU0", "10.0.0.1", "8080")
         self.assertFalse(result)
+        status_cmd = mock_execute_command.call_args.args[0]
+        self.assertIn("-insecure", status_cmd)
+        self.assertNotIn("-notls", status_cmd)
 
     def test_sonic_platform_import_mock(self):
         """Simple test to verify sonic_platform import mocking works."""
@@ -498,10 +501,13 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
     def test_send_reboot_command_success(self):
         """Test successful _send_reboot_command."""
-        with patch('gnoi_shutdown_daemon.execute_command', return_value=(0, "success", "")):
+        with patch('gnoi_shutdown_daemon.execute_command', return_value=(0, "success", "")) as mock_execute_command:
             handler = gnoi_shutdown_daemon.GnoiRebootHandler(MagicMock(), MagicMock(), MagicMock())
             result = handler._send_reboot_command("DPU0", "10.0.0.1", "8080")
             self.assertTrue(result)
+            reboot_cmd = mock_execute_command.call_args.args[0]
+            self.assertIn("-insecure", reboot_cmd)
+            self.assertNotIn("-notls", reboot_cmd)
 
     @patch('gnoi_shutdown_daemon._get_halt_timeout', return_value=60)
     @patch('gnoi_shutdown_daemon.get_dpu_ip', return_value="10.0.0.1")

--- a/tests/gnoi_shutdown_daemon_test.py
+++ b/tests/gnoi_shutdown_daemon_test.py
@@ -190,8 +190,9 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
             2, 3   # For _poll_reboot_status
         ]
 
-        # Port probe, Reboot command, RebootStatus success
+        # Configured port probe fails, native port probe and operations succeed
         mock_execute_command.side_effect = [
+            (-1, "", "unavailable"),
             (0, "time", ""),
             (0, "reboot sent", ""),
             (0, "reboot complete", "")
@@ -209,7 +210,16 @@ class TestGnoiShutdownDaemon(unittest.TestCase):
 
         self.assertTrue(result)
         mock_module.clear_module_gnoi_halt_in_progress.assert_called_once()
-        self.assertEqual(mock_execute_command.call_count, 3)
+        self.assertEqual(mock_execute_command.call_count, 4)
+        commands = [call.args[0] for call in mock_execute_command.call_args_list]
+        self.assertIn("-target=10.0.0.1:8080", commands[0])
+        self.assertIn("-rpc", commands[0])
+        self.assertIn("Time", commands[0])
+        self.assertIn("-target=10.0.0.1:50052", commands[1])
+        self.assertIn("-target=10.0.0.1:50052", commands[2])
+        self.assertIn("Reboot", commands[2])
+        self.assertIn("-target=10.0.0.1:50052", commands[3])
+        self.assertIn("RebootStatus", commands[3])
 
     @patch('gnoi_shutdown_daemon._get_halt_timeout', return_value=60)
     @patch('gnoi_shutdown_daemon.get_dpu_ip')


### PR DESCRIPTION
## Why

Certificate-free DPU telemetry servers use ephemeral self-signed TLS. The shutdown daemon must use TLS rather than plaintext and remain robust when the configured legacy port is unavailable.

Tracks sonic-net/sonic-buildimage#28540.

Microsoft ADO (number only): 39179388

## What

- Change DPU gNOI calls from `-notls` to `-insecure`.
- Probe configured, `8080`, and native `50052` ports with bounded, side-effect-free `System.Time`, deduplicated in preference order.
- Document that two unreachable ports can add up to 20 seconds to graceful shutdown.
- Send `Reboot` exactly once on the selected port and poll `RebootStatus` there.
- Clear the halt flag and report failure when no port responds.

## Validation

- The focused suite previously passed 37 tests using import-only stubs because SONiC Python packages are unavailable on the host.
- The added all-ports-fail test verifies `False` return and halt-flag cleanup.
- Python compilation, review, and `git diff --check` pass for head `3677e1e`.
- Integrated physical validation passed through the related utility/DPUProxy TLS path; this daemon was not exercised there.

## Remaining Validation

- Required PR CI is rerunning for head `3677e1e`.
